### PR TITLE
#714: placement.writer can mirror a footprint to the other board face

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,6 +413,19 @@ same change — and vice versa. When adding a flag, grep the
 through there too.
 
 **Parity gates (run these when touching CLI/GUI routing):**
+- `tests/gui_parity/test_714_mirror_pcbnew_parity.py` — needs KiCad python; the
+  acceptance gate for the placement writer's **layer flip**. Compares the
+  footprint block `write_placed_output` emits for a side change against the
+  block pcbnew writes after `FOOTPRINT.Flip(pos, FLIP_DIRECTION_TOP_BOTTOM)` +
+  `SaveBoard()`, as canonical trees: numbers to integer nanometres (so the
+  tolerance is exactly zero, not a float epsilon), `at` angles folded, children
+  sorted, and the uuid multiset asserted rather than normalised away. **Exits 2
+  when pcbnew is absent and does NOT self-skip** — `tests/mutate_714.py` uses
+  it as a killer gate, and a killer gate that exits 0 reports every row it
+  guards as SURVIVED. Run it whenever you touch `placement/writer.py`'s flip
+  path or `kicad_parser.flip_layer_token`; ~2 min. Its wx-free siblings are
+  `tests/test_714_{mirror_discriminates,side_self_consistency,flip_roundtrip,
+  refusals,identity_write_unchanged}.py`, which `run_all.py` does collect.
 - `tests/gui_parity/test_manifest_plan_parity.py` — no wx; asserts every CLI
   `--flag` survives `manifest_to_plan` into the GUI plan step (plan→params).
 - `tests/gui_parity/test_cli_postpass_coverage.py` — no wx; asserts every CLI

--- a/docs/api-kicad-parser.md
+++ b/docs/api-kicad-parser.md
@@ -375,7 +375,7 @@ sided layer `F.<x>` / `B.<x>`, not the list of which ones exist. Measured over
 the 22 tracked boards, the layer tokens appearing inside a `(footprint ...)`
 block are `F.Cu F.Mask F.Paste F.SilkS F.CrtYd F.Fab F.Adhes B.SilkS B.Fab B.Cu
 B.CrtYd B.Mask B.Paste *.Cu *.Mask Dwgs.User Cmts.User Eco1.User Eco2.User
-User.1`; this flips the twelve sided ones and returns the other eight as they
+User.1`; this flips the thirteen sided ones and returns the other seven as they
 are.
 
 Two things it deliberately does **not** do, because both would be guesses:
@@ -383,13 +383,13 @@ Two things it deliberately does **not** do, because both would be guesses:
 - `*.Cu` and `*.Mask` pass through. They are KiCad's ALL-copper / all-mask sets
   and are already their own mirror; narrowing `*.Cu` to `B.Cu` would silently
   drop 66 pads on `rp2350_fpga_eensy_prePlane` U8 alone.
-- Inner copper passes through unchanged, which is the identity answer and not
-  the right one. `In1.Cu`'s mirror image is `In<n+1-k>.Cu`, which depends on
-  the board's inner-layer count *and* on `remove_unused_layers` padstack
-  semantics, and no tracked board carries an explicit `In<n>.Cu` in a footprint
-  pad. Callers that must decide about one are expected to **refuse** rather
-  than take this function's answer —
-  `placement.writer` does exactly that.
+- Inner copper passes through unchanged, and that matches KiCad: probed
+  against pcbnew 10.0.0 on a six-layer board, `FOOTPRINT::Flip` leaves a pad on
+  `In1.Cu` and an `fp_line` on `In2.Cu` where they are. So the identity answer
+  is correct here, not merely conservative. `placement.writer` nonetheless
+  **refuses** a pad naming an explicit `In<n>.Cu`, for a different reason: no
+  tracked board carries one, so nothing here would notice if a future KiCad
+  began remapping them.
 
 ## Utility functions
 

--- a/docs/api-kicad-parser.md
+++ b/docs/api-kicad-parser.md
@@ -356,6 +356,41 @@ Converts footprint-local pad coordinates to absolute board coordinates.
 KiCad's rotation convention means the angle is **negated** inside the
 standard rotation matrix — use this helper rather than rolling your own.
 
+There is **no mirror term**, and that is correct rather than an omission: KiCad
+stores a B-side footprint's children *pre-mirrored*, so a plain rotate and
+translate resolves them. A consumer that adds a mirror of its own for B-side
+parts double-applies it.
+
+## Board side: `flip_layer_token`
+
+```python
+flip_layer_token(name: str) -> str
+```
+
+The other face's spelling of a layer token (#714): `F.SilkS` → `B.SilkS`,
+`B.Cu` → `F.Cu`, and **anything else unchanged**.
+
+A prefix rule, deliberately not a table — the knowledge is that KiCad spells a
+sided layer `F.<x>` / `B.<x>`, not the list of which ones exist. Measured over
+the 22 tracked boards, the layer tokens appearing inside a `(footprint ...)`
+block are `F.Cu F.Mask F.Paste F.SilkS F.CrtYd F.Fab F.Adhes B.SilkS B.Fab B.Cu
+B.CrtYd B.Mask B.Paste *.Cu *.Mask Dwgs.User Cmts.User Eco1.User Eco2.User
+User.1`; this flips the twelve sided ones and returns the other eight as they
+are.
+
+Two things it deliberately does **not** do, because both would be guesses:
+
+- `*.Cu` and `*.Mask` pass through. They are KiCad's ALL-copper / all-mask sets
+  and are already their own mirror; narrowing `*.Cu` to `B.Cu` would silently
+  drop 66 pads on `rp2350_fpga_eensy_prePlane` U8 alone.
+- Inner copper passes through unchanged, which is the identity answer and not
+  the right one. `In1.Cu`'s mirror image is `In<n+1-k>.Cu`, which depends on
+  the board's inner-layer count *and* on `remove_unused_layers` padstack
+  semantics, and no tracked board carries an explicit `In<n>.Cu` in a footprint
+  pad. Callers that must decide about one are expected to **refuse** rather
+  than take this function's answer —
+  `placement.writer` does exactly that.
+
 ## Utility functions
 
 ```python

--- a/docs/placement-optimization.md
+++ b/docs/placement-optimization.md
@@ -345,10 +345,19 @@ precedent), which is simpler and may capture most of the value:
     wins; mixed-size swaps are usually illegal anyway, so restrict by
     footprint compatibility)
   - *side flip* (optional; mirrored courtyard): treated as a first-class move
-    in recent PCB literature. **Not implemented as a move.** Board side *is*
-    now modelled by the clearance/halo terms (#456): a part occupies its own
-    side with its courtyard and the far side only with its drilled-pad box, so
-    cross-side parts no longer collide or repel — but nothing flips a part.
+    in recent PCB literature. **Still not implemented as a move** — and that
+    sentence wants reading carefully, because half of what used to block it is
+    gone. Board side *is* modelled by the clearance/halo terms (#456): a part
+    occupies its own side with its courtyard and the far side only with its
+    drilled-pad box, so cross-side parts no longer collide or repel. And since
+    **#714** the WRITER can emit a real flip: `write_placed_output` mirrors a
+    footprint to the other face on request, held to pcbnew's own
+    `FOOTPRINT.Flip` node for node, so `perturb` can stage a `layer_flip`
+    damage kind. What is missing is the SEARCH — `_Part.side` is assigned once
+    at construction and no move signature carries it, so nothing in the
+    optimizer *chooses* a face. That is #836, and it is gated on its own
+    pre-registered measurement, because `reseat.py` is already side-aware and
+    the open question is how many parts a flip helps that a re-seat does not.
   - *rigid-group moves*: an IC plus its decoupling caps moves as one
     super-component. **Translation is implemented** (`--group-by`, #459);
     rigid *rotation* of a block is not. Blocks come from KiCad `(group ...)`,

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -969,7 +969,7 @@ rather than scraping text.
 | state | why refusing beats trying | override |
 |---|---|---|
 | **unplaced** (parts stacked at one coordinate) | the quench REFINES a placement. On a pile every candidate pose is illegal, so the run prints "0 parts moved" plus a legality block that looks like a result, and a large `--max-displacement` yields a tiny scatter around the origin that looks like progress | `--allow-unplaced` |
-| **already routed** | the quench models no copper at all: legality is courtyard + outline, cost is pad-to-pad airwires, and `writer.write_placed_output` rewrites footprint positions only. Every track would be left behind, detached from its pad | `--allow-routed` |
+| **already routed** | the quench models no copper at all: legality is courtyard + outline, cost is pad-to-pad airwires, and `writer.write_placed_output` rewrites footprint poses and — since #714, on request — their board SIDE, but never copper. Every track would be left behind, detached from its pad | `--allow-routed` |
 
 `place_route_loop` gates BEFORE round 0, which routes the whole board -- refusing
 there saves minutes-to-hours of A* that would fail everything and then quench a

--- a/py_placer/placement/perturb.py
+++ b/py_placer/placement/perturb.py
@@ -35,12 +35,13 @@ Two things are deliberately NOT offered as mutations:
   than displacement -- you would be measuring legality recovery. A single-part
   flip stays available as a test fixture for the rotation term of the metric,
   never as an experiment arm.
-- **Layer flip (F.Cu <-> B.Cu).** `placement.writer.write_placed_output` rewrites
-  `(at ...)` and pad angles only: it writes no `(layer ...)` and mirrors no pads.
-  A "flip" through it produces a board whose pads contradict its side, which
-  corrupts `footprint_side` / `sides_occupied` and therefore every overlap number
-  downstream. If the wrong SIDE is wanted rather than the wrong HALF, that is a
-  writer capability first.
+(Until #714 there was a third: a **layer flip**, because
+`placement.writer.write_placed_output` rewrote `(at ...)` and pad angles only
+and a "flip" through it produced a board whose pads contradicted its side. That
+is now the `layer_flip` kind below -- the writer mirrors the geometry, and
+`tests/gui_parity/test_714_mirror_pcbnew_parity.py` holds it to pcbnew's own
+`FOOTPRINT.Flip` node for node. `wrong_side` is unchanged and still means the
+wrong HALF: a point reflection through the board centre.)
 """
 from __future__ import annotations
 
@@ -53,7 +54,26 @@ from typing import Dict, List, Optional, Sequence, Tuple
 
 from kicad_parser import parse_kicad_pcb
 
-KINDS = ('translate', 'wrong_side', 'swap', 'scatter', 'pile')
+KINDS = ('translate', 'wrong_side', 'swap', 'scatter', 'pile', 'layer_flip')
+
+#: `layer_flip` is deliberately a NEW kind rather than a redefinition of
+#: `wrong_side`, which is a point reflection through the board centre and whose
+#: measured numbers are recorded in `docs/placement-predictors.md` and in two
+#: committed baselines (`tests/553_diagnosis_recall_baseline.json`,
+#: `tests/554_block_relocation_baseline.json`). Redefining it would invalidate
+#: every one of those inside a PR whose subject is a writer capability -- a
+#: measurement change wearing a code change's clothes.
+#:
+#: Adding one is safe because the study arm tuples are LITERAL, not derived from
+#: KINDS: `tests/stress/block_relocation_study.py` EVIDENCE_KINDS /
+#: INSTRUMENT_KINDS and `tests/stress/diagnosis_recall.py` ARMS / EVIDENCE_ARMS
+#: all enumerate arms by hand, so nothing selects this one until someone asks.
+#:
+#: It is NOT an evidence arm yet, and that is a statement about the GRADER, not
+#: about the kind: the recall study grades by displacement
+#: (`routability.block_displacements`), and a flip in place produces exactly
+#: zero of it, so a `layer_flip` arm would score "nothing moved" until the
+#: grader learns about sides.
 
 # A unit smaller than this is not a block, and one larger than this fraction of
 # the movable parts is the board rather than a block in it.
@@ -316,6 +336,19 @@ def rigid_offsets(state, members: Sequence[str], t: Tuple[float, float], *,
     return {r: (dx, dy) for r in members if r in state.parts}
 
 
+def _fp_side(pcb_data, ref) -> str:
+    """'F' or 'B' for `ref`, through the ONE side rule (#714).
+
+    `legality.footprint_side`, not a local first-character test: the writer
+    validates `new_side` against the same function, so the perturber cannot
+    disagree with it about which face a part is already on -- which would flip
+    nothing, or flip everything.
+    """
+    from placement.legality import footprint_side
+    fp = (pcb_data.footprints or {}).get(ref)
+    return footprint_side(fp) if fp is not None else 'F'
+
+
 def _placements(state, offsets: Dict[str, Tuple[float, float]]) -> List[Dict]:
     out = []
     for ref, (dx, dy) in sorted(offsets.items()):
@@ -485,7 +518,18 @@ def perturb(board: str, out_board: str, *, kind: str = 'translate',
             applied_req = feasible
             clipped = True
 
-    if kind == 'pile':
+    if kind == 'layer_flip':
+        # A flip IN PLACE: pose held exactly, side inverted. `dose_mm` has no
+        # meaning here -- there is no distance -- so the record says so rather
+        # than reporting a clipped dose that nobody applied.
+        placements = [{'reference': r, 'new_x': round(st.parts[r].x, 6),
+                       'new_y': round(st.parts[r].y, 6),
+                       'new_rotation': st.parts[r].rot,
+                       'new_side': ('F' if _fp_side(pcb, r) == 'B' else 'B')}
+                      for r in members if r in st.parts]
+        applied_req = 0.0
+        clipped = False
+    elif kind == 'pile':
         from placement.portfolio import free_refs
         members = sorted(r for r in free_refs(pcb, board, lock_globs)
                          if r in st.parts)

--- a/py_placer/placement/provenance.py
+++ b/py_placer/placement/provenance.py
@@ -164,6 +164,25 @@ def commit_write(output_file: str) -> Optional[Dict]:
     return row
 
 
+def _side_changed(fp, placement) -> bool:
+    """Did this placement ask to put `fp` on the other face (#714)?
+
+    Reads the side through `legality.footprint_side` rather than re-deriving
+    the first-character test here: this repo already carries that rule in one
+    place and a second copy is a second thing to get wrong. Imported lazily,
+    as this module already does for `kicad_parser`; `legality` imports nothing
+    from here, so there is no cycle.
+    """
+    want = placement.get('new_side')
+    if want is None:
+        return False
+    try:
+        from placement.legality import footprint_side
+    except ImportError:                                          # noqa: BLE001
+        return True     # cannot tell -> report the change, never hide it
+    return footprint_side(fp) != want
+
+
 def record_write(input_file: str, output_file: str,
                  placements: Sequence[Dict],
                  pending: bool = False) -> Optional[Dict]:
@@ -212,6 +231,16 @@ def record_write(input_file: str, output_file: str,
                             - (p.get('new_rotation') or 0.0) + 180.0) % 360.0
                            - 180.0) > 1e-6):
                 moved.append(ref)
+            elif _side_changed(fp, p):
+                # #714. A flip with identical x/y/rot is a real change to the
+                # delivered board, and without this term it lands in
+                # `refs_written` but NOT in `refs_moved`, with a
+                # `poses_written` row byte-identical to the incumbent -- so
+                # the ledger records the flip nowhere and `fence_audit` grades
+                # a flipped board as untouched. That is a silent wrongness of
+                # exactly the class #714 exists to remove, and it would have
+                # been introduced by the fix for it.
+                moved.append(ref)
     except Exception:                            # noqa: BLE001
         moved = [p.get('reference') for p in placements]
 
@@ -236,6 +265,16 @@ def record_write(input_file: str, output_file: str,
                         else (getattr(_fp, 'rotation', 0.0) or 0.0)) % 360.0,
                   4)]
 
+    # #714. A SEPARATE key, deliberately not a fourth element of
+    # `poses_written`: that list's shape is [x, y, rot] in every ledger ever
+    # written, and only refs that actually carried a `new_side` appear here, so
+    # an old ledger stays readable and `SCHEMA` does not move (`read_ledger` is
+    # shape-agnostic and no consumer indexes past [2] -- `git grep
+    # poses_written` finds only its own definition).
+    _sides = {p_.get('reference'): p_.get('new_side')
+              for p_ in placements
+              if p_.get('reference') and p_.get('new_side') is not None}
+
     row = {'t': time.time(), 'schema': SCHEMA,
            'path': os.path.abspath(output_file),
            'parent_sha256': (sha256_file(input_file)
@@ -244,6 +283,7 @@ def record_write(input_file: str, output_file: str,
            'declared': True, 'caller': _caller(),
            'refs_written': sorted(p.get('reference') for p in placements),
            'poses_written': _written,
+           'sides_written': _sides,
            'refs_moved': sorted(r for r in moved if r)}
     if pending:
         row['_root'] = root

--- a/py_placer/placement/writer.py
+++ b/py_placer/placement/writer.py
@@ -293,9 +293,26 @@ class SideFlipUnsupported(Exception):
 _COORD_LITERAL = re.compile(r'^-?\d+(\.\d+)?$')
 
 # Top-level children of a `(footprint ...)` block, by what the flip does with
-# them. Measured: these 27 heads are every top-level child kind on the tracked
-# corpus. Anything else REFUSES -- a whitelist, because you cannot test for a
+# them. Anything else REFUSES -- a whitelist, because you cannot test for a
 # node kind you have not thought of.
+#
+# TWO DIFFERENT COUNTS, and an earlier version of this comment read them as one
+# measured claim: the tracked corpus has 27 distinct top-level child kinds, and
+# this set also happens to hold 27 names, but they are not the same 27. Fifteen
+# of these have a corpus witness; TWELVE DO NOT -- `autoplace_cost90`,
+# `autoplace_cost180`, `clearance`, `generator`, `generator_version`,
+# `jumper_pad_groups`, `net_tie_pad_groups`, `thermal_gap`, `thermal_width`,
+# `tstamp`, `version`, `zone_connect`.
+#
+# Which raises the obvious objection: `chamfer` and `rect_delta` are refused
+# for having no witness, so why are these passed through? Because the doctrine
+# is about GEOMETRY, not about familiarity. Every name here is a scalar, an
+# identifier or a flag that a reflection cannot act on -- a cost weight, a
+# uuid, a margin, a pad-number group, a version string. `chamfer` and
+# `rect_delta` describe SHAPE, and their behaviour under a mirror is a real
+# question with a real answer that this corpus cannot supply. Passing through a
+# number that has no orientation is not a guess; guessing how a corner name
+# reflects is.
 _FLIP_PASSTHROUGH = frozenset({
     'uuid', 'descr', 'tags', 'path', 'attr', 'embedded_fonts', 'sheetfile',
     'sheetname', 'units', 'locked', 'variant', 'solder_mask_margin',
@@ -336,6 +353,22 @@ _PAD_REFUSALS = {
     'rect_delta': ("trapezoid pad deltas under a mirror are unmeasured -- no "
                    "tracked board carries one"),
 }
+
+# Pad children this mirror knows what to do with. `at`, `layers` and `drill`
+# are TRANSFORMED; the rest are mirror-invariant -- sizes, margins, net and pin
+# metadata, thermal and teardrop settings, which a reflection does not touch.
+# Measured: these 22 heads are every pad child kind on the 22 tracked boards
+# (9491 pads), with `primitives` the only one refused. Anything outside the set
+# refuses, so a KiCad that adds a pad child -- `padstack` is the live example
+# in 9/10 -- stops the flip instead of being emitted unmirrored.
+_PAD_HANDLED = frozenset({
+    'at', 'size', 'layers', 'uuid', 'net', 'pintype', 'pinfunction',
+    'roundrect_rratio', 'drill', 'remove_unused_layers', 'solder_paste_margin',
+    'solder_mask_margin', 'teardrops', 'zone_connect', 'property', 'options',
+    'clearance', 'thermal_bridge_angle', 'solder_paste_margin_ratio',
+    'thermal_bridge_width', 'thermal_gap', 'thermal_width', 'die_length',
+    'zone_layer_connections', 'tstamp', 'locked', 'chamfer_ratio',
+})
 
 _SIDED_LAYER = re.compile(r'^[FB]\.')
 _INNER_LAYER = re.compile(r'^In\d+\.Cu$', re.IGNORECASE)
@@ -390,7 +423,14 @@ def _iter_sexpr_children(text: str, open_idx: int = 0):
 def _mirror_xy_pairs(node: str, ref: str, heads=('start', 'end', 'center',
                                                  'mid', 'xy')) -> str:
     """Negate the Y of every `(head x y)` in `node`. X is never touched."""
-    pat = re.compile(r'\((' + '|'.join(heads) + r')(\s+)(\S+)(\s+)(\S+)\)')
+    # `[^\s()]+`, NOT `\S+`: `\S` matches `)`, so on the compact
+    # `(pts (xy -1 1))` spelling the last group backtracks to `1)` and the
+    # match runs to the `pts` closer. It failed CLOSED -- the literal `'1)'`
+    # is outside the coordinate grammar, so `_negate_coord` refused -- but with
+    # a message blaming the board for a regex bug, and it made every
+    # compactly-serialised `fp_poly` / `fp_curve` unflippable.
+    pat = re.compile(r'\((' + '|'.join(heads)
+                     + r')(\s+)([^\s()]+)(\s+)([^\s()]+)\)')
 
     def fix(m):
         return (f"({m.group(1)}{m.group(2)}{m.group(3)}{m.group(4)}"
@@ -416,9 +456,22 @@ def _flip_at_angle(node: str, ref: str, new_angle_of) -> str:
     the angle is 0 and stays 0 whenever the footprint's own rotation is 0 or
     180. A pad that would gain a non-zero angle gains the token.
     """
-    m = re.search(r'\(at\s+(\S+)\s+(\S+)(?:\s+(\S+))?\)', node)
+    m = re.search(r'\(at\s+([^\s()]+)\s+([^\s()]+)(?:\s+([^\s()]+))?\)', node)
     if not m:
-        return node
+        if not re.search(r'\(at\b', node):
+            return node          # genuinely has no `(at ...)`; nothing to move
+        # There IS one and it did not parse: REFUSE, never return the node
+        # untouched. The rest of the footprint mirrors around it, so a silently
+        # skipped `(at ...)` leaves exactly the half-mirrored block this whole
+        # feature exists to prevent. The reachable spelling is KiCad 6/7's
+        # four-token `(at 0 -3.98 0 unlocked)` -- no tracked board writes it
+        # (they all use the modern `(unlocked yes)` node), which is why nothing
+        # caught this.
+        raise SideFlipUnsupported(
+            f"{ref}: a node has an `(at ...)` this mirror cannot parse -- "
+            f"expected two or three plain numbers. Refusing rather than "
+            f"leaving it unmirrored inside a footprint whose every other node "
+            f"moved: {node[:120]!r}")
     x, y, a = m.group(1), m.group(2), m.group(3)
     ny = _negate_coord(y, ref, 'at')
     na = new_angle_of(float(a) if a is not None else 0.0)
@@ -430,13 +483,20 @@ def _flip_at_angle(node: str, ref: str, new_angle_of) -> str:
     return node[:m.start()] + rep + node[m.end():]
 
 
-def _flip_justify(node: str) -> str:
+def _flip_justify(node: str, ref: str) -> str:
     """Toggle the `mirror` token of the first `(justify ...)` in `node`.
 
-    Three cases, and two of them add or delete a whole node. Measured, the
-    tracked corpus contains exactly two forms -- `(justify mirror)` x1391 and
-    `(justify left bottom)` x58 -- so alignment tokens are preserved and only
-    `mirror` moves:
+    Three cases, and two of them add or delete a whole node. Measured INSIDE
+    footprint blocks on the 22 tracked boards -- which is the only place this
+    function ever runs -- there is exactly ONE form, `(justify mirror)`, 1356
+    of them, and ZERO instances of any alignment token. (Whole-file counts are
+    1367 and 42, but the 42 `(justify left bottom)` are board-level `gr_text`
+    that this never sees.) So the alignment-preserving branch below has no
+    corpus witness at all; it is there because pcbnew emits alignment tokens on
+    a footprint text the moment a user sets one, and dropping them would be a
+    silent edit to somebody's silkscreen. Said plainly because an earlier
+    version of this docstring quoted 1391/58 -- numbers that match no board set
+    -- and justified the branch with a form that cannot occur here.
 
       absent            -> insert `(justify mirror)` as the last child of
                            `(effects ...)`, at the `(font ...)` indentation,
@@ -462,11 +522,27 @@ def _flip_justify(node: str) -> str:
             rep = m.group(1) + '(justify ' + ' '.join(toks + ['mirror']) + ')'
         return node[:m.start()] + rep + node[m.end():]
 
-    fm = re.search(r'(\n([ \t]*))\(font\b', node)
+    # INSERT. The separator is taken from however `(font ...)` is actually
+    # written, so the compact one-line spelling works too. An earlier version
+    # required `(font` to START a line, which meant that on a compactly
+    # serialised board (KiCad 6/7 output, and anything a third-party tool
+    # writes) the DELETE path fired and the INSERT path silently did not:
+    # B->F removed the flag, F->B never added it, and the two stopped being
+    # inverses. No tracked board writes a one-line `(effects ...)`, so no gate
+    # could see it.
+    fm = re.search(r'(\s*)\(font\b', node)
     if fm is None:
-        return node          # no effects/font block: nothing to hang it on
+        # No font block to hang it on. REFUSE rather than return the node
+        # untouched: silently declining to mirror one text inside a footprint
+        # whose every other node moved is the half-flip this feature exists to
+        # prevent, and `write_placed_output` returns True either way.
+        raise SideFlipUnsupported(
+            f"{ref}: a text node has no `(effects (font ...))` to carry "
+            f"`(justify mirror)`, so its mirrored state cannot be written: "
+            f"{node[:120]!r}")
+    sep = fm.group(1) if '\n' in fm.group(1) else ' '
     fend = find_matching_paren(node, fm.end() - len('(font'))
-    return node[:fend] + fm.group(1) + '(justify mirror)' + node[fend:]
+    return node[:fend] + sep + '(justify mirror)' + node[fend:]
 
 
 def _flip_pad(node: str, ref: str, old_rot: float, new_rot: float) -> str:
@@ -483,11 +559,29 @@ def _flip_pad(node: str, ref: str, old_rot: float, new_rot: float) -> str:
     entirely and never calls it -- one code path per mode, so the ordinary
     non-flip write cannot regress.
     """
+    # A WHITELIST, like the footprint-level dispatch, and for the same reason.
+    # This was a blacklist -- refuse the three named heads, pass everything
+    # else through -- which meant the module's own argument stopped applying
+    # one level down: the very head that refuses at footprint level was emitted
+    # verbatim from inside a pad. The realistic instance is KiCad 9/10's
+    # `(padstack ...)` (per-layer pad geometry with its own nested
+    # `(primitives ...)` and per-layer `(layer ...)` sub-nodes): not in the
+    # refusal table, so its primitives never reached the check and its layers
+    # were never toggled. No tracked board carries one, which by this file's
+    # own doctrine is the argument for refusing rather than for passing
+    # through.
     for head, s, e in _iter_sexpr_children(node, 0):
         if head in _PAD_REFUSALS:
             raise SideFlipUnsupported(
                 f"{ref}: a pad carries ({head} ...) -- {_PAD_REFUSALS[head]}. "
                 f"Refusing to guess at its mirror image.")
+        if head not in _PAD_HANDLED:
+            raise SideFlipUnsupported(
+                f"{ref}: a pad carries a ({head} ...) node, which this mirror "
+                f"has no rule for. The pad dispatch is a WHITELIST for the "
+                f"same reason the footprint one is: a node passed through "
+                f"untouched leaves a pad whose geometry contradicts the face "
+                f"it claims, and nothing downstream raises.")
 
     lm = re.search(r'\(layers\b', node)
     if lm:
@@ -574,8 +668,22 @@ def _flip_footprint_block(fp_text: str, ref: str, old_rot: float,
     which negates the orientation itself; a caller that wants pcbnew's result
     passes the negated angle, which is what the parity gate does.
     """
+    # The block MUST declare a side of its own, and this is checked rather
+    # than assumed: `_block_side` defaults to 'F' when there is no top-level
+    # `(layer ...)`, so a block without one would have all its geometry
+    # mirrored and no layer written -- #714's exact silent failure,
+    # reintroduced in the degenerate case. KiCad always writes the node, so
+    # this is unreachable from KiCad; it is checked because a whitelist that
+    # refuses far less likely things should not wave this one through.
+    if not re.search(r'\(layer\s+"[^"]+"\)', fp_text):
+        raise SideFlipUnsupported(
+            f"{ref}: the footprint block declares no top-level `(layer ...)`, "
+            f"so there is nothing to flip and no way to say which face the "
+            f"mirrored geometry ended up on.")
+
     pieces = []
     prev = 0
+    saw_layer = False
     for head, s, e in _iter_sexpr_children(fp_text, 0):
         node = fp_text[s:e]
         if head in _FLIP_NAMED_REFUSALS:
@@ -597,6 +705,7 @@ def _flip_footprint_block(fp_text: str, ref: str, old_rot: float,
         if head == 'at':
             continue                     # already written by the caller
         elif head == 'layer':
+            saw_layer = True
             new = _flip_layer_nodes(node)
         elif head == 'private_layers':
             new = re.sub(r'"([^"]+)"',
@@ -616,15 +725,36 @@ def _flip_footprint_block(fp_text: str, ref: str, old_rot: float,
             # thirteen parity fixtures carried one until orangecrab U3 and J1
             # were added for exactly this.
             sided = bool(re.search(r'\(layer\s+"[FB]\.', node))
-            new = _flip_at_angle(node, ref, lambda a: 180.0 - a)
+            # A TEXT's angle composes with the pose change exactly as a pad's
+            # does; `180 - a` alone is the special case `new_rot == -old_rot`,
+            # i.e. pcbnew's own bare Flip, and it is wrong by the rotation
+            # delta for every other request. That is not hypothetical: the
+            # `layer_flip` perturbation HOLDS the pose, so its delta is 2R, and
+            # 9 of tigard's 33 flipped parts shipped a reference designator
+            # rotated 180 degrees from where KiCad puts it -- relative to their
+            # own pads, which had rotated correctly. Silent, and invisible to
+            # the parity gate because that gate only ever asked for the pure
+            # flip. See the COMPOSED pass in
+            # `tests/gui_parity/test_714_mirror_pcbnew_parity.py`.
+            new = _flip_at_angle(node, ref,
+                                 lambda a: new_rot + 180.0 - (a - old_rot))
             new = _flip_layer_nodes(new)
             if sided:
-                new = _flip_justify(new)
+                new = _flip_justify(new, ref)
         else:
             new = _flip_graphic(node, head, ref)
 
         if new != node:
             pieces.append((s, e, new))
+
+    if not saw_layer:
+        # Belt and braces: the regex above found a `(layer ...)` somewhere in
+        # the block, the WALK must have found it as a top-level child. If the
+        # two disagree, the walk is wrong and the block would ship half
+        # mirrored.
+        raise SideFlipUnsupported(
+            f"{ref}: the block's `(layer ...)` is not a top-level child, so "
+            f"the mirrored geometry would carry no face declaration.")
 
     if not pieces:
         return fp_text

--- a/py_placer/placement/writer.py
+++ b/py_placer/placement/writer.py
@@ -605,9 +605,21 @@ def _flip_footprint_block(fp_text: str, ref: str, old_rot: float,
         elif head == 'pad':
             new = _flip_pad(node, ref, old_rot, new_rot)
         elif head in _FLIP_TEXTS:
+            # The mirror FLAG is conditional on the text living on a sided
+            # layer, and only the flag is. Measured against pcbnew 10.0.0: a
+            # text on `Cmts.User` / `Eco1.User` / `Dwgs.User` has its y and its
+            # angle mirrored like any other, but pcbnew does NOT add
+            # `(justify mirror)` to it -- there is no face for it to be seen
+            # from the wrong side of. Toggling it anyway is a real divergence
+            # and it is invisible on an ordinary part: 28 flip-eligible texts
+            # on the tracked corpus sit on a User layer, and not one of the
+            # thirteen parity fixtures carried one until orangecrab U3 and J1
+            # were added for exactly this.
+            sided = bool(re.search(r'\(layer\s+"[FB]\.', node))
             new = _flip_at_angle(node, ref, lambda a: 180.0 - a)
             new = _flip_layer_nodes(new)
-            new = _flip_justify(new)
+            if sided:
+                new = _flip_justify(new)
         else:
             new = _flip_graphic(node, head, ref)
 

--- a/py_placer/placement/writer.py
+++ b/py_placer/placement/writer.py
@@ -11,7 +11,8 @@ import re
 import sys
 from typing import List, Dict
 
-from kicad_parser import find_matching_paren, iter_footprint_blocks
+from kicad_parser import (find_matching_paren, flip_layer_token,
+                          iter_footprint_blocks)
 from kicad_writer import move_copper_text_to_silkscreen
 
 
@@ -263,6 +264,367 @@ def _rotate_pad_angles(fp_text: str, delta_rot: float) -> str:
         fix_pad, fp_text)
 
 
+class SideFlipUnsupported(Exception):
+    """A flip was asked for on a footprint carrying a construct we will not guess at.
+
+    #714. RAISES rather than passing the construct through untouched, and the
+    argument is the same one `OutlineOwnerMove` above already makes:
+    `write_placed_output` returns True unconditionally, so a construct the
+    transform quietly skipped is indistinguishable from success at every call
+    site -- and a half-mirrored footprint is the SILENT failure this whole
+    feature is written around. `legality.footprint_side` reads `fp.layer[0]`
+    and nothing cross-checks the pads, so the board would grade plausibly and
+    wrongly forever.
+
+    Refusing is cheap, measured over the 22 tracked boards (1349 footprint
+    blocks): the refusal set touches at most 7 of them -- `primitives` 6,
+    `zone` 1 -- while `chamfer`, `rect_delta`, `fp_text_box` and `group` have
+    NO witness at all. A construct the corpus does not contain is a construct
+    no gate here can validate, so any rule for it would be an unfalsifiable
+    guess.
+    """
+
+
+# A coordinate literal, as this corpus actually spells them: measured 148417
+# tokens across every `(at|start|end|mid|center|xy|offset ...)` on every tracked
+# board, with ZERO outside this shape -- no leading `+`, no exponent, no `-0`.
+# That is what makes the sign TOGGLE below an exact involution, and it is why a
+# literal outside the shape is a refusal rather than a `float()` round trip.
+_COORD_LITERAL = re.compile(r'^-?\d+(\.\d+)?$')
+
+# Top-level children of a `(footprint ...)` block, by what the flip does with
+# them. Measured: these 27 heads are every top-level child kind on the tracked
+# corpus. Anything else REFUSES -- a whitelist, because you cannot test for a
+# node kind you have not thought of.
+_FLIP_PASSTHROUGH = frozenset({
+    'uuid', 'descr', 'tags', 'path', 'attr', 'embedded_fonts', 'sheetfile',
+    'sheetname', 'units', 'locked', 'variant', 'solder_mask_margin',
+    'solder_paste_margin', 'duplicate_pad_numbers_are_jumpers',
+    'net_tie_pad_groups', 'jumper_pad_groups', 'tstamp', 'autoplace_cost90',
+    'autoplace_cost180', 'clearance', 'zone_connect', 'thermal_width',
+    'thermal_gap', 'generator', 'generator_version', 'version',
+    # The 3D model is left COMPLETELY alone: the viewer applies the flip at
+    # render time, so mirroring its offset double-applies it. Probed on
+    # tigard J1 and orangecrab J4 -- pcbnew leaves both byte-identical.
+    'model',
+})
+_FLIP_GRAPHICS = frozenset({'fp_line', 'fp_rect', 'fp_circle', 'fp_poly',
+                            'fp_curve', 'fp_arc'})
+_FLIP_TEXTS = frozenset({'property', 'fp_text'})
+# `(layer ...)` and `(at ...)` are the footprint's OWN; `pad` and
+# `private_layers` have their own handlers.
+_FLIP_HANDLED = (_FLIP_GRAPHICS | _FLIP_TEXTS
+                 | {'layer', 'at', 'pad', 'private_layers'})
+
+# Constructs we refuse BY NAME, so the message can say which and why, rather
+# than falling through the generic "unknown node kind" arm.
+_FLIP_NAMED_REFUSALS = {
+    'zone': ("a footprint-internal (zone ...) stores its (pts (xy ...)) in "
+             "ABSOLUTE board coordinates, so mirroring it needs a flip centre "
+             "that this call does not have -- the pose may change in the same "
+             "write. One witness on the tracked corpus"),
+    'fp_text_box': "no tracked board carries one, so no gate here can validate a rule for it",
+    'group': "no tracked board carries one, so no gate here can validate a rule for it",
+}
+# ...and inside a pad.
+_PAD_REFUSALS = {
+    'primitives': ("a custom pad's sub-geometry frame is unconfirmed against "
+                   "pcbnew; 6 witnesses on the tracked corpus, none of them "
+                   "enough to validate a rule"),
+    'chamfer': ("corner NAMES under a mirror are unmeasured -- no tracked "
+                "board carries a chamfered pad"),
+    'rect_delta': ("trapezoid pad deltas under a mirror are unmeasured -- no "
+                   "tracked board carries one"),
+}
+
+_SIDED_LAYER = re.compile(r'^[FB]\.')
+_INNER_LAYER = re.compile(r'^In\d+\.Cu$', re.IGNORECASE)
+
+
+def _negate_coord(tok: str, ref: str, where: str) -> str:
+    """Toggle a coordinate literal's sign, as TEXT.
+
+    Not `_fmt_mm(-float(tok))`: that rewrites `0.500` as `0.5`, and the
+    flip-and-flip-back byte-identity gate would then be pinning the formatter
+    instead of the transform. A sign toggle over the measured literal grammar
+    is an exact involution by construction.
+    """
+    if not _COORD_LITERAL.match(tok):
+        raise SideFlipUnsupported(
+            f"{ref}: the coordinate {tok!r} in {where} is outside the literal "
+            f"grammar -?\\d+(\\.\\d+)? that makes a sign toggle an exact "
+            f"involution (measured: 148417 tokens on the tracked corpus, 0 "
+            f"outside it). Refusing rather than round-tripping it through "
+            f"float and silently reformatting the board.")
+    if float(tok) == 0.0:
+        return tok                      # '0' and '-0.000' both stay put
+    return tok[1:] if tok.startswith('-') else '-' + tok
+
+
+def _iter_sexpr_children(text: str, open_idx: int = 0):
+    """(head, start, end) for each direct child of the node starting at open_idx.
+
+    Built on the shipped string-aware `find_matching_paren`, so a lone paren
+    inside a quoted property value (an MPN like "TCR2EF115,LM(CT", #113) cannot
+    run the walk out of one node into the next.
+    """
+    end_all = find_matching_paren(text, open_idx)
+    i = open_idx + 1
+    while i < end_all - 1:
+        c = text[i]
+        if c == '"':
+            i += 1
+            while i < end_all and text[i] != '"':
+                i += 2 if text[i] == '\\' else 1
+            i += 1
+            continue
+        if c == '(':
+            end = find_matching_paren(text, i)
+            m = re.match(r'\(\s*([A-Za-z_][A-Za-z_0-9]*)', text[i:end])
+            yield (m.group(1) if m else '?'), i, end
+            i = end
+            continue
+        i += 1
+
+
+def _mirror_xy_pairs(node: str, ref: str, heads=('start', 'end', 'center',
+                                                 'mid', 'xy')) -> str:
+    """Negate the Y of every `(head x y)` in `node`. X is never touched."""
+    pat = re.compile(r'\((' + '|'.join(heads) + r')(\s+)(\S+)(\s+)(\S+)\)')
+
+    def fix(m):
+        return (f"({m.group(1)}{m.group(2)}{m.group(3)}{m.group(4)}"
+                f"{_negate_coord(m.group(5), ref, m.group(1))})")
+
+    return pat.sub(fix, node)
+
+
+def _flip_layer_nodes(node: str) -> str:
+    """Toggle every `(layer "X")` token inside `node`."""
+    def fix(m):
+        return f'(layer "{flip_layer_token(m.group(1))}")'
+    return re.sub(r'\(layer\s+"([^"]+)"\)', fix, node)
+
+
+def _flip_at_angle(node: str, ref: str, new_angle_of) -> str:
+    """Mirror the FIRST `(at x y [a])` in `node`: y negated, angle remapped.
+
+    The angle token's PRESENCE is preserved, which is what makes the round trip
+    exact. Measured: all 1110 `fp_text` and all 6565 `property` nodes on the
+    tracked corpus carry an explicit three-token `(at x y a)`, so a text never
+    gains or loses the token; 2884 pads carry the two-token form, and for those
+    the angle is 0 and stays 0 whenever the footprint's own rotation is 0 or
+    180. A pad that would gain a non-zero angle gains the token.
+    """
+    m = re.search(r'\(at\s+(\S+)\s+(\S+)(?:\s+(\S+))?\)', node)
+    if not m:
+        return node
+    x, y, a = m.group(1), m.group(2), m.group(3)
+    ny = _negate_coord(y, ref, 'at')
+    na = new_angle_of(float(a) if a is not None else 0.0)
+    na = round(na % 360, 6)
+    if a is not None or na != 0:
+        rep = f"(at {x} {ny} {na:.6g})"
+    else:
+        rep = f"(at {x} {ny})"
+    return node[:m.start()] + rep + node[m.end():]
+
+
+def _flip_justify(node: str) -> str:
+    """Toggle the `mirror` token of the first `(justify ...)` in `node`.
+
+    Three cases, and two of them add or delete a whole node. Measured, the
+    tracked corpus contains exactly two forms -- `(justify mirror)` x1391 and
+    `(justify left bottom)` x58 -- so alignment tokens are preserved and only
+    `mirror` moves:
+
+      absent            -> insert `(justify mirror)` as the last child of
+                           `(effects ...)`, at the `(font ...)` indentation,
+                           which is where KiCad writes it
+      `left bottom`     -> `left bottom mirror`
+      `mirror` alone    -> DELETE the node and its leading newline+indent
+                           (dropping only the token would leave `(justify)`)
+
+    The delete case is the one a token-replacement implementation gets wrong,
+    and it is the whole of the B->F direction.
+    """
+    m = re.search(r'(\s*)\(justify\s+([^()]*?)\)', node)
+    if m:
+        toks = m.group(2).split()
+        if 'mirror' in toks:
+            toks = [t for t in toks if t != 'mirror']
+            if not toks:
+                # the node's ENTIRE text, leading whitespace included, so
+                # insert and delete are exact inverses
+                return node[:m.start()] + node[m.end():]
+            rep = m.group(1) + '(justify ' + ' '.join(toks) + ')'
+        else:
+            rep = m.group(1) + '(justify ' + ' '.join(toks + ['mirror']) + ')'
+        return node[:m.start()] + rep + node[m.end():]
+
+    fm = re.search(r'(\n([ \t]*))\(font\b', node)
+    if fm is None:
+        return node          # no effects/font block: nothing to hang it on
+    fend = find_matching_paren(node, fm.end() - len('(font'))
+    return node[:fend] + fm.group(1) + '(justify mirror)' + node[fend:]
+
+
+def _flip_pad(node: str, ref: str, old_rot: float, new_rot: float) -> str:
+    """Mirror one `(pad ...)` node.
+
+    The pad ANGLE is the subtle one and is derived, not copied. KiCad stores a
+    pad's angle ABSOLUTE (`a = R + p`, p the pad-local angle); a flip sends
+    `p -> -p`, so
+
+        a' = R_new - (a - R_old)
+
+    `_rotate_pad_angles` computes `a + (R_new - R_old) = R_new + p`, which
+    agrees only when p is 0 or 180. This path therefore owns the pad `(at ...)`
+    entirely and never calls it -- one code path per mode, so the ordinary
+    non-flip write cannot regress.
+    """
+    for head, s, e in _iter_sexpr_children(node, 0):
+        if head in _PAD_REFUSALS:
+            raise SideFlipUnsupported(
+                f"{ref}: a pad carries ({head} ...) -- {_PAD_REFUSALS[head]}. "
+                f"Refusing to guess at its mirror image.")
+
+    lm = re.search(r'\(layers\b', node)
+    if lm:
+        lend = find_matching_paren(node, lm.start())
+        block = node[lm.start():lend]
+        toks = re.findall(r'"([^"]+)"', block)
+        for t in toks:
+            if '&' in t:
+                raise SideFlipUnsupported(
+                    f"{ref}: a pad names the layer set {t!r}. It is plausibly "
+                    f"its own mirror, and no tracked board carries one, so "
+                    f"nothing here can check that. Refusing rather than "
+                    f"guessing.")
+            if _INNER_LAYER.match(t):
+                raise SideFlipUnsupported(
+                    f"{ref}: a pad names the inner copper layer {t!r}. Its "
+                    f"mirror image depends on the board's inner-layer count "
+                    f"and on remove_unused_layers padstack semantics, and no "
+                    f"tracked board carries one in a footprint pad. Refusing.")
+        new_block = re.sub(r'"([^"]+)"',
+                           lambda m: '"' + flip_layer_token(m.group(1)) + '"',
+                           block)
+        node = node[:lm.start()] + new_block + node[lend:]
+
+    node = _flip_at_angle(node, ref, lambda a: new_rot - (a - old_rot))
+
+    # `(drill ... (offset x y))` -- the offset is the HOLE's displacement from
+    # the copper centre and mirrors with everything else. The only witness on
+    # the tracked corpus is rp2350 U8.
+    dm = re.search(r'\(drill\b', node)
+    if dm:
+        dend = find_matching_paren(node, dm.start())
+        node = (node[:dm.start()]
+                + _mirror_xy_pairs(node[dm.start():dend], ref, heads=('offset',))
+                + node[dend:])
+    return node
+
+
+def _flip_graphic(node: str, head: str, ref: str) -> str:
+    """Mirror one `fp_*` graphic node."""
+    node = _mirror_xy_pairs(node, ref)
+    node = _flip_layer_nodes(node)
+    if head == 'fp_arc':
+        # An arc's SWEEP is start->mid->end. Mirroring the three points
+        # reverses the sweep, so KiCad exchanges start and end to restore it.
+        # Measured on sonde_u U2 and rp2350 SW1. This is invisible to every
+        # geometric check -- the same curve passes through the same three
+        # points either way -- which is why the acceptance gate compares nodes.
+        sm = re.search(r'\(start\s+(\S+)\s+(\S+)\)', node)
+        em = re.search(r'\(end\s+(\S+)\s+(\S+)\)', node)
+        if sm and em:
+            s_body, e_body = f"{sm.group(1)} {sm.group(2)}", f"{em.group(1)} {em.group(2)}"
+            lo, hi = sorted((sm, em), key=lambda m: m.start())
+            lo_new = f"(start {e_body})" if lo is sm else f"(end {s_body})"
+            hi_new = f"(end {s_body})" if hi is em else f"(start {e_body})"
+            node = (node[:lo.start()] + lo_new + node[lo.end():hi.start()]
+                    + hi_new + node[hi.end():])
+    return node
+
+
+def _block_side(fp_text: str) -> str:
+    """'F' or 'B' from the block's own `(layer ...)`.
+
+    The same first-character rule `legality.footprint_side` applies to the
+    parsed object, read here off the text so the writer and the side model
+    cannot disagree about what a block says it is.
+    """
+    m = re.search(r'\(layer\s+"([^"]+)"\)', fp_text)
+    return 'B' if (m and m.group(1).startswith('B')) else 'F'
+
+
+def _flip_footprint_block(fp_text: str, ref: str, old_rot: float,
+                          new_rot: float) -> str:
+    """Mirror a whole footprint block to the other face (#714).
+
+    A paren-balanced walk over the block's top-level children with a per-kind
+    dispatch, NOT a set of global regexes: a blanket `y -> -y` over the block
+    would also hit `(size 1 1)`, `(thickness 0.15)` and `(stroke (width 0.12))`,
+    and a blanket layer toggle would hit nodes that must not move.
+
+    The block's own `(at ...)` is deliberately skipped -- `write_placed_output`
+    has already written it from `new_x/new_y/new_rotation`, and the caller owns
+    the final rotation. Note that means this differs from `pcbnew`'s `Flip`,
+    which negates the orientation itself; a caller that wants pcbnew's result
+    passes the negated angle, which is what the parity gate does.
+    """
+    pieces = []
+    prev = 0
+    for head, s, e in _iter_sexpr_children(fp_text, 0):
+        node = fp_text[s:e]
+        if head in _FLIP_NAMED_REFUSALS:
+            raise SideFlipUnsupported(
+                f"{ref}: the footprint carries a ({head} ...) node -- "
+                f"{_FLIP_NAMED_REFUSALS[head]}. Refusing to guess at its "
+                f"mirror image.")
+        if head in _FLIP_PASSTHROUGH:
+            continue
+        if head not in _FLIP_HANDLED:
+            raise SideFlipUnsupported(
+                f"{ref}: the footprint carries a ({head} ...) node, which this "
+                f"mirror has no rule for. The dispatch is a WHITELIST on "
+                f"purpose: a node passed through untouched leaves a footprint "
+                f"whose geometry contradicts the face it claims, and nothing "
+                f"downstream raises. Add a measured rule for ({head} ...) or "
+                f"leave the flip refused.")
+
+        if head == 'at':
+            continue                     # already written by the caller
+        elif head == 'layer':
+            new = _flip_layer_nodes(node)
+        elif head == 'private_layers':
+            new = re.sub(r'"([^"]+)"',
+                         lambda m: '"' + flip_layer_token(m.group(1)) + '"',
+                         node)
+        elif head == 'pad':
+            new = _flip_pad(node, ref, old_rot, new_rot)
+        elif head in _FLIP_TEXTS:
+            new = _flip_at_angle(node, ref, lambda a: 180.0 - a)
+            new = _flip_layer_nodes(new)
+            new = _flip_justify(new)
+        else:
+            new = _flip_graphic(node, head, ref)
+
+        if new != node:
+            pieces.append((s, e, new))
+
+    if not pieces:
+        return fp_text
+    out = []
+    for s, e, new in pieces:
+        out.append(fp_text[prev:s])
+        out.append(new)
+        prev = e
+    out.append(fp_text[prev:])
+    return ''.join(out)
+
+
 def write_placed_output(input_file: str, output_file: str,
                         placements: List[Dict],
                         via_moves: List = None,
@@ -340,6 +702,26 @@ def write_placed_output(input_file: str, output_file: str,
         new_rot = placement['new_rotation']
         old_rot = float(at_match.group(3)) if at_match.group(3) else 0.0
 
+        # #714. An OPTIONAL key: absent or None means the layer is left alone
+        # and this write is byte-identical to one built before the flip
+        # existed, which is what keeps the ~20 producers of these dicts
+        # (quench, seeder, portfolio, relocate, perturb, fanout_clearance,
+        # place_reconstruct, place_seed, converge, net_rescue) unchanged.
+        #
+        # Spelled 'F'/'B', matching `legality.footprint_side` exactly, and
+        # anything else RAISES at the boundary rather than 200 lines
+        # downstream -- 'B.Cu' is the mistake a caller actually makes.
+        new_side = placement.get('new_side')
+        if new_side is not None:
+            if new_side not in ('F', 'B'):
+                raise ValueError(
+                    f"{key}: new_side must be 'F' or 'B' (the spelling "
+                    f"`legality.footprint_side` uses), not {new_side!r}. A "
+                    f"layer NAME is not a side.")
+            side_change = new_side != _block_side(fp_text)
+        else:
+            side_change = False
+
         # #829 backstop. RAISES, and does not skip: this function returns True
         # unconditionally, so a skip would be indistinguishable from success --
         # and `route.py`'s #666 cap move gates its IN-MEMORY mirror on that
@@ -359,7 +741,16 @@ def write_placed_output(input_file: str, output_file: str,
         if (_OWNS_OUTLINE_RE.search(fp_text)
                 and (abs(new_x - float(at_match.group(1))) > _POSE_EPS
                      or abs(new_y - float(at_match.group(2))) > _POSE_EPS
-                     or abs((new_rot - old_rot + 180) % 360 - 180) > _POSE_EPS)
+                     or abs((new_rot - old_rot + 180) % 360 - 180) > _POSE_EPS
+                     # #714: a flip with identical x/y/rot is still a change,
+                     # and on an outline owner it MIRRORS the owned Edge.Cuts
+                     # geometry -- the board resize this guard exists to
+                     # refuse. Without this term the flip walks straight past
+                     # it. `perturb._all_at_current` never sets `new_side`, so
+                     # the dose-0 control board is unaffected, which is the
+                     # reason the rest of this predicate is written the way it
+                     # is.
+                     or side_change)
                 # `key`, not the raw reference: #726 keys a duplicated
                 # reference's second block `TP4~2`, and the owner map is keyed
                 # the same way (kicad_parser._footprint_blocks_by_key), so a
@@ -391,9 +782,18 @@ def write_placed_output(input_file: str, output_file: str,
 
         # KiCad stores pad angles as footprint rotation + pad-local rotation,
         # so a footprint rotation change must be added to every pad angle.
-        delta_rot = (new_rot - old_rot) % 360
-        if delta_rot != 0:
-            new_fp_text = _rotate_pad_angles(new_fp_text, delta_rot)
+        if side_change:
+            # The flip owns every pad angle itself: a mirror sends the
+            # pad-local angle p -> -p, so a' = new_rot - (a - old_rot), which
+            # `_rotate_pad_angles`' a + delta_rot equals only when p is 0 or
+            # 180. One code path per mode, so the ordinary write below cannot
+            # regress.
+            new_fp_text = _flip_footprint_block(new_fp_text, key,
+                                                old_rot, new_rot)
+        else:
+            delta_rot = (new_rot - old_rot) % 360
+            if delta_rot != 0:
+                new_fp_text = _rotate_pad_angles(new_fp_text, delta_rot)
 
         content = content[:start] + new_fp_text + content[end:]
         modified_count += 1

--- a/py_router/kicad_parser.py
+++ b/py_router/kicad_parser.py
@@ -637,6 +637,42 @@ class PCBData:
         return total
 
 
+def flip_layer_token(name: str) -> str:
+    """The other face's spelling of a layer token (#714).
+
+    A PREFIX RULE, deliberately not a table. Three name->id tables in this repo
+    already happen to enumerate the F/B pairs (`fix_kicad_drc_settings.
+    _TECH_LAYER_IDS`, and twice in this file's pcbnew paths); a fourth
+    enumeration is a fourth thing to keep in sync, and the enumeration is not
+    where the knowledge is. The knowledge is that KiCad spells a sided layer
+    `F.<x>` / `B.<x>` and an unsided one anything else.
+
+    Measured over the 22 tracked boards, the layer tokens that appear inside a
+    `(footprint ...)` block are exactly:
+
+        F.Cu F.Mask F.Paste F.SilkS F.CrtYd F.Fab F.Adhes
+        B.Cu B.Mask B.Paste B.SilkS B.CrtYd B.Fab
+        *.Cu *.Mask Dwgs.User Cmts.User Eco1.User Eco2.User User.1
+
+    This flips the twelve sided ones and returns the other eight unchanged --
+    including both wildcards, which pcbnew also leaves alone (`*.Cu` is KiCad's
+    ALL-copper set and is already its own mirror; rewriting it to `B*.Cu` or
+    `B.Cu` would silently narrow 66 pads on rp2350's U8 alone).
+
+    Inner copper is NOT handled here and must never be: `In1.Cu` has no
+    face, its mirror image would be `In<n+1-k>.Cu`, that depends on the board's
+    inner-layer count AND on `remove_unused_layers` padstack semantics, and no
+    tracked board carries an explicit `In<n>.Cu` in a footprint pad. Callers
+    that must decide about one are expected to REFUSE rather than take the
+    identity answer this returns.
+    """
+    if name.startswith('F.'):
+        return 'B.' + name[2:]
+    if name.startswith('B.'):
+        return 'F.' + name[2:]
+    return name
+
+
 def local_to_global(fp_x: float, fp_y: float, fp_rotation_deg: float,
                     pad_local_x: float, pad_local_y: float) -> Tuple[float, float]:
     """

--- a/py_router/kicad_parser.py
+++ b/py_router/kicad_parser.py
@@ -654,17 +654,23 @@ def flip_layer_token(name: str) -> str:
         B.Cu B.Mask B.Paste B.SilkS B.CrtYd B.Fab
         *.Cu *.Mask Dwgs.User Cmts.User Eco1.User Eco2.User User.1
 
-    This flips the twelve sided ones and returns the other eight unchanged --
+    This flips the THIRTEEN sided ones and returns the other SEVEN unchanged --
     including both wildcards, which pcbnew also leaves alone (`*.Cu` is KiCad's
     ALL-copper set and is already its own mirror; rewriting it to `B*.Cu` or
     `B.Cu` would silently narrow 66 pads on rp2350's U8 alone).
 
-    Inner copper is NOT handled here and must never be: `In1.Cu` has no
-    face, its mirror image would be `In<n+1-k>.Cu`, that depends on the board's
-    inner-layer count AND on `remove_unused_layers` padstack semantics, and no
-    tracked board carries an explicit `In<n>.Cu` in a footprint pad. Callers
-    that must decide about one are expected to REFUSE rather than take the
-    identity answer this returns.
+    Inner copper passes through unchanged, and that is what KiCad does too:
+    probed against pcbnew 10.0.0 on a six-layer board, `FOOTPRINT::Flip` leaves
+    a pad on `In1.Cu` and an `fp_line` on `In2.Cu` exactly where they are. An
+    earlier version of this docstring asserted the mirror image would be
+    `In<n+1-k>.Cu` -- that was reasoning, and the oracle this repo uses as
+    ground truth everywhere else contradicts it.
+
+    The identity answer is therefore CORRECT for KiCad 10, not merely
+    conservative. `placement.writer` still refuses a pad naming an explicit
+    `In<n>.Cu`, which is a separate and deliberate choice: no tracked board
+    carries one, so this repo has no regression test that would notice if a
+    future KiCad started remapping them.
     """
     if name.startswith('F.'):
         return 'B.' + name[2:]

--- a/tests/data/714_identity_sha256.json
+++ b/tests/data/714_identity_sha256.json
@@ -1,0 +1,93 @@
+{
+ "_command": "python3 tests/test_714_identity_write_unchanged.py --write-baseline",
+ "boards": {
+  "cap_chain.kicad_pcb": {
+   "footprints": 4,
+   "sha256": "2198b0c2b740757ace7887d0b27468aadbd20f7b81dfe694d96abefd9c729d35"
+  },
+  "esp_prog.kicad_pcb": {
+   "footprints": 21,
+   "sha256": "1a5ac4dd9726baf85d67a5c6f0fe9a16803e56b5ad403c872b8375cdefad1d7d"
+  },
+  "flat_hierarchy.kicad_pcb": {
+   "footprints": 64,
+   "sha256": "a20e6e09e350d4698a1487ab6b985e159bbbf8ad0990eeaeb80f5d3cf4c0104a"
+  },
+  "glasgow_revC.kicad_pcb": {
+   "footprints": 272,
+   "sha256": "73c8f2500953bfeeeeb8d44d8293f8f10480e3f5dcafbdb9d48cb7a42ff52981"
+  },
+  "haasoscope_pro_max_test.kicad_pcb": {
+   "footprints": 8,
+   "sha256": "8ee0164efefc3d601d416010bad8f8cf202eb9db6a71938831dd18d7f317a5c5"
+  },
+  "interf_u_unrouted.kicad_pcb": {
+   "footprints": 25,
+   "sha256": "4e7495fc1957249e88444268dd275dde32657bde4dcf881b84ddd05cb0e4e7a6"
+  },
+  "interf_u_unrouted_placed.kicad_pcb": {
+   "footprints": 25,
+   "sha256": "2142e45320cbbcd26078a09c484dd023f45a1f604da8a7ce00257e8479b316a3"
+  },
+  "kit-dev-coldfire-xilinx_5213.kicad_pcb": {
+   "footprints": 160,
+   "sha256": "79474acbf9f3c4001b51c2baf03bf40c76fc5f74fda37d7bc9205cc51d79bae4"
+  },
+  "lvds_converter_dualclk.kicad_pcb": {
+   "footprints": 13,
+   "sha256": "8797c3e3c456dc9b7fb61f6a5cc6523e0064d6260eb2e519786901aba8952e33"
+  },
+  "lvds_converter_dualclk_gnd.kicad_pcb": {
+   "footprints": 13,
+   "sha256": "14c1e2ce74d2c35800882e754cc95b0b4c5bd4a80f2c5d7782857f7bd0a737c2"
+  },
+  "orangecrab_ext_pll.kicad_pcb": {
+   "footprints": 167,
+   "sha256": "92ecf93305bc29bb02e0f789e187178ff257035f35a3215028a0ae4153697aae"
+  },
+  "qfn_csi_underpad_diff.kicad_pcb": {
+   "footprints": 2,
+   "sha256": "f00842c8bbb53213a6266a5bc0826ca5b2d9c47a29d8503bdc55a180414ab8a8"
+  },
+  "qfn_diffpair_escape.kicad_pcb": {
+   "footprints": 1,
+   "sha256": "f6c2603c32c4e2dea96ceee915c878835782e2f7ac18b325c9daea56d90e942d"
+  },
+  "qfn_interior_pads.kicad_pcb": {
+   "footprints": 1,
+   "sha256": "295e640099edbde59092d46c51956302f286586dd52b73ac56bc5a8c1066d233"
+  },
+  "qfn_underpad_coupling.kicad_pcb": {
+   "footprints": 1,
+   "sha256": "865c4524fbb04e905882447774693dbf54983aeec276a3c7ad6663d301e34b5b"
+  },
+  "routed_output.kicad_pcb": {
+   "footprints": 8,
+   "sha256": "890864b4545ec26534a61741a6d488dccba5e9a90c80657ec89127087c290f56"
+  },
+  "rp2350_fpga_eensy_prePlane.kicad_pcb": {
+   "footprints": 61,
+   "sha256": "3eaf9c742345c95099284e2c69e26e8355150825de96887578501bd55b4323b1"
+  },
+  "sonde_u.kicad_pcb": {
+   "footprints": 25,
+   "sha256": "4a8a77f761a533d58357d785cc6b227745b6ebd5698f53627e79a9a6911cdf5a"
+  },
+  "splitflap_driver.kicad_pcb": {
+   "footprints": 65,
+   "sha256": "c7f2789196b073ffaaea6492ebe7873bf9336db36e9cbe3f0b8d88e01c082cb8"
+  },
+  "tigard.kicad_pcb": {
+   "footprints": 92,
+   "sha256": "cb6dd215537d8850cd8e4ef61994c568a083d3c9ee94942208a2bf4e2b3ebc47"
+  },
+  "ulx3s.kicad_pcb": {
+   "footprints": 235,
+   "sha256": "1ca4adfa5fac156f1cdd9806a14c1bc60258d33ea71046ed42bca7a06bb703d6"
+  },
+  "watchy.kicad_pcb": {
+   "footprints": 86,
+   "sha256": "24337ed88a2d875e0eb878f021d736038f159e6ecf0efa6d6ac7c6125ca172a9"
+  }
+ }
+}

--- a/tests/gui_parity/test_714_mirror_pcbnew_parity.py
+++ b/tests/gui_parity/test_714_mirror_pcbnew_parity.py
@@ -201,7 +201,25 @@ def _count_nodes(text):
     return collections.Counter(re.findall(r'\(\s*([A-Za-z_][A-Za-z_0-9]*)', text))
 
 
-def _diff(a, b, path='', out=None, limit=40):
+# pcbnew's own flip LOSES A NANOMETRE on an arc's mid point, and ours does not.
+# Measured: a plain `LoadBoard` + `SaveBoard` round trip preserves rp2350 SW1's
+# `(mid 1.40384 0)` exactly, but `fp.Flip(...)` + `SaveBoard` writes
+# `1.403839` -- pcbnew holds an arc as centre/radius/angles and re-derives mid
+# from the polar form when it mirrors. This transform never touches an arc's X
+# at all, so it emits the board's own value verbatim.
+#
+# So this is a divergence in OUR favour, and it is waived rather than matched:
+# adopting pcbnew's rounding would make the transform lossy and would break the
+# flip-and-flip-back byte identity `tests/test_714_flip_roundtrip.py` pins.
+#
+# The waiver is deliberately narrow and LOUD -- `mid` only, one nanometre only,
+# every instance printed, and a cap, so it cannot quietly widen into a blanket
+# float tolerance that would hide a real disagreement.
+_MID_WAIVER_NM = 1
+MAX_WAIVED = 6
+
+
+def _diff(a, b, path='', out=None, limit=40, waived=None):
     """First differing paths between two canonical trees."""
     out = [] if out is None else out
     if len(out) >= limit:
@@ -212,6 +230,12 @@ def _diff(a, b, path='', out=None, limit=40):
         return out
     if not isinstance(a, tuple):
         if a != b:
+            if (waived is not None and '/mid[' in path
+                    and isinstance(a, int) and isinstance(b, int)
+                    and abs(a - b) <= _MID_WAIVER_NM):
+                waived.append(f"{path}: {a} (ours, = the board's own value) "
+                              f"vs {b} (pcbnew, re-derived from centre/angles)")
+                return out
             out.append(f"{path}: {a!r} (ours) vs {b!r} (pcbnew)")
         return out
     if len(a) != len(b):
@@ -219,7 +243,7 @@ def _diff(a, b, path='', out=None, limit=40):
         return out
     for i, (x, y) in enumerate(zip(a, b)):
         head = a[0] if isinstance(a[0], str) else '?'
-        _diff(x, y, f"{path}/{head}[{i}]", out, limit)
+        _diff(x, y, f"{path}/{head}[{i}]", out, limit, waived)
         if len(out) >= limit:
             break
     return out
@@ -238,6 +262,7 @@ def main(argv=None):
     tmp = tempfile.mkdtemp(prefix='krt714par')
     problems = []
     n_fix = n_pads = n_nonpad = 0
+    waived = []
     surfaces = set()
     direction_checked = False
     try:
@@ -299,7 +324,7 @@ def main(argv=None):
                                 f"membership and #726 keying rest on these")
 
             d = _diff(canon(parse_sexpr(ta)), canon(parse_sexpr(tk)),
-                      limit=args.show)
+                      limit=args.show, waived=waived)
             if d:
                 problems.append(f"{board}:{ref} {len(d)} node difference(s):")
                 problems.extend("      " + x for x in d[:args.show])
@@ -321,6 +346,15 @@ def main(argv=None):
                         f"covering a surface it claims to")
     if not direction_checked:
         problems.append("the flip direction was never verified to mirror Y")
+    if waived:
+        print(f"waived {len(waived)} arc-mid nanometre difference(s) -- pcbnew "
+              f"re-derives an arc's mid from centre/angles when it flips and "
+              f"loses 1 nm; this transform emits the board's own value:")
+        for w in waived:
+            print("    " + w)
+    if len(waived) > MAX_WAIVED:
+        problems.append(f"{len(waived)} waived differences (cap {MAX_WAIVED}) "
+                        f"-- the waiver is widening into a blanket tolerance")
 
     if problems:
         print(f"FAIL: {len(problems)} problem(s)")

--- a/tests/gui_parity/test_714_mirror_pcbnew_parity.py
+++ b/tests/gui_parity/test_714_mirror_pcbnew_parity.py
@@ -94,11 +94,23 @@ FIXTURES = [
     ('orangecrab_ext_pll', 'J1'),   # property on Eco1.User
 ]
 
+# Each fixture is compared TWICE: once against pcbnew's bare flip, and once
+# against a flip COMPOSED with a rotation the caller chose. The composed pass
+# exists because its absence hid a real bug -- the text-angle rule was the
+# constant `180 - a`, which is the general composition only when
+# `new_rot == -old_rot`, i.e. only for the bare flip this gate used to be the
+# whole of. Every shipped consumer asks for something else: `perturb`'s
+# `layer_flip` HOLDS the pose, so its delta is 2R, and 9 of tigard's 33 flipped
+# parts shipped a reference designator rotated 180 degrees from where KiCad
+# puts it -- relative to their own pads, which had rotated correctly.
+COMPOSED_DELTAS = (None, 90.0, 180.0)
+PASSES = [(b, r, d) for (b, r) in FIXTURES for d in COMPOSED_DELTAS]
+
 # A run that compared nothing must fail. Floors are below today's counts so a
 # board changing is not a failure, and far above zero so a vacuous run is.
-MIN_FIXTURES = 12
-MIN_PADS = 400
-MIN_NON_PAD_NODES = 400
+MIN_FIXTURES = 36
+MIN_PADS = 1200
+MIN_NON_PAD_NODES = 1200
 # Surfaces at least one fixture must actually carry, so the set cannot silently
 # stop covering them.
 REQUIRED_SURFACES = ('fp_arc', 'fp_curve', 'model', 'fp_poly', 'fp_circle')
@@ -180,7 +192,13 @@ def canon(node):
     rest = node[1:]
     if head == 'at':
         vals = [_num(t) for t in rest[:2]]
-        vals += [_num(t, angle=True) for t in rest[2:3]]
+        # A MISSING angle is zero, and is normalised to it. Declared because it
+        # is a real normalisation and not a formatting nicety: this writer
+        # PRESERVES the angle token's presence (which is what buys the
+        # byte-identical round trip) while pcbnew drops a zero, so under a
+        # composed rotation the same pad is `(at x y 0)` here and `(at x y)`
+        # there. Same angle, different arity.
+        vals += [_num(rest[2], angle=True) if len(rest) > 2 else 0.0]
         vals += [canon(t) for t in rest[3:]]
         return (head,) + tuple(vals)
     kids = [canon(t) if not isinstance(t, str) else _num(t) for t in rest]
@@ -223,7 +241,11 @@ def _count_nodes(text):
 # every instance printed, and a cap, so it cannot quietly widen into a blanket
 # float tolerance that would hide a real disagreement.
 _MID_WAIVER_NM = 1
-MAX_WAIVED = 6
+# Two arcs waive, once per pass. Stated as the product rather than as the
+# number, so adding a pass does not silently push the run through a cap it
+# was sitting exactly on -- it was at 6 of 6 the moment the composed
+# passes landed, which is a boundary, not a margin.
+MAX_WAIVED = 2 * 3 + 3
 
 
 def _diff(a, b, path='', out=None, limit=40, waived=None):
@@ -273,7 +295,7 @@ def main(argv=None):
     surfaces = set()
     direction_checked = False
     try:
-        for board, ref in FIXTURES:
+        for board, ref, delta in PASSES:
             src = os.path.join(REPO, 'kicad_files', board + '.kicad_pcb')
             if not os.path.isfile(src):
                 problems.append(f"{board}: board not tracked -- fixture stale")
@@ -288,6 +310,12 @@ def main(argv=None):
             before_y = [p.GetFPRelativePosition().y for p in fp.Pads()]
             before_x = [p.GetFPRelativePosition().x for p in fp.Pads()]
             fp.Flip(fp.GetPosition(), tb)
+            if delta is not None:
+                # COMPOSED: a flip AND a rotation the caller chose, which
+                # is not pcbnew's bare flip and is the case every shipped
+                # consumer actually asks for.
+                fp.SetOrientationDegrees(
+                    round((fp.GetOrientationDegrees() + delta) % 360, 6))
             if before_y and not direction_checked:
                 # The enum is KiCad 10; on 9 the second arg is a bool. Prove
                 # the direction TAKEN mirrors Y, so a KiCad that changes the
@@ -312,7 +340,8 @@ def main(argv=None):
             write_placed_output(src, ours, [{
                 'reference': ref, 'new_x': round(fp0.x, 6),
                 'new_y': round(fp0.y, 6),
-                'new_rotation': round((-(fp0.rotation or 0.0)) % 360, 6),
+                'new_rotation': round(((-(fp0.rotation or 0.0))
+                                       + (delta or 0.0)) % 360, 6),
                 'new_side': side}])
 
             ta, tk = _block(ours, ref), _block(kout, ref)
@@ -333,7 +362,9 @@ def main(argv=None):
             d = _diff(canon(parse_sexpr(ta)), canon(parse_sexpr(tk)),
                       limit=args.show, waived=waived)
             if d:
-                problems.append(f"{board}:{ref} {len(d)} node difference(s):")
+                tag = 'pure flip' if delta is None else f'flip + {delta} deg'
+                problems.append(
+                    f"{board}:{ref} [{tag}] {len(d)} node difference(s):")
                 problems.extend("      " + x for x in d[:args.show])
     finally:
         shutil.rmtree(tmp, ignore_errors=True)

--- a/tests/gui_parity/test_714_mirror_pcbnew_parity.py
+++ b/tests/gui_parity/test_714_mirror_pcbnew_parity.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""#714 PAR: the ACCEPTANCE criterion -- our flip against KiCad's own.
+
+    For every fixture, the footprint block `write_placed_output` emits for a
+    side change is -- after a declared, enumerated normalisation -- node for
+    node and number for number identical to the block pcbnew itself writes
+    after `fp.Flip(pos, FLIP_DIRECTION_TOP_BOTTOM)` + `SaveBoard()`.
+
+WHY NOT THE COMPARISON THE ISSUE SUGGESTS. #714 proposes comparing resolved
+`Pad.global_x/global_y/size_x/size_y/layers` plus `footprint.layer` through both
+parse paths. That is a smoke test, and it cannot see the bug it is written for:
+
+  * `local_to_global` (kicad_parser.py:640-671) has NO mirror term -- KiCad
+    stores B-side children pre-mirrored. So toggle `(layer "F.Cu")` to B.Cu and
+    toggle the pad `(layers)`, but forget the local y, and every pad's GLOBAL
+    position comes out exactly as before, on both parse paths, while
+    `footprint.layer` reads B. Every field the issue names passes. That is the
+    headline silent failure, and the suggested test is blind to it.
+  * Comparing two PARSERS over one file tests the parsers, not the writer. The
+    oracle has to be a different DOCUMENT: pcbnew's own flip of the original.
+  * PCBData models a minority of a block. Against 1319 pad-bearing footprints
+    the tracked corpus carries 1206 blocks with `fp_line`, 1215 with `model`,
+    1077 with `fp_text`, 132 `fp_circle`, 85 `fp_poly`, 54 `fp_arc`, 46
+    `fp_rect`. No pad field compares any of them.
+  * And `fp_arc`'s start/end swap is GEOMETRICALLY INVISIBLE: mirroring
+    start/mid/end without exchanging start and end yields the same curve
+    through the same three points. Only a node-level comparison against KiCad's
+    own serialisation can see it.
+
+NORMALISATION, declared because every normalisation is a place to hide a bug:
+numbers to integer NANOMETRES (`round(mm*1e6)`, the #493 `local_to_global`
+convention -- both sides are nm-quantised so the tolerance is exactly ZERO, not
+a float epsilon); angles folded to `round(a % 360, 4)`; child order sorted by
+canonical content, because pcbnew re-serialises in its own order. `uuid` is
+deliberately NOT normalised away -- the uuid multiset must be preserved, which
+buys group membership, netlist back-annotation and #726 keying in one line.
+
+FIXTURES ARE ALL `generator_version "10.0"` boards. 7 of the 22 tracked boards
+are 9.0, and `SaveBoard` format-upgrades those, so the diff would be unreadable
+for reasons unrelated to the flip.
+
+ABSENCE IS AN ERROR, NOT A SKIP (exit 2). This is the acceptance criterion, and
+`tests/mutate_714.py` uses it as a killer gate: a gate that self-skips at exit 0
+reports every mutation row it guards as SURVIVED.
+
+    python3 tests/gui_parity/test_714_mirror_pcbnew_parity.py
+    python3 tests/gui_parity/test_714_mirror_pcbnew_parity.py --show 40
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(REPO, 'py_router'))
+sys.path.insert(0, os.path.join(REPO, 'py_placer'))
+sys.path.insert(0, os.path.join(REPO, 'tests'))
+
+KICAD_PYTHONS = [
+    "/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/"
+    "Versions/Current/bin/python3",
+    "/usr/bin/python3",
+    os.path.expandvars(r"C:\Program Files\KiCad\bin\python.exe"),
+    *sorted(glob.glob(r"C:\Program Files\KiCad\*\bin\python.exe"), reverse=True),
+]
+
+# (board, ref) -- every board here is generator_version 10.0.
+FIXTURES = [
+    ('tigard', 'J7'),        # rot 0, 6 SMD pads
+    ('tigard', 'J1'),        # rot -90, 30 THT pads, *.Cu-adjacent, 2 models
+    ('tigard', 'U3'),        # 91 pads, F.Paste-only aperture sub-pads
+    ('tigard', 'LOGO2'),     # 0 pads, fp_curve, B.Cu
+    ('glasgow_revC', 'U7'),  # SOT-143, x- and y-asymmetric
+    ('glasgow_revC', 'SW1'),  # rot 180
+    ('glasgow_revC', 'U1'),  # fp_poly + fp_circle + *.Cu
+    ('glasgow_revC', 'R9'),  # non-orthogonal rotation, 45
+    ('orangecrab_ext_pll', 'J4'),   # B->F, (justify mirror), model offsets
+    ('rp2350_fpga_eensy_prePlane', 'U8'),   # the only (drill (offset)) witness
+    ('rp2350_fpga_eensy_prePlane', 'SW1'),  # fp_arc on a 10.0 board
+    ('rp2350_fpga_eensy_prePlane', 'D1'),   # non-orthogonal rotation, -45
+    ('ulx3s', 'BAT1'),       # 19 fp_arc, B.Cu -- graphics tier
+]
+
+# A run that compared nothing must fail. Floors are below today's counts so a
+# board changing is not a failure, and far above zero so a vacuous run is.
+MIN_FIXTURES = 10
+MIN_PADS = 200
+MIN_NON_PAD_NODES = 300
+# Surfaces at least one fixture must actually carry, so the set cannot silently
+# stop covering them.
+REQUIRED_SURFACES = ('fp_arc', 'fp_curve', 'model', 'fp_poly', 'fp_circle')
+
+_NUM = re.compile(r'^[-+]?(\d+\.?\d*|\.\d+)([eE][-+]?\d+)?$')
+
+
+def _reexec_into_kicad():
+    for cand in KICAD_PYTHONS:
+        if cand == sys.executable:
+            continue
+        if os.path.exists(cand):
+            r = subprocess.run([cand, '-c', 'import pcbnew'], capture_output=True)
+            if r.returncode == 0:
+                argv = [cand, os.path.abspath(__file__)] + sys.argv[1:]
+                if os.name == 'nt':
+                    # os.execv re-splits argv on spaces through the CRT on
+                    # Windows ("C:\Program Files\..." tears in two).
+                    sys.exit(subprocess.run(argv).returncode)
+                os.execv(cand, argv)
+    print("ERROR: no python with pcbnew found. This is the ACCEPTANCE gate for "
+          "#714; it does not self-skip, because a killer gate that exits 0 "
+          "reports every mutation row it guards as SURVIVED.")
+    sys.exit(2)
+
+
+# ------------------------------------------------------------- s-expressions
+
+def parse_sexpr(text):
+    """Nested lists of tokens. Test-side only -- the engine has no parser."""
+    out, stack, i, n = [], [], 0, len(text)
+    cur = out
+    while i < n:
+        c = text[i]
+        if c == '(':
+            new = []
+            cur.append(new)
+            stack.append(cur)
+            cur = new
+            i += 1
+        elif c == ')':
+            cur = stack.pop()
+            i += 1
+        elif c == '"':
+            j = i + 1
+            buf = []
+            while j < n and text[j] != '"':
+                if text[j] == '\\':
+                    buf.append(text[j + 1]); j += 2
+                else:
+                    buf.append(text[j]); j += 1
+            cur.append('"' + ''.join(buf) + '"')
+            i = j + 1
+        elif c.isspace():
+            i += 1
+        else:
+            j = i
+            while j < n and not text[j].isspace() and text[j] not in '()"':
+                j += 1
+            cur.append(text[i:j])
+            i = j
+    return out[0] if len(out) == 1 else out
+
+
+def _num(tok, angle=False):
+    if not isinstance(tok, str) or not _NUM.match(tok):
+        return tok
+    v = float(tok)
+    return round(v % 360, 4) if angle else int(round(v * 1e6))
+
+
+def canon(node):
+    """Canonical form: numbers to nm, `at` angles folded, children sorted."""
+    if isinstance(node, str):
+        return node
+    if not node:
+        return ()
+    head = node[0] if isinstance(node[0], str) else canon(node[0])
+    rest = node[1:]
+    if head == 'at':
+        vals = [_num(t) for t in rest[:2]]
+        vals += [_num(t, angle=True) for t in rest[2:3]]
+        vals += [canon(t) for t in rest[3:]]
+        return (head,) + tuple(vals)
+    kids = [canon(t) if not isinstance(t, str) else _num(t) for t in rest]
+    scalars = tuple(k for k in kids if not isinstance(k, tuple))
+    subs = tuple(sorted((k for k in kids if isinstance(k, tuple)), key=repr))
+    return (head,) + scalars + subs
+
+
+def _block(path, ref):
+    from kicad_parser import iter_footprint_blocks
+    text = open(path, encoding='utf-8').read()
+    for _s, _e, fp_text, _raw, key in iter_footprint_blocks(text):
+        if key == ref:
+            return fp_text
+    return None
+
+
+def _uuids(text):
+    import collections
+    return collections.Counter(re.findall(r'\(uuid\s+"([^"]+)"\)', text))
+
+
+def _count_nodes(text):
+    import collections
+    return collections.Counter(re.findall(r'\(\s*([A-Za-z_][A-Za-z_0-9]*)', text))
+
+
+def _diff(a, b, path='', out=None, limit=40):
+    """First differing paths between two canonical trees."""
+    out = [] if out is None else out
+    if len(out) >= limit:
+        return out
+    if type(a) is not type(b):
+        out.append(f"{path}: type {type(a).__name__} vs {type(b).__name__}: "
+                   f"{a!r} vs {b!r}")
+        return out
+    if not isinstance(a, tuple):
+        if a != b:
+            out.append(f"{path}: {a!r} (ours) vs {b!r} (pcbnew)")
+        return out
+    if len(a) != len(b):
+        out.append(f"{path}: arity {len(a)} vs {len(b)}: {a!r} vs {b!r}")
+        return out
+    for i, (x, y) in enumerate(zip(a, b)):
+        head = a[0] if isinstance(a[0], str) else '?'
+        _diff(x, y, f"{path}/{head}[{i}]", out, limit)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--show', type=int, default=12)
+    args = ap.parse_args(argv)
+
+    import pcbnew
+    from kicad_parser import parse_kicad_pcb
+    from placement.writer import write_placed_output
+
+    tb = getattr(pcbnew, 'FLIP_DIRECTION_TOP_BOTTOM', False)
+    tmp = tempfile.mkdtemp(prefix='krt714par')
+    problems = []
+    n_fix = n_pads = n_nonpad = 0
+    surfaces = set()
+    direction_checked = False
+    try:
+        for board, ref in FIXTURES:
+            src = os.path.join(REPO, 'kicad_files', board + '.kicad_pcb')
+            if not os.path.isfile(src):
+                problems.append(f"{board}: board not tracked -- fixture stale")
+                continue
+
+            # ---- path B: pcbnew's own flip
+            b = pcbnew.LoadBoard(src)
+            fp = b.FindFootprintByReference(ref)
+            if fp is None:
+                problems.append(f"{board}:{ref} not on the board -- fixture stale")
+                continue
+            before_y = [p.GetFPRelativePosition().y for p in fp.Pads()]
+            before_x = [p.GetFPRelativePosition().x for p in fp.Pads()]
+            fp.Flip(fp.GetPosition(), tb)
+            if before_y and not direction_checked:
+                # The enum is KiCad 10; on 9 the second arg is a bool. Prove
+                # the direction TAKEN mirrors Y, so a KiCad that changes the
+                # meaning fails loudly instead of comparing a different flip.
+                after_y = [p.GetFPRelativePosition().y for p in fp.Pads()]
+                after_x = [p.GetFPRelativePosition().x for p in fp.Pads()]
+                if after_x != before_x or after_y != [-v for v in before_y]:
+                    problems.append(
+                        "the flip direction taken does NOT mirror Y "
+                        f"(x moved={after_x != before_x}); refusing to compare "
+                        f"against a different flip")
+                direction_checked = True
+            kout = os.path.join(tmp, f"{board}_{ref}_kicad.kicad_pcb")
+            pcbnew.SaveBoard(kout, b)
+
+            # ---- path A: our writer. pcbnew NEGATES the orientation, and this
+            # writer deliberately does not (the caller owns `new_rotation`), so
+            # hand it the negated angle to compare like with like.
+            fp0 = parse_kicad_pcb(src).footprints[ref]
+            side = 'F' if (fp0.layer or 'F').startswith('B') else 'B'
+            ours = os.path.join(tmp, f"{board}_{ref}_ours.kicad_pcb")
+            write_placed_output(src, ours, [{
+                'reference': ref, 'new_x': round(fp0.x, 6),
+                'new_y': round(fp0.y, 6),
+                'new_rotation': round((-(fp0.rotation or 0.0)) % 360, 6),
+                'new_side': side}])
+
+            ta, tk = _block(ours, ref), _block(kout, ref)
+            if ta is None or tk is None:
+                problems.append(f"{board}:{ref} block missing from an output")
+                continue
+            n_fix += 1
+            counts = _count_nodes(tk)
+            n_pads += counts.get('pad', 0)
+            n_nonpad += sum(v for k, v in counts.items()
+                            if k.startswith('fp_') or k in ('model', 'property'))
+            surfaces |= {k for k in counts if k in REQUIRED_SURFACES}
+
+            if _uuids(ta) != _uuids(tk):
+                problems.append(f"{board}:{ref} uuid multiset changed -- group "
+                                f"membership and #726 keying rest on these")
+
+            d = _diff(canon(parse_sexpr(ta)), canon(parse_sexpr(tk)),
+                      limit=args.show)
+            if d:
+                problems.append(f"{board}:{ref} {len(d)} node difference(s):")
+                problems.extend("      " + x for x in d[:args.show])
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    print(f"coverage: {n_fix} fixtures, {n_pads} pads, {n_nonpad} non-pad nodes, "
+          f"surfaces={sorted(surfaces)}")
+    if n_fix < MIN_FIXTURES:
+        problems.append(f"only {n_fix} fixtures compared (floor {MIN_FIXTURES})")
+    if n_pads < MIN_PADS:
+        problems.append(f"only {n_pads} pads compared (floor {MIN_PADS})")
+    if n_nonpad < MIN_NON_PAD_NODES:
+        problems.append(f"only {n_nonpad} non-pad nodes compared "
+                        f"(floor {MIN_NON_PAD_NODES})")
+    missing = [s for s in REQUIRED_SURFACES if s not in surfaces]
+    if missing:
+        problems.append(f"no fixture carries {missing} -- the set stopped "
+                        f"covering a surface it claims to")
+    if not direction_checked:
+        problems.append("the flip direction was never verified to mirror Y")
+
+    if problems:
+        print(f"FAIL: {len(problems)} problem(s)")
+        for p in problems[:60]:
+            print("  " + p)
+        return 1
+    print("PASS: every fixture matches pcbnew's own flip, node for node")
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        import pcbnew  # noqa: F401
+    except ImportError:
+        _reexec_into_kicad()
+    sys.exit(main())

--- a/tests/gui_parity/test_714_mirror_pcbnew_parity.py
+++ b/tests/gui_parity/test_714_mirror_pcbnew_parity.py
@@ -85,13 +85,20 @@ FIXTURES = [
     ('rp2350_fpga_eensy_prePlane', 'SW1'),  # fp_arc on a 10.0 board
     ('rp2350_fpga_eensy_prePlane', 'D1'),   # non-orthogonal rotation, -45
     ('ulx3s', 'BAT1'),       # 19 fp_arc, B.Cu -- graphics tier
+    # Texts on a NON-sided layer. pcbnew mirrors their y and angle but leaves
+    # `(justify ...)` alone -- there is no face to be seen from the wrong side
+    # of. 28 flip-eligible texts on the tracked corpus sit on a User layer and
+    # NONE of the fixtures above carries one, so this divergence shipped
+    # invisibly until these two were added.
+    ('orangecrab_ext_pll', 'U3'),   # 2 fp_text on Cmts.User
+    ('orangecrab_ext_pll', 'J1'),   # property on Eco1.User
 ]
 
 # A run that compared nothing must fail. Floors are below today's counts so a
 # board changing is not a failure, and far above zero so a vacuous run is.
-MIN_FIXTURES = 10
-MIN_PADS = 200
-MIN_NON_PAD_NODES = 300
+MIN_FIXTURES = 12
+MIN_PADS = 400
+MIN_NON_PAD_NODES = 400
 # Surfaces at least one fixture must actually carry, so the set cannot silently
 # stop covering them.
 REQUIRED_SURFACES = ('fp_arc', 'fp_curve', 'model', 'fp_poly', 'fp_circle')

--- a/tests/measure_714_mirror_convention.py
+++ b/tests/measure_714_mirror_convention.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""#714 phase 0: what a layer flip actually has to do, measured -- not reasoned.
+
+Issue #714 asks `placement.writer.write_placed_output` to be able to emit a
+footprint on the other face. The failure mode is SILENT: `legality.footprint_side`
+(legality.py:239-242) decides a part's side from `Footprint.layer`'s first
+character alone, with no pad cross-check, so a block whose `(layer ...)` says
+B.Cu while its pads still say F.Cu reports side B and computes every overlap,
+courtyard and clearance number from F geometry, and nothing raises.
+
+That makes the mirror convention a thing to MEASURE against pcbnew, not to take
+from prose -- and the issue's own prose is one of the things this script
+falsifies. NOT named `test_*.py`, so `tests/run_all.py` never collects it; it is
+a measurement whose numbers the tests and the PR body then cite.
+
+    python3 tests/measure_714_mirror_convention.py            # everything
+    python3 tests/measure_714_mirror_convention.py --sections A,B,C
+    python3 tests/measure_714_mirror_convention.py --json out.json
+
+Sections:
+  A  corpus census: every top-level child node kind of every footprint block
+  B  the coordinate-literal grammar (does a text sign toggle round-trip?)
+  C  fixture discrimination, under BOTH symmetry predicates
+  D  generator_version per board (a SaveBoard diff is only readable on 10.0)
+  E  the pcbnew mirror convention, per node kind, at five rotations
+  F  involution: TOP_BOTTOM vs LEFT_RIGHT
+
+E and F need pcbnew and re-exec into KiCad's python; A-D are pure Python and
+run under any interpreter.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO, 'py_router'))
+sys.path.insert(0, os.path.join(REPO, 'py_placer'))
+sys.path.insert(0, os.path.join(REPO, 'tests'))
+
+KICAD_PYTHONS = [
+    "/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/"
+    "Versions/Current/bin/python3",
+    "/usr/bin/python3",
+    os.path.expandvars(r"C:\Program Files\KiCad\bin\python.exe"),
+    *sorted(glob.glob(r"C:\Program Files\KiCad\*\bin\python.exe"), reverse=True),
+]
+
+# The nodes whose numeric children are COORDINATES (mirror candidates), as
+# opposed to sizes/widths/thicknesses, which must never be touched.
+COORD_HEADS = ('at', 'start', 'end', 'mid', 'center', 'xy', 'offset')
+
+# A coordinate literal, as this corpus actually spells them. Section B checks
+# that this is the WHOLE grammar; a text sign toggle is an exact involution
+# only over literals of this shape.
+_NUM = re.compile(r'^-?\d+(\.\d+)?$')
+
+# Fixtures named in the plan, with what each is the sole witness for.
+FIXTURES = [
+    ('tigard', 'J7', 'rot 0, 6 SMD pads -- the canonical measured case'),
+    ('tigard', 'J1', 'rot -90, 30 THT pads -- rotation x flip composition'),
+    ('tigard', 'U3', 'QFN-64-1EP, F.Paste-only aperture sub-pads'),
+    ('tigard', 'LOGO2', '0 pads, fp_curve, B.Cu -- graphics with no pad signal'),
+    ('glasgow_revC', 'U7', 'SOT-143 -- smallest asymmetric part'),
+    ('glasgow_revC', 'SW1', 'rot 180'),
+    ('glasgow_revC', 'U1', 'fp_poly + fp_circle + *.Cu'),
+    ('glasgow_revC', 'R9', 'non-orthogonal rotation (45)'),
+    ('orangecrab_ext_pll', 'J4', 'B.Cu -> F.Cu; (model (offset ...)); justify mirror'),
+    ('orangecrab_ext_pll', 'U9', 'B.Cu; custom pad (primitives)'),
+    ('rp2350_fpga_eensy_prePlane', 'U8', 'the only (drill ... (offset)) witness'),
+    ('rp2350_fpga_eensy_prePlane', 'J2', 'the only footprint-internal (zone) witness'),
+    ('rp2350_fpga_eensy_prePlane', 'SW1', 'fp_arc on a KiCad-10 board'),
+    ('rp2350_fpga_eensy_prePlane', 'D1', 'non-orthogonal rotation (-45)'),
+    ('ulx3s', 'BAT1', 'fp_arc, B.Cu -- pad-vacuous, graphics tier only'),
+]
+
+# Constructs the plan REFUSES rather than guesses at. Section A prints the
+# corpus witness count for each; a count of 0 is the argument for refusing.
+ZERO_COVERAGE_CANDIDATES = ('chamfer', 'rect_delta', 'fp_text_box', 'group',
+                            'primitives', 'zone', 'fp_curve')
+
+
+def _reexec_into_kicad():
+    for cand in KICAD_PYTHONS:
+        if cand == sys.executable:
+            continue
+        if os.path.exists(cand):
+            r = subprocess.run([cand, '-c', 'import pcbnew'], capture_output=True)
+            if r.returncode == 0:
+                argv = [cand, os.path.abspath(__file__)] + sys.argv[1:]
+                if os.name == 'nt':
+                    # os.execv re-splits argv on spaces through the CRT on
+                    # Windows ("C:\Program Files\..." tears in two).
+                    sys.exit(subprocess.run(argv).returncode)
+                os.execv(cand, argv)
+    print("ERROR: no python with pcbnew found -- sections E/F cannot run")
+    sys.exit(2)
+
+
+def boards():
+    """The TRACKED boards. Never a plain glob -- see run_utils.corpus_boards."""
+    from run_utils import corpus_boards
+    out = corpus_boards()
+    if not out:
+        print("ERROR: git could not name the tracked corpus; refusing to "
+              "measure against a set this script cannot identify")
+        sys.exit(2)
+    return out
+
+
+def child_nodes(fp_text):
+    """(head, start, end) for each TOP-LEVEL child node of a footprint block.
+
+    Uses the shipped string-aware `find_matching_paren`, so a lone paren inside
+    a property value (an MPN like "TCR2EF115,LM(CT", #113) cannot run the walk
+    out of one node into the next.
+    """
+    from kicad_parser import find_matching_paren
+    # Skip the `(footprint "name"` header: advance past the quoted name.
+    i = fp_text.index('"')
+    i = fp_text.index('"', i + 1) + 1
+    n = len(fp_text)
+    while i < n:
+        c = fp_text[i]
+        if c == '"':
+            i += 1
+            while i < n and fp_text[i] != '"':
+                i += 2 if fp_text[i] == '\\' else 1
+            i += 1
+            continue
+        if c == '(':
+            end = find_matching_paren(fp_text, i)
+            m = re.match(r'\(\s*([A-Za-z_][A-Za-z_0-9]*)', fp_text[i:end])
+            yield (m.group(1) if m else '?'), i, end
+            i = end
+            continue
+        i += 1
+
+
+def descendant_heads(text):
+    """Every `(head` anywhere inside `text`, counted. Nested, not just top level."""
+    return collections.Counter(m.group(1)
+                               for m in re.finditer(r'\(\s*([A-Za-z_][A-Za-z_0-9]*)',
+                                                    text))
+
+
+# ------------------------------------------------------------------ section A
+
+def section_a(paths):
+    from kicad_parser import iter_footprint_blocks
+    top = collections.Counter()
+    deep = collections.Counter()
+    blocks = 0
+    witnesses = collections.defaultdict(list)
+    layer_tokens = collections.Counter()
+    for p in paths:
+        name = os.path.splitext(os.path.basename(p))[0]
+        text = open(p, encoding='utf-8').read()
+        for _s, _e, fp_text, _raw, key in iter_footprint_blocks(text):
+            blocks += 1
+            heads = {h for h, _a, _b in child_nodes(fp_text)}
+            top.update(heads)
+            d = descendant_heads(fp_text)
+            deep.update(d)
+            for k in ZERO_COVERAGE_CANDIDATES:
+                if d.get(k):
+                    witnesses[k].append(f"{name}:{key}")
+            for m in re.finditer(r'\(layers?\s+([^)]*)\)', fp_text):
+                layer_tokens.update(re.findall(r'"([^"]+)"', m.group(1)))
+    print(f"A. corpus census -- {len(paths)} tracked boards, {blocks} footprint blocks")
+    print("   top-level child kinds (blocks containing at least one):")
+    for k, v in sorted(top.items(), key=lambda kv: -kv[1]):
+        print(f"     {k:<36} {v:6d}")
+    print("   layer tokens appearing inside a footprint block:")
+    print("     " + ' '.join(sorted(layer_tokens)))
+    print("   refusal candidates, by witness count:")
+    for k in ZERO_COVERAGE_CANDIDATES:
+        w = witnesses[k]
+        shown = ', '.join(w[:4]) + (' ...' if len(w) > 4 else '')
+        print(f"     {k:<14} {len(w):5d} block(s)   {shown or '-- NO WITNESS'}")
+    return {'blocks': blocks, 'top_level_kinds': dict(top),
+            'all_kinds': dict(deep), 'layer_tokens': sorted(layer_tokens),
+            'refusal_witnesses': {k: witnesses[k] for k in ZERO_COVERAGE_CANDIDATES}}
+
+
+# ------------------------------------------------------------------ section B
+
+def section_b(paths):
+    """Is a TEXT sign toggle an exact involution over this corpus's literals?
+
+    It is, if and only if every coordinate literal matches `-?\\d+(\\.\\d+)?`.
+    Going through float instead would rewrite `0.500` as `0.5`, and the
+    round-trip gate would then be pinning the formatter, not the transform.
+    """
+    from kicad_parser import iter_footprint_blocks
+    total = 0
+    bad = []
+    for p in paths:
+        text = open(p, encoding='utf-8').read()
+        for _s, _e, fp_text, _raw, key in iter_footprint_blocks(text):
+            for head, a, b in child_nodes(fp_text):
+                node = fp_text[a:b]
+                for m in re.finditer(r'\(\s*(%s)\s+([^()]*?)\)'
+                                     % '|'.join(COORD_HEADS), node):
+                    for tok in m.group(2).split():
+                        total += 1
+                        if not _NUM.match(tok):
+                            bad.append((os.path.basename(p), key, head,
+                                        m.group(1), tok))
+    print(f"B. coordinate literals: {total} tokens, {len(bad)} outside "
+          f"-?\\d+(\\.\\d+)? ")
+    for row in bad[:20]:
+        print("     OUTSIDE GRAMMAR:", row)
+    if not bad:
+        print("     => a text sign toggle is an exact involution on this corpus")
+    return {'coord_tokens': total, 'outside_grammar': bad[:50]}
+
+
+# ------------------------------------------------------------------ section C
+
+def _pad_key_pos(p):
+    return (round(p.local_x, 6), round(p.local_y, 6))
+
+
+def _pad_key_tuple(p):
+    return (p.pad_number, p.pad_type, p.shape,
+            round(p.local_x, 6), round(p.local_y, 6),
+            round((getattr(p, 'rotation', 0.0) or 0.0) % 360, 4))
+
+
+def _mirror(key, axis):
+    k = list(key)
+    i = 3 if len(k) > 2 and isinstance(k[0], str) else 0
+    # position tuple (x, y) vs full tuple (..., x, y, ang)
+    if len(k) == 2:
+        xi, yi = 0, 1
+    else:
+        xi, yi = 3, 4
+    if axis == 'y':
+        k[yi] = round(-k[yi], 6)
+    else:
+        k[xi] = round(-k[xi], 6)
+    if len(k) > 2:
+        k[5] = round((-k[5]) % 360, 4)
+    return tuple(k)
+
+
+def section_c(paths):
+    from kicad_parser import parse_kicad_pcb
+    by_board = {os.path.splitext(os.path.basename(p))[0]: p for p in paths}
+    cache = {}
+    rows = []
+    for board, ref, why in FIXTURES:
+        p = by_board.get(board)
+        if p is None:
+            rows.append((board, ref, 'BOARD NOT TRACKED', why))
+            continue
+        if board not in cache:
+            cache[board] = parse_kicad_pcb(p)
+        fp = cache[board].footprints.get(ref)
+        if fp is None:
+            rows.append((board, ref, 'REF MISSING', why))
+            continue
+        pads = fp.pads or []
+        if not pads:
+            rows.append((board, ref, dict(pads=0, tier='graphic-only'), why))
+            continue
+        pos = sorted(_pad_key_pos(q) for q in pads)
+        tup = sorted(_pad_key_tuple(q) for q in pads)
+        d_pos_y = pos != sorted(_mirror(k, 'y') for k in pos)
+        d_tup_y = tup != sorted(_mirror(k, 'y') for k in tup)
+        d_axis = (sorted(_mirror(k, 'y') for k in pos)
+                  != sorted(_mirror(k, 'x') for k in pos))
+        rows.append((board, ref,
+                     dict(pads=len(pads), rot=fp.rotation, layer=fp.layer,
+                          D1_pos=d_pos_y, D1_tuple=d_tup_y, D2_axis=d_axis,
+                          tier='pad' if d_tup_y else 'graphic-only'), why))
+    print("C. fixture discrimination "
+          "(D1 = the y-mirror is observable; D2 = a wrong-axis mutant is observable)")
+    for board, ref, info, why in rows:
+        print(f"   {board:<28} {ref:<6} {info}")
+        print(f"        {why}")
+
+    # And the corpus-wide symmetric fraction, under BOTH predicates, so no
+    # threshold can be pinned to the wrong one.
+    stats = {}
+    for label, keyfn in (('position', _pad_key_pos), ('tuple', _pad_key_tuple)):
+        tot = sym = 0
+        for p in paths:
+            for _ref, fp in parse_kicad_pcb(p).footprints.items():
+                if not fp.pads:
+                    continue
+                tot += 1
+                ks = sorted(keyfn(q) for q in fp.pads)
+                if ks == sorted(_mirror(k, 'y') for k in ks):
+                    sym += 1
+        stats[label] = (sym, tot, round(100.0 * sym / tot, 1) if tot else 0.0)
+        print(f"   y-symmetric under the {label:<8} predicate: "
+              f"{sym}/{tot} = {stats[label][2]}%")
+    return {'fixtures': [(b, r, i if isinstance(i, dict) else str(i))
+                         for b, r, i, _w in rows],
+            'symmetric_fraction': stats}
+
+
+# ------------------------------------------------------------------ section D
+
+def section_d(paths):
+    print("D. generator_version (a pcbnew SaveBoard diff is only readable on 10.0)")
+    out = {}
+    for p in paths:
+        head = open(p, encoding='utf-8').read(4000)
+        m = re.search(r'\(generator_version\s+"([^"]+)"', head)
+        v = m.group(1) if m else '?'
+        out[os.path.splitext(os.path.basename(p))[0]] = v
+    for k, v in sorted(out.items(), key=lambda kv: (kv[1], kv[0])):
+        print(f"     {v:<6} {k}")
+    tens = [k for k, v in out.items() if v.startswith('10')]
+    print(f"   => {len(tens)} of {len(out)} boards are 10.x; parity fixtures "
+          f"must come from those")
+    return out
+
+
+# ------------------------------------------- sections E/F (need pcbnew)
+
+def _fp_signature(pcbnew, fp):
+    sig = {'layer': pcbnew.LayerName(fp.GetLayer()),
+           'orient': round(fp.GetOrientationDegrees() % 360, 4), 'pads': [],
+           'texts': []}
+    for p in fp.Pads():
+        r = p.GetFPRelativePosition()
+        sig['pads'].append((p.GetNumber(), r.x, r.y,
+                            round(p.GetOrientationDegrees() % 360, 4),
+                            tuple(sorted(pcbnew.LayerName(l)
+                                         for l in p.GetLayerSet().Seq()))))
+    for t in (fp.Reference(), fp.Value()):
+        r = t.GetFPRelativePosition()
+        sig['texts'].append((r.x, r.y, round(t.GetTextAngleDegrees() % 360, 4),
+                             bool(t.IsMirrored()),
+                             pcbnew.LayerName(t.GetLayer())))
+    return sig
+
+
+def _flip(pcbnew, fp, direction):
+    fp.Flip(fp.GetPosition(), direction)
+
+
+def section_e(paths):
+    import pcbnew
+    tb = getattr(pcbnew, 'FLIP_DIRECTION_TOP_BOTTOM', False)
+    by_board = {os.path.splitext(os.path.basename(p))[0]: p for p in paths}
+    print("E. the pcbnew mirror convention "
+          f"(pcbnew {pcbnew.GetBuildVersion()}, FLIP_DIRECTION_TOP_BOTTOM={tb!r})")
+    out = {}
+    for board, ref, _why in FIXTURES:
+        p = by_board.get(board)
+        if p is None:
+            continue
+        b = pcbnew.LoadBoard(p)
+        fp = b.FindFootprintByReference(ref)
+        if fp is None:
+            print(f"   {board}:{ref} MISSING")
+            continue
+        before = _fp_signature(pcbnew, fp)
+        _flip(pcbnew, fp, tb)
+        after = _fp_signature(pcbnew, fp)
+        # The three rules, stated as checks rather than as prose.
+        pad_x_fixed = all(a[1] == c[1] for a, c in zip(before['pads'], after['pads']))
+        pad_y_neg = all(a[2] == -c[2] for a, c in zip(before['pads'], after['pads']))
+        layer_flipped = before['layer'][0] != after['layer'][0]
+        txt_180 = all(round((180 - a[2]) % 360, 4) == c[2]
+                      for a, c in zip(before['texts'], after['texts']))
+        mirror_tog = all(a[3] != c[3] for a, c in zip(before['texts'], after['texts']))
+        orient_neg = round((-before['orient']) % 360, 4) == after['orient']
+        print(f"   {board:<28} {ref:<6} pads={len(before['pads']):3d} "
+              f"{before['layer']}->{after['layer']}  "
+              f"x_fixed={pad_x_fixed} y_neg={pad_y_neg} layer={layer_flipped} "
+              f"txt180={txt_180} mirror_toggle={mirror_tog} orient_neg={orient_neg}")
+        out[f"{board}:{ref}"] = dict(pad_x_fixed=pad_x_fixed, pad_y_neg=pad_y_neg,
+                                     layer_flipped=layer_flipped,
+                                     text_180_minus_a=txt_180,
+                                     mirror_toggles=mirror_tog,
+                                     orientation_negates=orient_neg,
+                                     before_layer=before['layer'],
+                                     after_layer=after['layer'])
+    return out
+
+
+def section_f(paths):
+    import pcbnew
+    dirs = [('TOP_BOTTOM', getattr(pcbnew, 'FLIP_DIRECTION_TOP_BOTTOM', False)),
+            ('LEFT_RIGHT', getattr(pcbnew, 'FLIP_DIRECTION_LEFT_RIGHT', True))]
+    by_board = {os.path.splitext(os.path.basename(p))[0]: p for p in paths}
+    print("F. involution: flip twice and compare "
+          "(byte-identity round-trip is only statable for an involution)")
+    out = {}
+    for board, ref, _why in FIXTURES:
+        p = by_board.get(board)
+        if p is None:
+            continue
+        for name, d in dirs:
+            b = pcbnew.LoadBoard(p)
+            fp = b.FindFootprintByReference(ref)
+            if fp is None:
+                continue
+            s0 = _fp_signature(pcbnew, fp)
+            _flip(pcbnew, fp, d)
+            _flip(pcbnew, fp, d)
+            ok = _fp_signature(pcbnew, fp) == s0
+            out[f"{board}:{ref}:{name}"] = ok
+            if not ok:
+                s1 = _fp_signature(pcbnew, fp)
+                diff = [(a, c) for a, c in zip(s0['texts'], s1['texts']) if a != c]
+                print(f"   {board:<28} {ref:<6} {name:<11} involution=False  {diff}")
+            else:
+                print(f"   {board:<28} {ref:<6} {name:<11} involution=True")
+    return out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--sections', default='ABCDEF')
+    ap.add_argument('--json')
+    args = ap.parse_args(argv)
+    want = set(args.sections.upper())
+    need_pcbnew = bool(want & set('EF'))
+    if need_pcbnew:
+        try:
+            import pcbnew  # noqa: F401
+        except ImportError:
+            _reexec_into_kicad()
+
+    paths = boards()
+    doc = {'basis': subprocess.run(['git', 'rev-parse', 'HEAD'], cwd=REPO,
+                                   capture_output=True, text=True).stdout.strip(),
+           'boards': len(paths)}
+    for letter, fn in (('A', section_a), ('B', section_b), ('C', section_c),
+                       ('D', section_d), ('E', section_e), ('F', section_f)):
+        if letter in want:
+            print()
+            doc[letter] = fn(paths)
+    if args.json:
+        with open(args.json, 'w', encoding='utf-8') as fh:
+            json.dump(doc, fh, indent=1, sort_keys=True, default=str)
+        print(f"\nJSON -> {args.json}")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/measure_714_mirror_convention.py
+++ b/tests/measure_714_mirror_convention.py
@@ -287,10 +287,39 @@ def section_c(paths):
         print(f"   {board:<28} {ref:<6} {info}")
         print(f"        {why}")
 
-    # And the corpus-wide symmetric fraction, under BOTH predicates, so no
-    # threshold can be pinned to the wrong one.
+    # The corpus-wide symmetric fraction under THREE predicates, because the
+    # number depends on the predicate and the three answer different
+    # questions. Publishing one of them alone is how a safety margin gets
+    # quoted at twice its real size.
+    #
+    #   position          {(x, y)} closed under y -> -y
+    #                     "would a bare POSITION comparison notice the mirror?"
+    #                     -- the weakest, and the one the issue's 89.2% is.
+    #
+    #   tuple             {(num, type, shape, x, y, angle)} with the angle
+    #                     NEGATED on the mirrored side
+    #                     "would a full pad-tuple comparison notice an
+    #                     implementation that changes nothing but the layer
+    #                     token?" -- the angle term does most of the work here.
+    #
+    #   tuple_angle_held  the same tuple with the angle IDENTICAL on both sides
+    #                     "how often is the Y-MIRROR ITSELF unobservable?"
+    #                     -- i.e. against the mutant that negates angles and
+    #                     layers but forgets y, which is exactly the local-X /
+    #                     local-Y confusion the issue's own prose invites.
+    #
+    # That third one is the number an implementer needs and it is the worst of
+    # the three. Measured: 90.8% / 40.3% / 76.6%. Reading 40.3% as the margin
+    # against a forgotten y-mirror is off by nearly a factor of two.
+    def _hold_angle(k):
+        return (k[0], k[1], k[2], k[3], k[4], 0.0)
+
     stats = {}
-    for label, keyfn in (('position', _pad_key_pos), ('tuple', _pad_key_tuple)):
+    for label, keyfn, mirrorfn in (
+            ('position', _pad_key_pos, lambda k: _mirror(k, 'y')),
+            ('tuple', _pad_key_tuple, lambda k: _mirror(k, 'y')),
+            ('tuple_angle_held', lambda q: _hold_angle(_pad_key_tuple(q)),
+             lambda k: _mirror(_hold_angle(k), 'y'))):
         tot = sym = 0
         for p in paths:
             for _ref, fp in parse_kicad_pcb(p).footprints.items():
@@ -298,10 +327,10 @@ def section_c(paths):
                     continue
                 tot += 1
                 ks = sorted(keyfn(q) for q in fp.pads)
-                if ks == sorted(_mirror(k, 'y') for k in ks):
+                if ks == sorted(mirrorfn(k) for k in ks):
                     sym += 1
         stats[label] = (sym, tot, round(100.0 * sym / tot, 1) if tot else 0.0)
-        print(f"   y-symmetric under the {label:<8} predicate: "
+        print(f"   y-symmetric under the {label:<17} predicate: "
               f"{sym}/{tot} = {stats[label][2]}%")
     return {'fixtures': [(b, r, i if isinstance(i, dict) else str(i))
                          for b, r, i, _w in rows],
@@ -329,6 +358,18 @@ def section_d(paths):
 # ------------------------------------------- sections E/F (need pcbnew)
 
 def _fp_signature(pcbnew, fp):
+    """Every mirror-relevant field, keyed so two states can be compared.
+
+    ALL text-bearing nodes, not just Reference and Value. Sampling two of them
+    UNDERCOUNTS, and it undercounted here: a footprint carries ~5.7 text nodes
+    corpus-wide, 736 of them sit on the opposite face from their footprint's
+    own `(layer ...)`, and it is the excluded ones -- `Datasheet` and
+    `Description` on F.Fab -- that make LEFT_RIGHT non-involutive on tigard J1
+    and LOGO2. Measured: the two-field sample reported LEFT_RIGHT failing on
+    4 of 15 fixtures, the full sample reports 6 of 15. The conclusion held
+    (LEFT_RIGHT is lossy) but the published count was wrong, and wrong in the
+    direction that made the measurement look tidier than it was.
+    """
     sig = {'layer': pcbnew.LayerName(fp.GetLayer()),
            'orient': round(fp.GetOrientationDegrees() % 360, 4), 'pads': [],
            'texts': []}
@@ -338,12 +379,40 @@ def _fp_signature(pcbnew, fp):
                             round(p.GetOrientationDegrees() % 360, 4),
                             tuple(sorted(pcbnew.LayerName(l)
                                          for l in p.GetLayerSet().Seq()))))
-    for t in (fp.Reference(), fp.Value()):
+    # Keyed by UUID, never sorted. Sorting looked harmless and was not: a
+    # flip changes a text's y, angle, mirror flag and layer, so the sort order
+    # changes with it and a before/after zip then pairs unrelated texts --
+    # which reported `txt_lay=False` and `txt180=False` on six fixtures whose
+    # texts were in fact correct. pcbnew preserves uuids across a Flip, so the
+    # uuid is the one field that identifies the same node on both sides.
+    # `GetFields()`, not `Reference()` + `Value()`. A footprint's fields are
+    # Reference, Value, Datasheet and Description; the first two are the ones
+    # a human sees and the LAST TWO are the ones that make LEFT_RIGHT
+    # non-involutive on tigard J1 and LOGO2 (both sit on F.Fab and both fold
+    # 180 -> 0 / 270 -> 90 under a double LEFT_RIGHT flip). Sampling the
+    # visible two reported LEFT_RIGHT failing on 4 of 15 fixtures; sampling
+    # all four reports 6 of 15. `GraphicalItems()` carries `fp_text` and does
+    # NOT carry fields, so both sources are needed.
+    if hasattr(fp, 'GetFields'):
+        texts = list(fp.GetFields())
+    else:
+        texts = [fp.Reference(), fp.Value()]
+    for it in fp.GraphicalItems():
+        if hasattr(it, 'GetTextAngleDegrees'):
+            texts.append(it)
+    sig['texts'] = {}
+    for t in texts:
         r = t.GetFPRelativePosition()
-        sig['texts'].append((r.x, r.y, round(t.GetTextAngleDegrees() % 360, 4),
-                             bool(t.IsMirrored()),
-                             pcbnew.LayerName(t.GetLayer())))
+        sig['texts'][t.m_Uuid.AsString()] = (
+            r.x, r.y, round(t.GetTextAngleDegrees() % 360, 4),
+            bool(t.IsMirrored()), pcbnew.LayerName(t.GetLayer()))
     return sig
+
+
+def _paired(before, after):
+    """(before_row, after_row) for every text present on BOTH sides, by uuid."""
+    return [(before['texts'][k], after['texts'][k])
+            for k in before['texts'] if k in after['texts']]
 
 
 def _flip(pcbnew, fp, direction):
@@ -352,6 +421,7 @@ def _flip(pcbnew, fp, direction):
 
 def section_e(paths):
     import pcbnew
+    from kicad_parser import flip_layer_token
     tb = getattr(pcbnew, 'FLIP_DIRECTION_TOP_BOTTOM', False)
     by_board = {os.path.splitext(os.path.basename(p))[0]: p for p in paths}
     print("E. the pcbnew mirror convention "
@@ -372,16 +442,60 @@ def section_e(paths):
         # The three rules, stated as checks rather than as prose.
         pad_x_fixed = all(a[1] == c[1] for a, c in zip(before['pads'], after['pads']))
         pad_y_neg = all(a[2] == -c[2] for a, c in zip(before['pads'], after['pads']))
+        # ASSERTED, not merely captured. The first version of this script read
+        # pad angles and pad layer sets into the signature and then checked
+        # NEITHER, so "footprint and pad angles negate, 15/15" rested on a
+        # check that only ever looked at the footprint's own orientation.
+        pad_ang_neg = all(round((-a[3]) % 360, 4) == c[3]
+                          for a, c in zip(before['pads'], after['pads']))
+        pad_layers_flipped = all(
+            tuple(sorted(flip_layer_token(x) for x in a[4])) == c[4]
+            for a, c in zip(before['pads'], after['pads']))
+        _tx = _paired(before, after)
+        txt_layers_flipped = all(flip_layer_token(a[4]) == c[4] for a, c in _tx)
         layer_flipped = before['layer'][0] != after['layer'][0]
-        txt_180 = all(round((180 - a[2]) % 360, 4) == c[2]
-                      for a, c in zip(before['texts'], after['texts']))
-        mirror_tog = all(a[3] != c[3] for a, c in zip(before['texts'], after['texts']))
+        txt_180 = all(round((180 - a[2]) % 360, 4) == c[2] for a, c in _tx)
+        # The mirror FLAG toggles only for a text on a SIDED layer. Measured
+        # against pcbnew 10.0.0: a text on Cmts.User / Eco1.User / Dwgs.User
+        # has its y and its angle mirrored like any other and keeps its
+        # justify untouched -- there is no face for it to be seen from the
+        # wrong side of. 28 flip-eligible texts on the tracked corpus sit on a
+        # User layer. Reported separately so the qualifier cannot be lost:
+        # the unconditional form of this check is what shipped a writer that
+        # added `(justify mirror)` to all of them.
+        _sided = [(a, c) for a, c in _tx if a[4][:2] in ('F.', 'B.')]
+        _unsided = [(a, c) for a, c in _tx if a[4][:2] not in ('F.', 'B.')]
+        mirror_tog = all(a[3] != c[3] for a, c in _sided)
+        mirror_held = all(a[3] == c[3] for a, c in _unsided)
         orient_neg = round((-before['orient']) % 360, 4) == after['orient']
         print(f"   {board:<28} {ref:<6} pads={len(before['pads']):3d} "
               f"{before['layer']}->{after['layer']}  "
               f"x_fixed={pad_x_fixed} y_neg={pad_y_neg} layer={layer_flipped} "
-              f"txt180={txt_180} mirror_toggle={mirror_tog} orient_neg={orient_neg}")
+              f"pad_ang={pad_ang_neg} pad_lay={pad_layers_flipped} "
+              f"txt_lay={txt_layers_flipped} txt180={txt_180} "
+              f"mirror_tog={mirror_tog} mirror_held={mirror_held} "
+              f"orient_neg={orient_neg}")
+        # DISCRIMINATION, printed beside the verdict, because a check run on a
+        # fixture that cannot see it is not evidence. Measured: `orient_neg` is
+        # vacuous on 7 of 15 (rot 0 or 180, where -r == r) and `pad_y_neg` on 3
+        # -- tigard LOGO2 (no pads), ulx3s BAT1 (every pad at local x=0) and
+        # glasgow_revC R9 (every pad at local y=0), which is the set's ONLY
+        # 45-degree fixture, so the fixture carrying non-orthogonal rotation
+        # carries nothing at all about the y-mirror.
+        print(f"        [live: y={any(a[2] for a in before['pads'])} "
+              f"x={any(a[1] for a in before['pads'])} "
+              f"rot={round(before['orient'] % 180, 4) != 0.0} "
+              f"padang={any(a[3] % 180 for a in before['pads'])} "
+              f"unsided_texts={len(_unsided)}]")
         out[f"{board}:{ref}"] = dict(pad_x_fixed=pad_x_fixed, pad_y_neg=pad_y_neg,
+                                     pad_angles_negate=pad_ang_neg,
+                                     pad_layers_flipped=pad_layers_flipped,
+                                     text_layers_flipped=txt_layers_flipped,
+                                     mirror_held_on_unsided=mirror_held,
+                                     live_y=any(a[2] for a in before['pads']),
+                                     live_x=any(a[1] for a in before['pads']),
+                                     live_rot=round(before['orient'] % 180, 4) != 0.0,
+                                     unsided_texts=len(_unsided),
                                      layer_flipped=layer_flipped,
                                      text_180_minus_a=txt_180,
                                      mirror_toggles=mirror_tog,

--- a/tests/mutate_714.py
+++ b/tests/mutate_714.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""The #714 mutation battery, shipped so its numbers can be re-derived.
+
+Same contract as `tests/mutate_829.py`, which this copies: a row is KILLED by a
+failure OR an error; an anchor that does not match EXACTLY ONCE is BROKEN, never
+silently skipped; `str.replace(old, new, 1)`, never `sed`; originals restored in
+a `finally`; it REFUSES to start on a dirty engine; `.pyc` caches are dropped
+around every row because several of these are size-preserving one-token edits;
+and the gates must pass UNMUTATED first, because a battery whose gate was
+already failing reports every row as killed.
+
+ONE ADDITION TO THE CONTRACT, forced by this feature. The acceptance gate needs
+pcbnew and lives under `tests/gui_parity/`, and a gate that SELF-SKIPS at exit 0
+would report every row it guards as SURVIVED. So the baseline run asserts that
+`test_714_mirror_pcbnew_parity.py` printed its `coverage:` line -- it exits 2
+rather than skipping when pcbnew is absent, and this checks that it really ran.
+
+WHY BOTH THE VALUE GATES AND THE ROUND TRIP SHIP. They are not redundant, and
+the rows prove it in both directions:
+
+  * `the-negation-goes-through-float` is killed by RT ALONE. Every value test
+    passes -- the numbers are right, only their spelling changed.
+  * `fp_arc-mirrors-without-the-start-end-swap` is killed by PAR ALONE. The
+    round trip survives it (it is still an involution) and so does every
+    geometric check, because mirroring three points without exchanging start
+    and end gives the same curve through the same three points.
+
+Four more survive the round trip for the same structural reason -- a wrong
+transform that is still an involution round-trips perfectly -- and that is why
+"flip and flip back" was never going to be sufficient on its own.
+
+    python3 tests/mutate_714.py
+    python3 tests/mutate_714.py --row the-local-y-mirror-is-omitted
+    python3 tests/mutate_714.py --list
+    python3 tests/mutate_714.py --selftest
+
+NOT named `test_*.py`, so `tests/run_all.py` never collects it: it rewrites
+engine files in place. One writer per tree.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import shutil
+import subprocess
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+
+WRITER = os.path.join(_ROOT, 'py_placer', 'placement', 'writer.py')
+PARSER = os.path.join(_ROOT, 'py_router', 'kicad_parser.py')
+PROV = os.path.join(_ROOT, 'py_placer', 'placement', 'provenance.py')
+TARGETS = {'wr': WRITER, 'pa': PARSER, 'pv': PROV}
+
+VAC = os.path.join(_TESTS, 'test_714_mirror_discriminates.py')
+SELF = os.path.join(_TESTS, 'test_714_side_self_consistency.py')
+RT = os.path.join(_TESTS, 'test_714_flip_roundtrip.py')
+REF = os.path.join(_TESTS, 'test_714_refusals.py')
+IDENT = os.path.join(_TESTS, 'test_714_identity_write_unchanged.py')
+PERT = os.path.join(_TESTS, 'test_714_perturb_layer_flip.py')
+PAR = os.path.join(_TESTS, 'gui_parity', 'test_714_mirror_pcbnew_parity.py')
+
+# The cheap gates, run unmutated first. PAR is checked separately because it
+# re-execs into KiCad's python and costs a couple of minutes.
+BASELINE = (VAC, SELF, RT, REF, IDENT)
+
+ROWS = [
+    # ---------------------------------------------------- the mirror itself
+    # THE reason this battery exists. Measured on the 22 tracked boards, 1198
+    # of 1319 pad-bearing footprints (90.8%) have a pad POSITION multiset
+    # closed under y -> -y, so if this row SURVIVES the fixture set has fallen
+    # into that trap and every geometric assertion in the suite is decoration.
+    ('the-local-y-mirror-is-omitted', 'wr',
+     "                f\"{_negate_coord(m.group(5), ref, m.group(1))})\")\n",
+     "                f\"{m.group(5)})\")\n",
+     (VAC, PAR), 'KILLED'),
+
+    # Killed ONLY by the two x-asymmetric fixtures (glasgow_revC U7,
+    # orangecrab_ext_pll J4). Drop either and this goes green for free.
+    ('the-mirror-is-on-x-instead-of-y', 'wr',
+     "        return (f\"({m.group(1)}{m.group(2)}{m.group(3)}{m.group(4)}\"\n"
+     "                f\"{_negate_coord(m.group(5), ref, m.group(1))})\")\n",
+     "        return (f\"({m.group(1)}{m.group(2)}\"\n"
+     "                f\"{_negate_coord(m.group(3), ref, m.group(1))}\"\n"
+     "                f\"{m.group(4)}{m.group(5)})\")\n",
+     (VAC, PAR), 'KILLED'),
+
+    # Killed by SELF with no pcbnew at all -- the cheapest kill in the set,
+    # and the one that proves the two independent side derivations disagree.
+    ('pad-layers-are-not-toggled', 'wr',
+     "        node = node[:lm.start()] + new_block + node[lend:]\n",
+     "        node = node\n",
+     (SELF, PAR), 'KILLED'),
+
+    # `*.Cu` is KiCad's ALL-copper set and is already its own mirror.
+    # Narrowing it to `B.Cu` silently drops 66 pads on rp2350 U8 alone.
+    ('wildcards-are-toggled-too', 'pa',
+     "    if name.startswith('F.'):\n        return 'B.' + name[2:]\n",
+     "    if name.startswith('*'):\n        return 'B' + name[1:]\n"
+     "    if name.startswith('F.'):\n        return 'B.' + name[2:]\n",
+     (VAC, PAR), 'KILLED'),
+
+    # ------------------------------------------------------------- the texts
+    ('text-angle-negates-instead-of-180-minus', 'wr',
+     "            new = _flip_at_angle(node, ref, lambda a: 180.0 - a)\n",
+     "            new = _flip_at_angle(node, ref, lambda a: -a)\n",
+     (PAR,), 'KILLED'),
+
+    # The B->F direction in one line. Dropping only the token would leave an
+    # empty `(justify)`; never deleting the node leaves a doubled mirror.
+    ('justify-mirror-is-added-never-removed', 'wr',
+     "        if 'mirror' in toks:\n",
+     "        if False:\n",
+     (RT, PAR), 'KILLED'),
+
+    # The bug an adversarial verification actually found. pcbnew adds
+    # `(justify mirror)` only to a text on a SIDED layer; 28 flip-eligible
+    # texts on the corpus sit on a User layer, and none of the first thirteen
+    # parity fixtures carried one.
+    ('the-justify-toggle-is-unconditional', 'wr',
+     "            if sided:\n                new = _flip_justify(new)\n",
+     "            if True:\n                new = _flip_justify(new)\n",
+     (PAR,), 'KILLED'),
+
+    # ---------------------------------------------------------- the graphics
+    # Killed by PAR ALONE. RT survives it -- reversing a sweep twice restores
+    # it -- and so does every geometric check, because the mirrored arc passes
+    # through the same three points either way.
+    ('fp_arc-mirrors-without-the-start-end-swap', 'wr',
+     "    if head == 'fp_arc':\n",
+     "    if False:\n",
+     (PAR,), 'KILLED'),
+
+    # The 3D viewer applies the flip at render time; mirroring the offset
+    # double-applies it. orangecrab J4 carries a large non-zero one.
+    ('the-model-offset-is-mirrored', 'wr',
+     "    'model',\n})\n",
+     "})\n",
+     (PAR,), 'KILLED'),
+
+    # ------------------------------------------------- the shape of the bug
+    # The EXACT silent failure #714 describes: the layer says B, the geometry
+    # is still F, and `legality.footprint_side` reports B for the whole run.
+    ('only-the-footprint-layer-changes', 'wr',
+     "        elif head == 'pad':\n            new = _flip_pad(node, ref, old_rot, new_rot)\n",
+     "        elif head == 'pad':\n            new = node\n",
+     (SELF, VAC, PAR), 'KILLED'),
+
+    # a = R + p, and a flip sends p -> -p, so a' = R_new - (a - R_old). The
+    # translate formula a + delta_rot equals that only when p is 0 or 180.
+    ('pad-angle-uses-the-translate-delta', 'wr',
+     "    node = _flip_at_angle(node, ref, lambda a: new_rot - (a - old_rot))\n",
+     "    node = _flip_at_angle(node, ref, lambda a: a + (new_rot - old_rot))\n",
+     (VAC, PAR), 'KILLED'),
+
+    # ---------------------------------------------------------- the refusals
+    ('an-unknown-node-passes-through', 'wr',
+     "        if head not in _FLIP_HANDLED:\n            raise SideFlipUnsupported(\n",
+     "        if head not in _FLIP_HANDLED:\n            continue\n        if False:\n            raise SideFlipUnsupported(\n",
+     (REF,), 'KILLED'),
+
+    # EXPECTED TO SURVIVE, and correctly -- measured, not assumed. Disabling
+    # the named table does NOT let a `(zone ...)` through: the head is not in
+    # the whitelist either, so the generic arm refuses it AND names it, which
+    # is what REF checks. Two independent guards cover the same construct.
+    # Kept with its real expectation rather than deleted: a row that documents
+    # overlapping defences is worth more than a missing one.
+    ('the-zone-refusal-is-dropped', 'wr',
+     "        if head in _FLIP_NAMED_REFUSALS:\n",
+     "        if False:\n",
+     (REF,), 'SURVIVED'),
+
+    ('the-pad-construct-refusals-are-dropped', 'wr',
+     "        if head in _PAD_REFUSALS:\n",
+     "        if False:\n",
+     (REF,), 'KILLED'),
+
+    # -------------------------------------------------- format and the ledger
+    # Killed by RT ALONE: every value test passes, because the numbers are
+    # right and only their SPELLING changed (`0.500` -> `0.5`). The exact
+    # mirror image of the fp_arc row above, and the reason both gates ship.
+    ('the-negation-goes-through-float', 'wr',
+     "    if float(tok) == 0.0:\n        return tok                      # '0' and '-0.000' both stay put\n"
+     "    return tok[1:] if tok.startswith('-') else '-' + tok\n",
+     "    return _fmt_mm(-float(tok))\n",
+     (RT,), 'KILLED'),
+
+    # The #829 outline gate must count a side-only change as a change, or a
+    # footprint that draws the board outline can be mirrored silently.
+    ('the-pose-eps-gate-ignores-side', 'wr',
+     "                     or side_change)\n",
+     "                     )\n",
+     (REF,), 'SURVIVED'),
+
+    # Proves the IDENT baseline is load-bearing rather than decorative: a
+    # baseline committed in its own PR is self-certifying, so something has to
+    # be able to redden it.
+    ('the-coordinate-format-loses-precision', 'wr',
+     "            new_at = f\"(at {new_x:.6f} {new_y:.6f} {new_rot:.6g})\"\n",
+     "            new_at = f\"(at {new_x:.4g} {new_y:.4g} {new_rot:.6g})\"\n",
+     (IDENT,), 'KILLED'),
+
+    ('provenance-does-not-record-the-side', 'pv',
+     "            elif _side_changed(fp, p):\n",
+     "            elif False:\n",
+     (PERT,), 'KILLED'),
+
+    ('provenance-drops-the-sides-written-key', 'pv',
+     "           'sides_written': _sides,\n",
+     "",
+     (PERT,), 'KILLED'),
+]
+
+
+def _git_clean(paths):
+    r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths), cwd=_ROOT)
+    return r.returncode == 0
+
+
+def _drop_pyc():
+    """Remove cached bytecode under the trees we mutate.
+
+    CPython validates a `.pyc` on the source's mtime with ONE-SECOND
+    granularity and its size. Several rows here are size-preserving one-token
+    edits (`if sided:` -> `if True:`, `elif _side_changed(...)` -> `elif
+    False:`), so two rows applied inside the same second would otherwise leave
+    the second import reading the FIRST mutant -- reported as a survivor for a
+    row that was never really applied.
+    """
+    for base in (os.path.join(_ROOT, 'py_placer'),
+                 os.path.join(_ROOT, 'py_router')):
+        for dirpath, dirnames, _files in os.walk(base):
+            if os.path.basename(dirpath) == '__pycache__':
+                shutil.rmtree(dirpath, ignore_errors=True)
+                dirnames[:] = []
+
+
+def _run(tests):
+    env = dict(os.environ, PYTHONDONTWRITEBYTECODE='1')
+    for t in tests:
+        r = subprocess.run([sys.executable, '-B', '-X', 'utf8', t],
+                           cwd=_ROOT, capture_output=True, text=True,
+                           encoding='utf-8', errors='replace', env=env)
+        if r.returncode != 0:
+            return True, f"{os.path.basename(t)} exit {r.returncode}"
+        if t == PAR and 'coverage:' not in r.stdout:
+            # A killer gate that did not run reports every row as SURVIVED.
+            return True, "PARITY GATE DID NOT RUN (no coverage line)"
+    return False, "all named tests passed"
+
+
+def _selftest():
+    """Prove the .pyc defence instead of asserting it.
+
+    Applies a size-preserving mutation twice within one second and requires
+    the SECOND probe to observe the SECOND mutant. The probe prints a value
+    that differs per mutant -- one that printed only "it ran" would report OK
+    against a stale cache.
+    """
+    if not _git_clean([WRITER]):
+        print("REFUSED: writer.py is dirty", file=sys.stderr)
+        return 2
+    src = io.open(WRITER, encoding='utf-8').read()
+    anchor = "_POSE_EPS = 1e-6\n"
+    if src.count(anchor) != 1:
+        print(f"BROKEN selftest: anchor matched {src.count(anchor)} times",
+              file=sys.stderr)
+        return 2
+    probe = [sys.executable, '-B', '-X', 'utf8', '-c',
+             "import sys; sys.path[:0]=['py_router','py_placer'];"
+             "import placement.writer as w; print(repr(w._POSE_EPS))"]
+    env = dict(os.environ, PYTHONDONTWRITEBYTECODE='1')
+    seen = []
+    try:
+        for repl in ("_POSE_EPS = 2e-6\n", "_POSE_EPS = 3e-6\n"):
+            _drop_pyc()
+            io.open(WRITER, 'w', encoding='utf-8', newline='').write(
+                src.replace(anchor, repl, 1))
+            r = subprocess.run(probe, cwd=_ROOT, capture_output=True,
+                               text=True, encoding='utf-8', env=env)
+            seen.append(r.stdout.strip())
+    finally:
+        _drop_pyc()
+        io.open(WRITER, 'w', encoding='utf-8', newline='').write(src)
+    ok = len(seen) == 2 and all(seen) and seen[0] != seen[1]
+    print(f"  selftest: two same-second size-preserving mutations, probe read "
+          f"{seen} -- "
+          + ('OK: the second import saw the SECOND mutant' if ok else
+             'the probe cannot tell the mutants apart, or the second read a '
+             'STALE .pyc'))
+    return 0 if ok else 1
+
+
+def _verify_anchors():
+    originals = {k: io.open(p, encoding='utf-8').read()
+                 for k, p in TARGETS.items()}
+    bad = []
+    for name, tgt, old, _new, _t, _e in ROWS:
+        n = originals[tgt].count(old)
+        if n != 1:
+            bad.append(f"{name}: matched {n} times in {tgt}")
+    for b in bad:
+        print("  BROKEN ANCHOR " + b)
+    print(f"  {len(ROWS) - len(bad)}/{len(ROWS)} anchors match exactly once")
+    return 1 if bad else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--row', action='append', default=None)
+    ap.add_argument('--list', action='store_true')
+    ap.add_argument('--selftest', action='store_true')
+    ap.add_argument('--verify-anchors', action='store_true')
+    ap.add_argument('--no-parity', action='store_true',
+                    help="skip rows whose only gate is the pcbnew parity test "
+                         "(they will report BROKEN-BY-OMISSION, never a pass)")
+    a = ap.parse_args()
+
+    if a.list:
+        for name, tgt, _o, _n, tests, exp in ROWS:
+            print(f"  {exp:9} {name}  [{tgt}] "
+                  f"-> {', '.join(os.path.basename(t) for t in tests)}")
+        return 0
+    if a.selftest:
+        return _selftest()
+    if a.verify_anchors:
+        return _verify_anchors()
+
+    rows = ROWS
+    if a.row:
+        unknown = [n for n in a.row if n not in {r[0] for r in ROWS}]
+        if unknown:
+            print(f"no such row: {', '.join(unknown)}; try --list",
+                  file=sys.stderr)
+            return 2
+        rows = [r for r in ROWS if r[0] in set(a.row)]
+    if a.no_parity:
+        rows = [r for r in rows if tuple(r[4]) != (PAR,)]
+
+    if not _git_clean(TARGETS.values()):
+        print("REFUSED: the target files are dirty. Restoring would write the "
+              "COMMITTED text back over uncommitted work.", file=sys.stderr)
+        return 2
+
+    # The battery is only evidence if the gates pass UNMUTATED first.
+    _drop_pyc()
+    gates = list(BASELINE)
+    if any(PAR in r[4] for r in rows):
+        gates.append(PAR)
+    baseline_killed, why = _run(tuple(gates))
+    if baseline_killed:
+        print(f"BROKEN: the gates do not pass on the UNMUTATED tree ({why}). "
+              f"Every row would report KILLED and this run would exit 0.",
+              file=sys.stderr)
+        return 2
+    print(f"  baseline: {len(gates)} gate(s) pass unmutated")
+
+    originals = {k: io.open(p, encoding='utf-8').read()
+                 for k, p in TARGETS.items()}
+    verdicts = []
+    try:
+        for name, tgt, old, new, tests, expect in rows:
+            src = originals[tgt]
+            n = src.count(old)
+            if n != 1:
+                verdicts.append((name, 'BROKEN', f"anchor matched {n} times"))
+                print(f"  BROKEN   {name} -- anchor matched {n} times")
+                continue
+            _drop_pyc()
+            io.open(TARGETS[tgt], 'w', encoding='utf-8', newline='').write(
+                src.replace(old, new, 1))
+            killed, why = _run(tests)
+            io.open(TARGETS[tgt], 'w', encoding='utf-8', newline='').write(src)
+            _drop_pyc()
+            got = 'KILLED' if killed else 'SURVIVED'
+            mark = 'ok' if got == expect else 'WRONG'
+            verdicts.append((name, got, why))
+            print(f"  {got:9}{'' if mark == 'ok' else ' WRONG'} "
+                  f"{name} -- {why}")
+    finally:
+        for k, p in TARGETS.items():
+            io.open(p, 'w', encoding='utf-8', newline='').write(originals[k])
+        _drop_pyc()
+
+    killed = sum(1 for _n, g, _w in verdicts if g == 'KILLED')
+    survived = sum(1 for _n, g, _w in verdicts if g == 'SURVIVED')
+    broken = [n for n, g, _w in verdicts if g == 'BROKEN']
+    wrong = [r[0] for r, (_n, g, _w) in zip(rows, verdicts)
+             if g != r[5] and g != 'BROKEN']
+    print(f"\n{len(verdicts)} row(s): {killed} killed, {survived} survived, "
+          f"{len(broken)} broken, {len(wrong)} disagreeing with expectation")
+    if wrong:
+        print("  WRONG: " + ', '.join(wrong))
+    if broken:
+        print("  BROKEN: " + ', '.join(broken))
+    return 1 if (wrong or broken) else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutate_714.py
+++ b/tests/mutate_714.py
@@ -164,10 +164,18 @@ ROWS = [
 
     # A block with no top-level `(layer ...)` had all its geometry mirrored and
     # no layer written -- #714's own silent failure, in the degenerate case.
+    #
+    # EXPECTED TO SURVIVE, and the reason is a design fact worth recording:
+    # there are TWO guards. The early regex check is the one that gives a good
+    # message; the `saw_layer` backstop after the walk catches the same case
+    # if the walk and the regex ever disagree. Disabling either leaves the
+    # other, so no single row can kill this -- which is what "belt and braces"
+    # means, and is why the row is kept with its real expectation rather than
+    # deleted for looking like a failure.
     ('a-block-with-no-layer-is-flipped-anyway', 'wr',
      "    if not re.search(r'\\(layer\\s+\"[^\"]+\"\\)', fp_text):\n",
      "    if False:\n",
-     (REF,), 'KILLED'),
+     (REF,), 'SURVIVED'),
 
     # An `(at ...)` the mirror cannot parse was SKIPPED, leaving one node
     # unmirrored inside a footprint whose every other node moved. The
@@ -225,10 +233,18 @@ ROWS = [
      "        if False:\n",
      (REF,), 'SURVIVED'),
 
+    # EXPECTED TO SURVIVE since the pad dispatch became a WHITELIST. It used to
+    # kill, and the change that made it survive is the change that made the pad
+    # side safe: `primitives`, `chamfer` and `rect_delta` are not in
+    # `_PAD_HANDLED` either, so dropping the NAMED table leaves them refused by
+    # the generic arm. The named table now exists to give a better MESSAGE --
+    # which construct, and why nothing here can validate a rule for it -- not to
+    # be the only guard. `the-pad-dispatch-is-a-blacklist-again` above is the
+    # row that proves the whitelist is load-bearing.
     ('the-pad-construct-refusals-are-dropped', 'wr',
      "        if head in _PAD_REFUSALS:\n",
      "        if False:\n",
-     (REF,), 'KILLED'),
+     (REF,), 'SURVIVED'),
 
     # -------------------------------------------------- format and the ledger
     # Killed by RT ALONE: every value test passes, because the numbers are

--- a/tests/mutate_714.py
+++ b/tests/mutate_714.py
@@ -103,9 +103,16 @@ ROWS = [
      (VAC, PAR), 'KILLED'),
 
     # ------------------------------------------------------------- the texts
-    ('text-angle-negates-instead-of-180-minus', 'wr',
-     "            new = _flip_at_angle(node, ref, lambda a: 180.0 - a)\n",
-     "            new = _flip_at_angle(node, ref, lambda a: -a)\n",
+    # RE-ANCHORED: the text-angle rule gained its rotation term (see
+    # `the-text-angle-ignores-the-rotation-delta` below), which staled the old
+    # anchor. The mutation is restated rather than transliterated -- writing
+    # `new_rot - 180.0 - (a - old_rot)` would have differed by exactly 360 and
+    # been a NO-OP that survived for the wrong reason. This applies the PAD
+    # rule to a text instead: the same angle without the 180 reflection, which
+    # is what a reader who saw `_flip_pad` first would plausibly write.
+    ('text-uses-the-pad-rule-with-no-180-reflection', 'wr',
+     "                                 lambda a: new_rot + 180.0 - (a - old_rot))\n",
+     "                                 lambda a: new_rot - (a - old_rot))\n",
      (PAR,), 'KILLED'),
 
     # The B->F direction in one line. Dropping only the token would leave an
@@ -119,10 +126,56 @@ ROWS = [
     # `(justify mirror)` only to a text on a SIDED layer; 28 flip-eligible
     # texts on the corpus sit on a User layer, and none of the first thirteen
     # parity fixtures carried one.
+    # RE-ANCHORED: `_flip_justify` gained a `ref` argument so its own refusal
+    # can name the footprint. Same mutation.
     ('the-justify-toggle-is-unconditional', 'wr',
-     "            if sided:\n                new = _flip_justify(new)\n",
-     "            if True:\n                new = _flip_justify(new)\n",
+     "            if sided:\n                new = _flip_justify(new, ref)\n",
+     "            if True:\n                new = _flip_justify(new, ref)\n",
      (PAR,), 'KILLED'),
+
+    # ---------------------------- what an adversarial branch review found
+    # THE SHIPPING BUG. `180 - a` is the general composition ONLY when
+    # new_rot == -old_rot, i.e. only for pcbnew's bare flip -- which is the
+    # only thing the parity gate used to ask for. Every real consumer asks for
+    # something else: `perturb`'s layer_flip HOLDS the pose, so its delta is
+    # 2R, and 9 of tigard's 33 flipped parts shipped a reference designator
+    # rotated 180 degrees from where KiCad puts it, relative to their own pads.
+    # Killed only by the COMPOSED passes added to PAR for exactly this.
+    ('the-text-angle-ignores-the-rotation-delta', 'wr',
+     "                                 lambda a: new_rot + 180.0 - (a - old_rot))\n",
+     "                                 lambda a: 180.0 - a)\n",
+     (PAR,), 'KILLED'),
+
+    # `\\S` matches `)`, so on the compact `(pts (xy -1 1))` spelling the last
+    # group backtracks to `1)` and the match runs to the `pts` closer. Fails
+    # CLOSED, but it makes every KiCad 6/7-formatted fp_poly unflippable.
+    ('the-coordinate-group-swallows-a-closing-paren', 'wr',
+     "                     + r')(\\s+)([^\\s()]+)(\\s+)([^\\s()]+)\\)')\n",
+     "                     + r')(\\s+)(\\S+)(\\s+)(\\S+)\\)')\n",
+     (VAC,), 'KILLED'),
+
+    # The pad dispatch was a BLACKLIST, so the head that refuses at footprint
+    # level was emitted verbatim from inside a pad. KiCad 9/10's `(padstack)`
+    # is the live instance.
+    ('the-pad-dispatch-is-a-blacklist-again', 'wr',
+     "        if head not in _PAD_HANDLED:\n",
+     "        if False:\n",
+     (REF,), 'KILLED'),
+
+    # A block with no top-level `(layer ...)` had all its geometry mirrored and
+    # no layer written -- #714's own silent failure, in the degenerate case.
+    ('a-block-with-no-layer-is-flipped-anyway', 'wr',
+     "    if not re.search(r'\\(layer\\s+\"[^\"]+\"\\)', fp_text):\n",
+     "    if False:\n",
+     (REF,), 'KILLED'),
+
+    # An `(at ...)` the mirror cannot parse was SKIPPED, leaving one node
+    # unmirrored inside a footprint whose every other node moved. The
+    # reachable spelling is KiCad 6/7's `(at 0 -3.98 0 unlocked)`.
+    ('an-unparseable-at-is-skipped-not-refused', 'wr',
+     "        if not re.search(r'\\(at\\b', node):\n            return node",
+     "        if True:\n            return node",
+     (REF,), 'KILLED'),
 
     # ---------------------------------------------------------- the graphics
     # Killed by PAR ALONE. RT survives it -- reversing a sweep twice restores

--- a/tests/test_714_flip_roundtrip.py
+++ b/tests/test_714_flip_roundtrip.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""#714 RT: flip, flip back, and the bytes must come back exactly.
+
+The issue proposes this as an acceptance criterion, and it is the only gate in
+the set that can see a transform which is *self-consistent but not an
+involution* -- a coordinate negated through `float` instead of by toggling the
+sign character, which rewrites `0.500` as `0.5`, or a `(justify mirror)` token
+that is added on the way out and never removed on the way back.
+
+WHAT "BYTE-IDENTICAL" IS MEASURED AGAINST, and it is not the input board.
+`write_placed_output` runs `move_copper_text_to_silkscreen` over the whole file
+and reformats `(at)` to six decimals for every ref it is handed, so a raw
+comparison fails for reasons that have nothing to do with the flip. The baseline
+is the DOSE-0 PASS OF THE SAME WRITER -- exactly the control board
+`perturb.perturb` builds before it perturbs anything, and for exactly this
+reason.
+
+WHY IT IS NOT VACUOUS, in four arms, all required:
+
+  1. `sha256(flipped) != sha256(control)`, ASSERTED FIRST. Without this a writer
+     that ignores the side key entirely round-trips perfectly. It is the single
+     most important line in the file, and it is the arm that is red today.
+  2. The delta between control and flipped is CONFINED to the target block's
+     span. Nothing else in the file may move.
+  3. A FLOOR on how much of the block changed, per surface. A flip that rewrote
+     only the footprint's `(layer ...)` line round-trips flawlessly and is the
+     exact silent failure #714 is about.
+  4. It runs on fixtures that already carry `(justify mirror)`, so the
+     add-but-never-remove asymmetry has somewhere to show up.
+
+DIRECTION IS PINNED. Measured (`tests/measure_714_mirror_convention.py`
+section F): `FLIP_DIRECTION_TOP_BOTTOM` is an involution on 15/15 fixtures;
+`LEFT_RIGHT` is not, on 4 of them, because its text-angle rule collapses to
+`a mod 180` (glasgow_revC SW1 180 -> 0, orangecrab_ext_pll J4 270 -> 90). So
+byte-identity is statable only for TOP_BOTTOM -- which is the argument for the
+writer supporting no other direction.
+
+    python3 tests/test_714_flip_roundtrip.py
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import sys
+import tempfile
+
+TESTS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TESTS)
+sys.path.insert(0, os.path.join(REPO, 'py_router'))
+sys.path.insert(0, os.path.join(REPO, 'py_placer'))
+sys.path.insert(0, TESTS)
+
+RUN_ALL_TIMEOUT = 600
+
+# `orangecrab_ext_pll J4` and `rp2350 J2` already carry `(justify mirror)`, so
+# the removal branch is exercised rather than only the insertion branch.
+FIXTURES = [
+    ('tigard', 'J7'),
+    ('tigard', 'J1'),
+    ('glasgow_revC', 'SW1'),
+    ('orangecrab_ext_pll', 'J4'),
+    ('rp2350_fpga_eensy_prePlane', 'J2'),
+    ('rp2350_fpga_eensy_prePlane', 'SW1'),
+]
+
+# Per-surface floors on how much of the block a real flip must change. A flip
+# that rewrote one line would satisfy an involution perfectly.
+MIN_CHANGED_LINES = 4
+
+
+def _sha(path):
+    with open(path, 'rb') as fh:
+        return hashlib.sha256(fh.read()).hexdigest()
+
+
+def _control(src, dst):
+    """The dose-0 pass of the same writer: every part at the pose it has."""
+    from kicad_parser import parse_kicad_pcb
+    from placement.writer import write_placed_output
+    pcb = parse_kicad_pcb(src)
+    write_placed_output(src, dst, [
+        {'reference': r, 'new_x': round(f.x, 6), 'new_y': round(f.y, 6),
+         'new_rotation': f.rotation} for r, f in sorted(pcb.footprints.items())])
+    return dst
+
+
+def _flip(src, dst, ref, side):
+    from kicad_parser import parse_kicad_pcb
+    from placement.writer import write_placed_output
+    fp = parse_kicad_pcb(src).footprints[ref]
+    write_placed_output(src, dst, [{
+        'reference': ref, 'new_x': round(fp.x, 6), 'new_y': round(fp.y, 6),
+        'new_rotation': fp.rotation, 'new_side': side}])
+    return dst
+
+
+def _block_span(path, ref):
+    from kicad_parser import iter_footprint_blocks
+    text = open(path, encoding='utf-8').read()
+    for s, e, _t, _raw, key in iter_footprint_blocks(text):
+        if key == ref:
+            return text, s, e
+    return text, None, None
+
+
+def main():
+    from kicad_parser import parse_kicad_pcb
+
+    tmp = tempfile.mkdtemp(prefix='krt714rt')
+    problems, checked = [], 0
+    try:
+        for board, ref in FIXTURES:
+            src = os.path.join(REPO, 'kicad_files', board + '.kicad_pcb')
+            if not os.path.isfile(src):
+                problems.append(f"{board}: board not tracked")
+                continue
+            fp0 = parse_kicad_pcb(src).footprints.get(ref)
+            if fp0 is None:
+                problems.append(f"{board}:{ref} missing -- fixture stale")
+                continue
+            here = (fp0.layer or 'F.Cu')[0]
+            other = 'F' if here == 'B' else 'B'
+
+            ctrl = _control(src, os.path.join(tmp, f"{board}_{ref}_ctrl.kicad_pcb"))
+            f1 = _flip(ctrl, os.path.join(tmp, f"{board}_{ref}_f1.kicad_pcb"),
+                       ref, other)
+            f2 = _flip(f1, os.path.join(tmp, f"{board}_{ref}_f2.kicad_pcb"),
+                       ref, here)
+
+            h_ctrl, h_f1, h_f2 = _sha(ctrl), _sha(f1), _sha(f2)
+
+            # --- arm 1: the flip did something. Red today; without it every
+            # other arm passes on a writer that ignores the side key.
+            if h_f1 == h_ctrl:
+                problems.append(
+                    f"{board}:{ref} the flipped board is byte-identical to the "
+                    f"control -- nothing was flipped, so the round trip below "
+                    f"would pass for the wrong reason")
+                continue
+            checked += 1
+
+            # --- arm 2: the delta is confined to this block
+            t_ctrl, cs, ce = _block_span(ctrl, ref)
+            t_f1, fs, fe = _block_span(f1, ref)
+            if cs is None or fs is None:
+                problems.append(f"{board}:{ref} block not locatable in the output")
+            else:
+                if t_ctrl[:cs] != t_f1[:fs] or t_ctrl[ce:] != t_f1[fe:]:
+                    problems.append(
+                        f"{board}:{ref} the flip changed bytes OUTSIDE its own "
+                        f"footprint block")
+                # --- arm 3: enough of the block actually changed
+                a = t_ctrl[cs:ce].splitlines()
+                b = t_f1[fs:fe].splitlines()
+                changed = sum(1 for x, y in zip(a, b) if x != y) + abs(len(a) - len(b))
+                if changed < MIN_CHANGED_LINES:
+                    problems.append(
+                        f"{board}:{ref} only {changed} line(s) of the block "
+                        f"changed -- a flip that rewrites one line round-trips "
+                        f"perfectly and is the silent failure this gate exists "
+                        f"for")
+
+            # --- arm 4: and back again, exactly
+            if h_f2 != h_ctrl:
+                problems.append(
+                    f"{board}:{ref} flip-and-flip-back is NOT byte-identical\n"
+                    f"      control {h_ctrl}\n      round   {h_f2}")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    if checked == 0 and not problems:
+        problems.append("no fixture round-tripped -- nothing was graded")
+
+    if problems:
+        print(f"FAIL: {len(problems)} problem(s)")
+        for p in problems[:25]:
+            print("  " + p)
+        return 1
+    print(f"PASS: {checked} fixtures flip and flip back byte-identically")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_714_flip_roundtrip.py
+++ b/tests/test_714_flip_roundtrip.py
@@ -53,14 +53,18 @@ sys.path.insert(0, TESTS)
 
 RUN_ALL_TIMEOUT = 600
 
-# `orangecrab_ext_pll J4` and `rp2350 J2` already carry `(justify mirror)`, so
-# the removal branch is exercised rather than only the insertion branch.
+# `orangecrab_ext_pll J4` and `ulx3s BAT1` are already on B.Cu and already
+# carry `(justify mirror)`, so the REMOVAL branch is exercised rather than
+# only the insertion branch. Deliberately NOT `rp2350 J2`, which carries the
+# corpus's one footprint-internal `(zone ...)` and is therefore a REFUSAL
+# witness (tests/test_714_refusals.py), not a flip fixture -- a fixture the
+# transform refuses cannot round-trip, and the two lists must not overlap.
 FIXTURES = [
     ('tigard', 'J7'),
     ('tigard', 'J1'),
     ('glasgow_revC', 'SW1'),
     ('orangecrab_ext_pll', 'J4'),
-    ('rp2350_fpga_eensy_prePlane', 'J2'),
+    ('ulx3s', 'BAT1'),
     ('rp2350_fpga_eensy_prePlane', 'SW1'),
 ]
 

--- a/tests/test_714_flip_roundtrip.py
+++ b/tests/test_714_flip_roundtrip.py
@@ -170,6 +170,69 @@ def main():
                 problems.append(
                     f"{board}:{ref} flip-and-flip-back is NOT byte-identical\n"
                     f"      control {h_ctrl}\n      round   {h_f2}")
+            # --- arm 5, on the FIRST fixture only: a coordinate that is not
+            # already in `_fmt_mm`'s minimal form.
+            #
+            # This exists because the mutation battery said it had to. The row
+            # `the-negation-goes-through-float` replaces the sign toggle with
+            # `_fmt_mm(-float(tok))` and SURVIVED every gate here -- and the
+            # reason is a fact about the corpus, not about the code: measured,
+            # all 148417 coordinate literals on the 22 tracked boards are
+            # ALREADY in minimal form and none carries more than six decimals,
+            # so on this input the float round trip happens to be an
+            # involution too.
+            #
+            # That makes the sign toggle's advantage real but undemonstrated:
+            # it is exact BY CONSTRUCTION over the declared grammar, whereas
+            # the float path is exact only because of a property of these
+            # particular files that another tool's board can break. So the
+            # discriminating input is synthesised rather than found.
+            if checked == 1:
+                nm = os.path.join(tmp, 'nonminimal.kicad_pcb')
+                # newline='' on BOTH sides: without it the read translates
+                # CRLF to LF and the rewrite emits LF, so the round trip
+                # compares two different line endings and fails for a reason
+                # that has nothing to do with the mirror. (It did.)
+                with open(ctrl, encoding='utf-8', newline='') as fh:
+                    text = fh.read()
+                # Scoped to THIS block. `(at -1.5 -2)` is an ordinary pad
+                # coordinate and occurs on other footprints too; a whole-file
+                # replace can land in a block the flip never touches, and the
+                # arm then round-trips trivially.
+                #
+                # The span is computed on THIS string, not via `_block_span`,
+                # which does its own newline-translating read: on Windows a
+                # `newline=''` read keeps CRLF and a default read collapses it,
+                # so the two disagree by one byte per line and the window comes
+                # out shifted. (It did, and the arm reported a lost anchor.)
+                from kicad_parser import iter_footprint_blocks
+                bs = be = None
+                for _s, _e, _t, _raw, _k in iter_footprint_blocks(text):
+                    if _k == ref:
+                        bs, be = _s, _e
+                        break
+                marker = '(at -1.5 -2)'
+                if bs is None or marker not in text[bs:be]:
+                    problems.append(
+                        f"the non-minimal-literal arm lost its anchor "
+                        f"{marker!r} inside {ref} -- re-anchor it rather than "
+                        f"dropping it, or the float path stops being "
+                        f"distinguishable")
+                else:
+                    block = text[bs:be].replace(marker, '(at -1.5 -2.500000)', 1)
+                    with open(nm, 'w', encoding='utf-8', newline='') as fh:
+                        fh.write(text[:bs] + block + text[be:])
+                    g1 = _flip(nm, os.path.join(tmp, 'nm_f1.kicad_pcb'),
+                               'J7', 'B')
+                    g2 = _flip(g1, os.path.join(tmp, 'nm_f2.kicad_pcb'),
+                               'J7', 'F')
+                    if _sha(g2) != _sha(nm):
+                        problems.append(
+                            "a coordinate written non-minimally "
+                            "(`-2.500000`) does not survive flip-and-flip-back "
+                            "-- the transform is reformatting numbers instead "
+                            "of toggling their sign, so it is an involution "
+                            "only for input that was already minimal")
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 

--- a/tests/test_714_identity_write_unchanged.py
+++ b/tests/test_714_identity_write_unchanged.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""#714 IDENT: a write with no side key is BYTE-IDENTICAL to the shipped writer.
+
+The #714 flip is opt-in: a placement dict carrying no `new_side` key must take
+the path that shipped, byte for byte, on every board. About twenty producers
+build those dicts (`quench`, `seeder`, `portfolio`, `relocate`, `perturb`,
+`fanout_clearance`, `place_reconstruct`, `place_seed`, `converge`,
+`net_rescue`), and none of them will be changed, so this gate is what stands
+between them and a regression.
+
+WHY A SHA AND NOT A FIELD COMPARISON. The failure this guards against is the
+writer emitting *slightly* different text -- a `(layer ...)` line rewritten
+unconditionally, a number reformatted, a node reordered. Every one of those
+survives a parse-and-compare-fields check and none survives a hash.
+
+WHY THE BASELINE IS TRUSTWORTHY. It is recorded in the same PR as the change it
+guards, which makes it self-certifying and therefore worth nothing on its own.
+What makes it load-bearing is `tests/mutate_714.py`'s row that perturbs the
+`:.6f` coordinate format in `writer.py` and REQUIRES this gate to go red. A
+baseline no mutation can redden is decoration.
+
+The board set is `run_utils.corpus_boards()` -- the boards git TRACKS. Not a
+glob: `kicad_files/` accumulates generated outputs, so the same glob returns 22
+entries on a clean clone and 33 on a machine that has run the suite, and a
+baseline pinned to the second one fails in CI as machine-dependent flake.
+
+    python3 tests/test_714_identity_write_unchanged.py
+    python3 tests/test_714_identity_write_unchanged.py --write-baseline
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+TESTS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TESTS)
+sys.path.insert(0, os.path.join(REPO, 'py_router'))
+sys.path.insert(0, os.path.join(REPO, 'py_placer'))
+sys.path.insert(0, TESTS)
+
+RUN_ALL_TIMEOUT = 900
+BASELINE = os.path.join(TESTS, 'data', '714_identity_sha256.json')
+
+# The command that produced the baseline, recorded IN the baseline so a reader
+# never has to guess how to regenerate it.
+BASELINE_CMD = 'python3 tests/test_714_identity_write_unchanged.py --write-baseline'
+
+
+def _all_at_current(pcb):
+    """Every parsed footprint at the pose it already has.
+
+    The `perturb._all_at_current` shape (perturb.py), which is the call that
+    exercises the writer's whole per-block loop for every block on the board --
+    the widest identity write there is. Poses are unchanged; only the `(at)`
+    formatting is, which is exactly what the hash is pinning.
+    """
+    return [{'reference': ref, 'new_x': round(fp.x, 6),
+             'new_y': round(fp.y, 6), 'new_rotation': fp.rotation}
+            for ref, fp in sorted(pcb.footprints.items())]
+
+
+def _sha(path):
+    h = hashlib.sha256()
+    with open(path, 'rb') as fh:
+        for chunk in iter(lambda: fh.read(1 << 16), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def measure():
+    from kicad_parser import parse_kicad_pcb
+    from placement.writer import write_placed_output
+    from run_utils import corpus_boards
+
+    boards = corpus_boards()
+    if not boards:
+        # A board set this test cannot identify is not a set to grade against.
+        print("SKIP: git could not name the tracked corpus")
+        sys.exit(77)
+
+    out = {}
+    tmp = tempfile.mkdtemp(prefix='krt714ident')
+    try:
+        for src in boards:
+            name = os.path.basename(src)
+            pcb = parse_kicad_pcb(src)
+            dst = os.path.join(tmp, name)
+            write_placed_output(src, dst, _all_at_current(pcb))
+            out[name] = {'sha256': _sha(dst), 'footprints': len(pcb.footprints)}
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+    return out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--write-baseline', action='store_true')
+    args = ap.parse_args(argv)
+
+    got = measure()
+    if args.write_baseline:
+        os.makedirs(os.path.dirname(BASELINE), exist_ok=True)
+        with open(BASELINE, 'w', encoding='utf-8') as fh:
+            json.dump({'_command': BASELINE_CMD, 'boards': got}, fh,
+                      indent=1, sort_keys=True)
+        print(f"wrote {BASELINE}: {len(got)} boards")
+        return 0
+
+    if not os.path.exists(BASELINE):
+        # FAIL, never pass. A missing baseline is the state in which this gate
+        # can no longer tell a regression from a fresh checkout.
+        print(f"FAIL: no baseline at {BASELINE}. Regenerate with:\n"
+              f"    {BASELINE_CMD}")
+        return 1
+
+    with open(BASELINE, encoding='utf-8') as fh:
+        want = json.load(fh)['boards']
+
+    problems = []
+    if set(want) != set(got):
+        for k in sorted(set(want) - set(got)):
+            problems.append(f"board in baseline but not measured: {k}")
+        for k in sorted(set(got) - set(want)):
+            problems.append(f"board measured but not in baseline: {k}")
+    for k in sorted(set(want) & set(got)):
+        if want[k]['sha256'] != got[k]['sha256']:
+            problems.append(f"{k}: identity write CHANGED\n"
+                            f"    baseline {want[k]['sha256']}\n"
+                            f"    now      {got[k]['sha256']}")
+        if want[k]['footprints'] != got[k]['footprints']:
+            problems.append(f"{k}: footprint count {want[k]['footprints']} -> "
+                            f"{got[k]['footprints']}")
+
+    # Non-vacuity: a gate that graded nothing must not pass. 22 tracked boards
+    # today; the floor is deliberately below that so adding a board is not a
+    # failure, and far above zero so an empty run is.
+    if len(got) < 15:
+        problems.append(f"only {len(got)} boards measured -- this gate cannot "
+                        f"pass on a corpus it did not see")
+    total_fps = sum(v['footprints'] for v in got.values())
+    if total_fps < 1000:
+        problems.append(f"only {total_fps} footprints written -- too few for "
+                        f"the identity claim to mean anything")
+
+    if problems:
+        print(f"FAIL: {len(problems)} problem(s)")
+        for p in problems[:25]:
+            print("  " + p)
+        return 1
+    print(f"PASS: identity write byte-identical on {len(got)} tracked boards, "
+          f"{total_fps} footprints")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_714_mirror_discriminates.py
+++ b/tests/test_714_mirror_discriminates.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""#714 VAC: the mirror is asserted with numbers, on fixtures PROVEN to discriminate.
+
+Measured on the 22 tracked boards (`tests/measure_714_mirror_convention.py`
+section C): **1198 of 1319 pad-bearing footprints -- 90.8% -- have a pad
+POSITION multiset that is closed under `y -> -y`.** For those parts the whole
+local-y mirror is a no-op, so a fixture drawn from ordinary 0402s, 0603s and
+symmetric QFNs passes every geometric assertion **with the mirror deleted
+entirely**. That is the trap this file exists to not fall into.
+
+So the fixtures are not asserted through; they are FIRST PROVEN to discriminate,
+per surface, and the run REFUSES if the set has gone vacuous:
+
+    D1  the y-mirror is observable        mirror_y(pads) != pads
+    D2  a wrong-AXIS mutant is observable mirror_y(pads) != mirror_x(pads)
+    D4  the flip took at all              the emitted (layer ...) changed
+
+D1 is evaluated on the full pad TUPLE `(number, type, shape, x, y, angle)`, not
+on positions. That is the predicate that answers "is the mirror observable",
+and it is a different number: 532/1319 = 40.3% symmetric, against 90.8% by
+position. A mirror does not renumber pads, so a part with pad 1 at (0,-2) and
+pad 2 at (0,+2) has a symmetric position set and a plainly observable flip.
+Grading discrimination on positions would write off `tigard U3` and every
+non-orthogonal fixture as useless when they are not.
+
+D2 matters because only two fixtures are x-asymmetric. Drop `glasgow_revC U7`
+or `orangecrab_ext_pll J4` and the "mirror the wrong axis" mutation goes green
+for free.
+
+THE ROTATION CONTRACT, asserted here because it is the one place this writer
+and pcbnew deliberately differ: `new_rotation` stays the FINAL footprint
+orientation and the writer does not secretly negate it. With `a = R + p` (p the
+pad-local angle) and `p -> -p` under a flip, a pad's stored angle must become
+`a' = R_new - (a - R_old)`. Holding rotation constant that is `2R - a`; it is
+NOT `a + delta_rot`, which is what `_rotate_pad_angles` computes and which
+agrees only when p is 0 or 180.
+
+    python3 tests/test_714_mirror_discriminates.py
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+
+TESTS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TESTS)
+sys.path.insert(0, os.path.join(REPO, 'py_router'))
+sys.path.insert(0, os.path.join(REPO, 'py_placer'))
+sys.path.insert(0, TESTS)
+
+RUN_ALL_TIMEOUT = 300
+
+FIXTURES = [
+    ('tigard', 'J7'),
+    ('tigard', 'J1'),
+    ('tigard', 'U3'),
+    ('glasgow_revC', 'U7'),
+    ('glasgow_revC', 'SW1'),
+    ('orangecrab_ext_pll', 'J4'),
+    ('orangecrab_ext_pll', 'U9'),
+    ('rp2350_fpga_eensy_prePlane', 'U8'),
+]
+
+# Named anchors, measured against pcbnew 10.0.0. Stated as exact values so a
+# mirror that is merely "different" cannot pass: `x` is pinned as hard as `y`,
+# which is what kills a mutant that negates the wrong axis.
+#   (board, ref, pad_number, (x_before, y_before), (x_after, y_after))
+ANCHORS = [
+    ('tigard', 'J7', '1', (-1.5, -2.0), (-1.5, 2.0)),
+    ('tigard', 'J7', '2', (-0.5, -2.0), (-0.5, 2.0)),
+]
+
+
+def _tuple_key(p):
+    return (p.pad_number, p.pad_type, p.shape,
+            round(p.local_x, 6), round(p.local_y, 6),
+            round((getattr(p, 'rotation', 0.0) or 0.0) % 360, 4))
+
+
+def _mirror_key(k, axis):
+    x, y, a = k[3], k[4], k[5]
+    if axis == 'y':
+        y = -y
+    else:
+        x = -x
+    return (k[0], k[1], k[2], round(x, 6), round(y, 6), round((-a) % 360, 4))
+
+
+def _keys(fp):
+    return sorted(_tuple_key(p) for p in (fp.pads or []))
+
+
+def preflight(fixtures, parse):
+    """Prove the fixture set can see what the assertions below claim to test.
+
+    Returns (rows, problems). A fixture set that cannot discriminate is a
+    refusal, not a pass -- 90.8% of real footprints are y-mirror no-ops by
+    position, so "the tests passed" carries almost no information until this
+    has run.
+    """
+    rows, problems = [], []
+    for board, ref in fixtures:
+        src = os.path.join(REPO, 'kicad_files', board + '.kicad_pcb')
+        if not os.path.isfile(src):
+            problems.append(f"{board}: board not tracked")
+            continue
+        fp = parse(src).footprints.get(ref)
+        if fp is None:
+            problems.append(f"{board}:{ref} missing -- fixture stale")
+            continue
+        ks = _keys(fp)
+        my = sorted(_mirror_key(k, 'y') for k in ks)
+        mx = sorted(_mirror_key(k, 'x') for k in ks)
+        rows.append({'board': board, 'ref': ref, 'pads': len(ks),
+                     'rot': fp.rotation, 'side': (fp.layer or 'F')[0],
+                     'D1': ks != my, 'D2': my != mx})
+    if not any(r['D1'] for r in rows):
+        problems.append("NO fixture discriminates the y-mirror (D1). Every "
+                        "assertion below would pass with the mirror deleted.")
+    if not any(r['D2'] for r in rows):
+        problems.append("NO fixture discriminates the mirror AXIS (D2). A "
+                        "mutant that negates x instead of y would pass.")
+    if not any(r['side'] == 'B' for r in rows):
+        problems.append("NO fixture starts on B.Cu. A direction-asymmetric "
+                        "rule would pass.")
+    if not any(abs((r['rot'] or 0) % 180) not in (0.0,) for r in rows):
+        problems.append("NO fixture is at a rotation where the flip composes "
+                        "with a non-trivial angle.")
+    return rows, problems
+
+
+def main():
+    from kicad_parser import parse_kicad_pcb
+    from placement.writer import write_placed_output
+
+    rows, problems = preflight(FIXTURES, parse_kicad_pcb)
+    print("pre-flight -- does this fixture set discriminate?")
+    for r in rows:
+        print(f"   {r['board']:<28} {r['ref']:<5} pads={r['pads']:3d} "
+              f"rot={str(r['rot']):>6} side={r['side']} "
+              f"D1(y-mirror)={r['D1']} D2(axis)={r['D2']}")
+    if problems:
+        print("REFUSING to assert through a fixture set that cannot see the "
+              "thing being asserted:")
+        for p in problems:
+            print("  " + p)
+        return 1
+
+    tmp = tempfile.mkdtemp(prefix='krt714vac')
+    checked = 0
+    try:
+        for board, ref in FIXTURES:
+            src = os.path.join(REPO, 'kicad_files', board + '.kicad_pcb')
+            before = parse_kicad_pcb(src).footprints[ref]
+            want = 'F' if (before.layer or 'F').startswith('B') else 'B'
+            dst = os.path.join(tmp, f"{board}__{ref}.kicad_pcb")
+            write_placed_output(src, dst, [{
+                'reference': ref, 'new_x': round(before.x, 6),
+                'new_y': round(before.y, 6), 'new_rotation': before.rotation,
+                'new_side': want}])
+            after = parse_kicad_pcb(dst).footprints.get(ref)
+            if after is None:
+                problems.append(f"{board}:{ref} vanished from the output")
+                continue
+
+            if (after.layer or 'F')[0] != want:
+                problems.append(f"{board}:{ref} layer {after.layer!r} -- asked "
+                                f"for side {want}; the writer did not flip")
+                continue
+            checked += 1
+
+            # The caller owns rotation: it must land exactly as handed over.
+            if round((after.rotation or 0) % 360, 4) != round(
+                    (before.rotation or 0) % 360, 4):
+                problems.append(f"{board}:{ref} rotation {before.rotation} -> "
+                                f"{after.rotation}; the writer negated a "
+                                f"rotation the caller owns")
+
+            bpads = {p.pad_number: p for p in (before.pads or [])}
+            R = round((before.rotation or 0.0) % 360, 4)
+            for p in (after.pads or []):
+                q = bpads.get(p.pad_number)
+                if q is None:
+                    continue
+                if round(p.local_x, 6) != round(q.local_x, 6):
+                    problems.append(
+                        f"{board}:{ref} pad {p.pad_number} local X moved "
+                        f"{q.local_x} -> {p.local_x}; a flip mirrors Y only")
+                if round(p.local_y, 6) != round(-q.local_y, 6):
+                    problems.append(
+                        f"{board}:{ref} pad {p.pad_number} local Y "
+                        f"{q.local_y} -> {p.local_y}, expected "
+                        f"{round(-q.local_y, 6)}")
+                want_a = round((2 * R - (q.rotation or 0.0)) % 360, 4)
+                got_a = round((p.rotation or 0.0) % 360, 4)
+                if got_a != want_a:
+                    problems.append(
+                        f"{board}:{ref} pad {p.pad_number} angle {q.rotation} "
+                        f"-> {p.rotation}, expected {want_a} "
+                        f"(a' = R_new - (a - R_old); NOT a + delta_rot)")
+                for lay in (p.layers or []):
+                    s = str(lay)
+                    if s.startswith('*'):
+                        continue          # wildcards are not sided
+                    if s.startswith(('F.', 'B.')) and s[0] != want:
+                        problems.append(
+                            f"{board}:{ref} pad {p.pad_number} still on {s} "
+                            f"after a flip to {want}")
+                        break
+                # A wildcard must survive VERBATIM -- `*.Cu` becoming `B*.Cu`
+                # or `B.Cu` is a real corpus hazard (rp2350 U8, 66 pads).
+                for a, b in zip(sorted(str(l) for l in (q.layers or [])),
+                                sorted(str(l) for l in (p.layers or []))):
+                    if a.startswith('*') and a != b:
+                        problems.append(f"{board}:{ref} pad {p.pad_number} "
+                                        f"wildcard {a} rewritten to {b}")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    # The named anchors, checked last so their failure is not buried.
+    for board, ref, num, exp_before, exp_after in ANCHORS:
+        src = os.path.join(REPO, 'kicad_files', board + '.kicad_pcb')
+        fp = parse_kicad_pcb(src).footprints.get(ref)
+        got = next((p for p in (fp.pads or []) if p.pad_number == num), None)
+        if got is None:
+            problems.append(f"anchor {board}:{ref} pad {num} is gone -- "
+                            f"re-anchor rather than delete")
+        elif (round(got.local_x, 6), round(got.local_y, 6)) != exp_before:
+            problems.append(
+                f"anchor {board}:{ref} pad {num} is at "
+                f"({got.local_x}, {got.local_y}), recorded as {exp_before} -- "
+                f"the board moved under the anchor")
+
+    if checked == 0:
+        problems.append("no fixture reached the geometry checks")
+
+    if problems:
+        print(f"\nFAIL: {len(problems)} problem(s)")
+        for p in problems[:25]:
+            print("  " + p)
+        return 1
+    print(f"\nPASS: mirror asserted on {checked} fixtures proven to discriminate")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_714_mirror_discriminates.py
+++ b/tests/test_714_mirror_discriminates.py
@@ -59,7 +59,6 @@ FIXTURES = [
     ('glasgow_revC', 'U7'),
     ('glasgow_revC', 'SW1'),
     ('orangecrab_ext_pll', 'J4'),
-    ('orangecrab_ext_pll', 'U9'),
     ('rp2350_fpga_eensy_prePlane', 'U8'),
 ]
 
@@ -178,44 +177,43 @@ def main():
                                 f"{after.rotation}; the writer negated a "
                                 f"rotation the caller owns")
 
-            bpads = {p.pad_number: p for p in (before.pads or [])}
+            # Pads are compared as a MULTISET of tuples, never keyed by
+            # pad number. A QFN-64-1EP's thermal sub-pads and a USB-C shield
+            # share -- or omit -- their number, so a dict keyed on it silently
+            # collapses 91 pads to a handful and then compares the survivors
+            # against the wrong partners. That is how this gate first reported
+            # "local X moved" on a transform that had not touched X.
             R = round((before.rotation or 0.0) % 360, 4)
-            for p in (after.pads or []):
-                q = bpads.get(p.pad_number)
-                if q is None:
-                    continue
-                if round(p.local_x, 6) != round(q.local_x, 6):
-                    problems.append(
-                        f"{board}:{ref} pad {p.pad_number} local X moved "
-                        f"{q.local_x} -> {p.local_x}; a flip mirrors Y only")
-                if round(p.local_y, 6) != round(-q.local_y, 6):
-                    problems.append(
-                        f"{board}:{ref} pad {p.pad_number} local Y "
-                        f"{q.local_y} -> {p.local_y}, expected "
-                        f"{round(-q.local_y, 6)}")
-                want_a = round((2 * R - (q.rotation or 0.0)) % 360, 4)
-                got_a = round((p.rotation or 0.0) % 360, 4)
-                if got_a != want_a:
-                    problems.append(
-                        f"{board}:{ref} pad {p.pad_number} angle {q.rotation} "
-                        f"-> {p.rotation}, expected {want_a} "
-                        f"(a' = R_new - (a - R_old); NOT a + delta_rot)")
-                for lay in (p.layers or []):
-                    s = str(lay)
-                    if s.startswith('*'):
-                        continue          # wildcards are not sided
-                    if s.startswith(('F.', 'B.')) and s[0] != want:
-                        problems.append(
-                            f"{board}:{ref} pad {p.pad_number} still on {s} "
-                            f"after a flip to {want}")
-                        break
-                # A wildcard must survive VERBATIM -- `*.Cu` becoming `B*.Cu`
-                # or `B.Cu` is a real corpus hazard (rp2350 U8, 66 pads).
-                for a, b in zip(sorted(str(l) for l in (q.layers or [])),
-                                sorted(str(l) for l in (p.layers or []))):
-                    if a.startswith('*') and a != b:
-                        problems.append(f"{board}:{ref} pad {p.pad_number} "
-                                        f"wildcard {a} rewritten to {b}")
+
+            def key(q, mirror):
+                x = round(q.local_x, 6)
+                y = round(q.local_y, 6)
+                a = round((q.rotation or 0.0) % 360, 4)
+                if mirror:
+                    y = round(-y, 6)
+                    a = round((2 * R - a) % 360, 4)
+                lay = tuple(sorted(
+                    str(l) if str(l).startswith('*')
+                    else (('B' + str(l)[1:]) if str(l).startswith('F')
+                          else ('F' + str(l)[1:]) if str(l).startswith('B')
+                          else str(l))
+                    if mirror else str(l)
+                    for l in (q.layers or [])))
+                return (q.pad_number, q.pad_type, q.shape, x, y, a, lay)
+
+            want_pads = sorted(key(q, True) for q in (before.pads or []))
+            got_pads = sorted(key(q, False) for q in (after.pads or []))
+            if want_pads != got_pads:
+                extra = [t for t in got_pads if t not in want_pads]
+                miss = [t for t in want_pads if t not in got_pads]
+                problems.append(
+                    f"{board}:{ref} {len(miss)} of {len(want_pads)} pads do not "
+                    f"match the mirror image "
+                    f"(x unchanged, y negated, angle 2R-a, layers toggled, "
+                    f"wildcards left alone)")
+                for a, b in list(zip(miss, extra))[:4]:
+                    problems.append(f"      expected {a}")
+                    problems.append(f"      got      {b}")
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 

--- a/tests/test_714_mirror_discriminates.py
+++ b/tests/test_714_mirror_discriminates.py
@@ -217,19 +217,99 @@ def main():
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 
-    # The named anchors, checked last so their failure is not buried.
-    for board, ref, num, exp_before, exp_after in ANCHORS:
-        src = os.path.join(REPO, 'kicad_files', board + '.kicad_pcb')
-        fp = parse_kicad_pcb(src).footprints.get(ref)
-        got = next((p for p in (fp.pads or []) if p.pad_number == num), None)
-        if got is None:
-            problems.append(f"anchor {board}:{ref} pad {num} is gone -- "
-                            f"re-anchor rather than delete")
-        elif (round(got.local_x, 6), round(got.local_y, 6)) != exp_before:
-            problems.append(
-                f"anchor {board}:{ref} pad {num} is at "
-                f"({got.local_x}, {got.local_y}), recorded as {exp_before} -- "
-                f"the board moved under the anchor")
+    # The named anchors, checked last so their failure is not buried. BOTH
+    # halves are asserted: an earlier version destructured `exp_after` and
+    # never used it, so the docstring's claim that `x` is pinned as hard as
+    # `y` -- the thing that kills a wrong-axis mutant -- was not implemented
+    # here at all, and the anchors were a board-staleness check wearing a
+    # correctness check's description.
+    tmp2 = tempfile.mkdtemp(prefix='krt714anchor')
+    try:
+        for board, ref, num, exp_before, exp_after in ANCHORS:
+            src = os.path.join(REPO, 'kicad_files', board + '.kicad_pcb')
+            fp = parse_kicad_pcb(src).footprints.get(ref)
+            got = next((p for p in (fp.pads or []) if p.pad_number == num), None)
+            if got is None:
+                problems.append(f"anchor {board}:{ref} pad {num} is gone -- "
+                                f"re-anchor rather than delete")
+                continue
+            if (round(got.local_x, 6), round(got.local_y, 6)) != exp_before:
+                problems.append(
+                    f"anchor {board}:{ref} pad {num} is at "
+                    f"({got.local_x}, {got.local_y}), recorded as "
+                    f"{exp_before} -- the board moved under the anchor")
+                continue
+            want = 'F' if (fp.layer or 'F').startswith('B') else 'B'
+            dst = os.path.join(tmp2, f"{board}__{ref}__{num}.kicad_pcb")
+            write_placed_output(src, dst, [{
+                'reference': ref, 'new_x': round(fp.x, 6),
+                'new_y': round(fp.y, 6), 'new_rotation': fp.rotation,
+                'new_side': want}])
+            after = parse_kicad_pcb(dst).footprints.get(ref)
+            aft = next((p for p in (after.pads or [])
+                        if p.pad_number == num), None)
+            if aft is None:
+                problems.append(f"anchor {board}:{ref} pad {num} vanished "
+                                f"from the flipped output")
+            elif (round(aft.local_x, 6), round(aft.local_y, 6)) != exp_after:
+                problems.append(
+                    f"anchor {board}:{ref} pad {num} flipped to "
+                    f"({aft.local_x}, {aft.local_y}), expected {exp_after}")
+    finally:
+        shutil.rmtree(tmp2, ignore_errors=True)
+
+    # A COMPACTLY serialised graphic must flip, not refuse. `(pts (xy a b))`
+    # written on one line put a `)` immediately after the last coordinate, and
+    # the mirror's `(\S+)\)` matched it -- `\S` includes `)` -- so the group
+    # backtracked to `1)`, the literal failed the coordinate grammar and the
+    # whole footprint refused. It failed CLOSED, but it made every KiCad 6/7
+    # formatted `fp_poly` / `fp_curve` unflippable, and no tracked board
+    # writes that spelling so nothing here could see it.
+    tmp3 = tempfile.mkdtemp(prefix='krt714compact')
+    try:
+        from kicad_parser import iter_footprint_blocks
+        src = os.path.join(REPO, 'kicad_files', 'tigard.kicad_pcb')
+        with open(src, encoding='utf-8', newline='') as fh:
+            text = fh.read()
+        span = next(((s, e) for s, e, _t, _r, k in iter_footprint_blocks(text)
+                     if k == 'J7'), None)
+        if span is None:
+            problems.append("the compact-serialisation arm lost its fixture J7")
+        else:
+            bs, be = span
+            block = text[bs:be].replace(
+                '(attr smd)',
+                '(attr smd)\n\t\t(fp_poly (pts (xy -1 -1) (xy 1 -1) (xy 1 1) '
+                '(xy -1 1)) (stroke (width 0.1) (type solid)) (fill yes) '
+                '(layer "F.SilkS"))', 1)
+            if 'fp_poly' not in block:
+                problems.append("the compact-serialisation arm lost its anchor "
+                                "`(attr smd)` in J7")
+            else:
+                cin = os.path.join(tmp3, 'compact.kicad_pcb')
+                with open(cin, 'w', encoding='utf-8', newline='') as fh:
+                    fh.write(text[:bs] + block + text[be:])
+                cout = os.path.join(tmp3, 'compact_flipped.kicad_pcb')
+                fpc = parse_kicad_pcb(cin).footprints['J7']
+                try:
+                    write_placed_output(cin, cout, [{
+                        'reference': 'J7', 'new_x': round(fpc.x, 6),
+                        'new_y': round(fpc.y, 6), 'new_rotation': fpc.rotation,
+                        'new_side': 'B'}])
+                except Exception as exc:               # noqa: BLE001
+                    problems.append(
+                        f"a compactly written `(pts (xy ...))` made the flip "
+                        f"raise {type(exc).__name__}: {exc}")
+                else:
+                    with open(cout, encoding='utf-8') as fh:
+                        got = fh.read()
+                    want = '(xy -1 1) (xy 1 1) (xy 1 -1) (xy -1 -1)'
+                    if want not in got.replace('\n', ' '):
+                        problems.append(
+                            "a compactly written `(pts (xy ...))` was not "
+                            "mirrored: expected the four points y-negated")
+    finally:
+        shutil.rmtree(tmp3, ignore_errors=True)
 
     if checked == 0:
         problems.append("no fixture reached the geometry checks")

--- a/tests/test_714_perturb_layer_flip.py
+++ b/tests/test_714_perturb_layer_flip.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""#714 consumer: the `layer_flip` damage kind, and what it must NOT disturb.
+
+`placement/perturb.py`'s module docstring listed a layer flip as one of two
+mutations deliberately NOT offered, because the writer could not emit one. It
+can now, so the kind exists -- and this gate holds it to the three properties
+that make it a damage kind rather than a broad rewrite.
+
+THE ONE THAT IS EASY TO GET WRONG is the third. `perturb._all_at_current` hands
+the writer EVERY part, deliberately: it exists so the moved set cannot be read
+off six-decimal `(at)` formatting, which is how run 14's perturbed block leaked
+(24 of 235 blocks, recoverable with no tooling and no truth). If the flip's
+side key reached those pass-through dicts, the kind would flip the whole board;
+if it failed to reach the members, it would flip nothing. Both look plausible in
+a summary. So the flipped set is compared against the member set EXACTLY, not
+counted.
+
+And the CONTROL board -- the dose-0 pass that is this rig's ground truth -- must
+be byte-identical to what it was before this kind existed, because a control
+formatted differently from its subject is itself a comparison anyone could make.
+
+    python3 tests/test_714_perturb_layer_flip.py
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import sys
+import tempfile
+
+TESTS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TESTS)
+sys.path.insert(0, os.path.join(REPO, 'py_router'))
+sys.path.insert(0, os.path.join(REPO, 'py_placer'))
+sys.path.insert(0, TESTS)
+
+RUN_ALL_TIMEOUT = 600
+BOARD = os.path.join(REPO, 'kicad_files', 'tigard.kicad_pcb')
+
+# tigard flips 33 of its 92 blocks through the default unit. Floored, not
+# pinned: a board edit may move the number, but a kind that damages one part
+# or the whole board is not the kind this is.
+MIN_FLIPPED = 5
+
+
+def _sha(path):
+    with open(path, 'rb') as fh:
+        return hashlib.sha256(fh.read()).hexdigest()
+
+
+def main():
+    from kicad_parser import parse_kicad_pcb
+    from placement.legality import PartPads, footprint_side
+    from placement.perturb import KINDS, perturb, _all_at_current
+    from placement.writer import write_placed_output
+
+    problems = []
+    if 'layer_flip' not in KINDS:
+        print("FAIL: perturb.KINDS has no 'layer_flip'")
+        return 1
+    # `wrong_side` is a point reflection through the board centre and carries
+    # published numbers in docs/placement-predictors.md and two committed
+    # baselines. It must still be there, and it must still be a different kind.
+    if 'wrong_side' not in KINDS:
+        problems.append("'wrong_side' was removed or renamed -- its measured "
+                        "numbers are recorded in two committed baselines")
+
+    tmp = tempfile.mkdtemp(prefix='krt714perturb')
+    try:
+        out = os.path.join(tmp, 'flipped.kicad_pcb')
+        ctrl = os.path.join(tmp, '_truth', 'control.kicad_pcb')
+        rec = perturb(BOARD, out, kind='layer_flip', dose_mm=0.0,
+                      control_out=ctrl, write_record=False)
+        if rec.get('status') != 'ok':
+            print(f"FAIL: perturb returned {rec.get('status')}: "
+                  f"{rec.get('reason')}")
+            return 1
+
+        members = set(rec['block']['members'])
+        a = parse_kicad_pcb(BOARD).footprints
+        b = parse_kicad_pcb(out).footprints
+
+        flipped = {r for r in b
+                   if r in a and footprint_side(a[r]) != footprint_side(b[r])}
+
+        # EXACT, not a count. A side key leaking into `_all_at_current`'s
+        # pass-through dicts flips the whole board; one that never reaches the
+        # members flips nothing. Both read as plausible in a summary.
+        if flipped != {r for r in members if r in b}:
+            problems.append(
+                f"the flipped set is not the member set: "
+                f"{len(flipped)} flipped, {len(members)} members, "
+                f"{len(flipped - members)} flipped that were not asked for, "
+                f"{len(members - flipped)} asked for that did not flip")
+        if len(flipped) < MIN_FLIPPED:
+            problems.append(f"only {len(flipped)} part(s) flipped -- a kind "
+                            f"that damages one part is not a damage class")
+        if len(flipped) == len(b):
+            problems.append("EVERY block flipped -- the side key reached the "
+                            "pass-through dicts in _all_at_current")
+
+        # The damaged board must not contradict itself: this is the whole
+        # point of the capability, checked on the rig that consumes it.
+        for ref in sorted(flipped)[:40]:
+            pp = PartPads(b[ref], clearance=0.2)
+            if pp.pad_sides != {'F', 'B'} and pp.pad_sides != {pp.side}:
+                problems.append(
+                    f"{ref}: fp.layer says {pp.side}, its pads say "
+                    f"{sorted(pp.pad_sides)}")
+
+        # The CONTROL is this rig's ground truth, and it must be
+        # KIND-INDEPENDENT: `_all_at_current(st, [], pcb)` is the same call
+        # whatever kind was asked for, so a control that differs between kinds
+        # means the side key leaked into the control path. Compared against
+        # another kind's control rather than against a hand-built identity
+        # write, because `_all_at_current` walks `state.parts` -- which
+        # EXCLUDES the zero-pad blocks `pcb.footprints` carries -- and the
+        # writer reformats `(at)` for every ref it is handed, so a hand-built
+        # list is a different call and differs for a reason that is not a
+        # regression. (Measured: it does differ, which is what this comment is
+        # here to stop the next reader re-discovering.)
+        other = os.path.join(tmp, 'other.kicad_pcb')
+        other_ctrl = os.path.join(tmp, '_truth2', 'control.kicad_pcb')
+        perturb(BOARD, other, kind='translate', dose_mm=0.0,
+                control_out=other_ctrl, write_record=False)
+        if _sha(ctrl) != _sha(other_ctrl):
+            problems.append(
+                "the dose-0 CONTROL board differs between `layer_flip` and "
+                "`translate` -- ground truth is supposed to be the same board "
+                "whatever kind was asked for, so the side key has leaked into "
+                "the control path")
+        # The LEDGER must see the flip. Before #714 `record_write` derived
+        # `moved` from x/y/rot only and wrote `poses_written` as [x, y, rot],
+        # so a flip holding its pose landed in `refs_written` and NOT in
+        # `refs_moved`, with a pose claim byte-identical to the incumbent --
+        # `fence_audit` and every provenance consumer would grade a flipped
+        # board as untouched. That would have been a new silent wrongness of
+        # the very class this issue removes, shipped by the fix for it.
+        # `record_write` answers None outside a regime, so the regime is armed
+        # here the way `tests/test_provenance_audit.py` arms one -- otherwise
+        # this arm would "pass" by never running.
+        from placement import provenance
+        wd = os.path.join(tmp, 'wk')
+        os.makedirs(wd, exist_ok=True)
+        staged = os.path.join(wd, 'board.kicad_pcb')
+        shutil.copyfile(BOARD, staged)
+        provenance.start_regime(wd, staged)
+        ledger_out = os.path.join(wd, 'flipped.kicad_pcb')
+        shutil.copyfile(out, ledger_out)
+
+        ref = sorted(flipped)[0]
+        with provenance.declare_lever('place_optimize.py',
+                                      ['place_optimize.py', staged]):
+            row = provenance.record_write(
+                staged, ledger_out,
+                [{'reference': ref, 'new_x': round(a[ref].x, 6),
+                  'new_y': round(a[ref].y, 6),
+                  'new_rotation': a[ref].rotation,
+                  'new_side': footprint_side(b[ref])}])
+            row2 = provenance.record_write(
+                staged, ledger_out,
+                [{'reference': ref, 'new_x': round(a[ref].x, 6),
+                  'new_y': round(a[ref].y, 6),
+                  'new_rotation': a[ref].rotation}])
+        if row is None:
+            problems.append("record_write returned no row -- the regime was "
+                            "not armed, so this arm proves nothing")
+        else:
+            if ref not in (row.get('refs_moved') or ()):
+                problems.append(
+                    f"{ref} flipped but the ledger does not call it moved: "
+                    f"refs_moved={row.get('refs_moved')}")
+            if (row.get('sides_written') or {}).get(ref) is None:
+                problems.append(f"{ref} flipped but `sides_written` has no "
+                                f"entry for it: {row.get('sides_written')}")
+            # ...and a write with NO side key must not gain a side row.
+            if row2 is not None and row2.get('sides_written'):
+                problems.append("a write with no side key recorded a side: "
+                                f"{row2.get('sides_written')}")
+    except Exception as exc:                                     # noqa: BLE001
+        import traceback
+        traceback.print_exc()
+        print(f"FAIL (BROKEN TEST): {type(exc).__name__}: {exc}")
+        return 1
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    if problems:
+        print(f"FAIL: {len(problems)} problem(s)")
+        for p in problems[:25]:
+            print("  " + p)
+        return 1
+    print(f"PASS: layer_flip flipped exactly its {len(flipped)} members, "
+          f"left {len(b) - len(flipped)} alone, and the control is unmoved")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_714_refusals.py
+++ b/tests/test_714_refusals.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""#714 REF: what the flip must REFUSE rather than guess.
+
+A wrong mirror is silent -- `legality.footprint_side` reads `fp.layer[0]` and
+nothing cross-checks the pads -- and `write_placed_output` returns True
+unconditionally, so a construct the transform quietly passed through is
+indistinguishable from success at every call site. That is the same argument
+`writer.py`'s #829 guard already makes for raising rather than skipping, and it
+is why the default for an unrecognised node here is a REFUSAL.
+
+REFUSING IS CHEAP, MEASURED. Over the 22 tracked boards
+(`tests/measure_714_mirror_convention.py` section A, 1349 footprint blocks) the
+refusal set touches at most 7 blocks: `primitives` 6, `zone` 1. Four of the
+constructs below have NO corpus witness at all -- `chamfer`, `rect_delta`,
+`fp_text_box`, `group` -- which is the whole argument for refusing them: no
+corpus gate can validate a rule for a construct the corpus does not contain, so
+any rule for it is an unfalsifiable guess. Those four are exercised here by
+INJECTING them into a real board, which is the only way to test a refusal for
+something nothing ships.
+
+A REFUSAL IS ONLY A GUARD IF IT REFUSES FOR ITS OWN REASON. An `ImportError`,
+an `AttributeError` or a `KeyError` also stops the write, and reads identical
+from outside. So every case below asserts the exception TYPE and requires the
+message to name both the ref and the construct; anything else is reported as a
+BROKEN TEST rather than as a guard that held (`tests/run_utils.py`'s `check`
+makes the same distinction for subprocesses).
+
+    python3 tests/test_714_refusals.py
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import sys
+import tempfile
+
+TESTS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TESTS)
+sys.path.insert(0, os.path.join(REPO, 'py_router'))
+sys.path.insert(0, os.path.join(REPO, 'py_placer'))
+sys.path.insert(0, TESTS)
+
+RUN_ALL_TIMEOUT = 300
+
+# Exceptions that mean the TEST broke, not that the guard held.
+_ACCIDENTS = (ImportError, AttributeError, KeyError, IndexError, NameError,
+              TypeError, FileNotFoundError)
+
+
+def _inject(src, dst, ref, extra=None, pad_layers=None, sub=None):
+    """Copy `src` to `dst`, editing only the footprint block named `ref`.
+
+    `extra`       an s-expression appended as a new top-level child
+    `pad_layers`  replace the first pad's `(layers ...)` with this text
+    `sub`         (pattern, replacement) applied once inside the block
+    """
+    from kicad_parser import iter_footprint_blocks
+    text = open(src, encoding='utf-8').read()
+    out = None
+    for s, e, fp_text, _raw, key in iter_footprint_blocks(text):
+        if key != ref:
+            continue
+        body = fp_text
+        if sub is not None:
+            body = re.sub(sub[0], sub[1], body, count=1)
+        if pad_layers is not None:
+            body = re.sub(r'\(layers[^)]*\)', pad_layers, body, count=1)
+        if extra is not None:
+            close = body.rindex(')')
+            body = body[:close] + '\n\t\t' + extra + '\n\t' + body[close:]
+        out = text[:s] + body + text[e:]
+        break
+    if out is None:
+        raise AssertionError(f"{ref} not found in {src} -- fixture stale")
+    with open(dst, 'w', encoding='utf-8') as fh:
+        fh.write(out)
+    return dst
+
+
+def _expect_refusal(label, ref, needles, fn):
+    """Run `fn`; require a refusal that names `ref` and every needle."""
+    from placement.writer import write_placed_output  # noqa: F401
+    try:
+        from placement.writer import SideFlipUnsupported
+    except ImportError:
+        return (label, 'NO REFUSAL TYPE',
+                'placement.writer defines no SideFlipUnsupported')
+    try:
+        fn()
+    except SideFlipUnsupported as exc:
+        msg = str(exc)
+        missing = [n for n in ([ref] + list(needles)) if n.lower() not in msg.lower()]
+        if missing:
+            return (label, 'UNNAMED',
+                    f"refused, but the message names neither {missing}: {msg!r}")
+        return (label, 'OK', msg)
+    except _ACCIDENTS as exc:
+        return (label, 'BROKEN TEST',
+                f"{type(exc).__name__}: {exc} -- this is an accident, not a guard")
+    except Exception as exc:                                     # noqa: BLE001
+        return (label, 'WRONG TYPE',
+                f"{type(exc).__name__}: {exc}")
+    return (label, 'NOT REFUSED', 'the write succeeded')
+
+
+def main():
+    from kicad_parser import parse_kicad_pcb
+    from placement.writer import write_placed_output
+
+    tmp = tempfile.mkdtemp(prefix='krt714ref')
+    results = []
+    try:
+        def flip(path, ref, side=None):
+            fp = parse_kicad_pcb(path).footprints[ref]
+            if side is None:
+                side = 'F' if (fp.layer or 'F').startswith('B') else 'B'
+            out = os.path.join(tmp, 'out.kicad_pcb')
+            return write_placed_output(path, out, [{
+                'reference': ref, 'new_x': round(fp.x, 6),
+                'new_y': round(fp.y, 6), 'new_rotation': fp.rotation,
+                'new_side': side}])
+
+        rp = os.path.join(REPO, 'kicad_files',
+                          'rp2350_fpga_eensy_prePlane.kicad_pcb')
+        oc = os.path.join(REPO, 'kicad_files', 'orangecrab_ext_pll.kicad_pcb')
+        tg = os.path.join(REPO, 'kicad_files', 'tigard.kicad_pcb')
+
+        # --- the two constructs the corpus DOES carry
+        results.append(_expect_refusal(
+            'footprint-internal (zone) [rp2350 J2, the only corpus witness]',
+            'J2', ['zone'], lambda: flip(rp, 'J2')))
+        results.append(_expect_refusal(
+            'custom pad (primitives) [orangecrab U9]',
+            'U9', ['primitives'], lambda: flip(oc, 'U9')))
+
+        # --- the four with NO corpus witness, injected
+        p = _inject(tg, os.path.join(tmp, 'textbox.kicad_pcb'), 'J7',
+                    extra='(fp_text_box "x" (start 0 0) (end 1 1) '
+                          '(layer "F.SilkS"))')
+        results.append(_expect_refusal('unknown node kind (fp_text_box)',
+                                       'J7', ['fp_text_box'],
+                                       lambda: flip(p, 'J7')))
+        p = _inject(tg, os.path.join(tmp, 'chamfer.kicad_pcb'), 'J7',
+                    sub=(r'\(roundrect_rratio [^)]*\)',
+                         '(chamfer top_left bottom_left)'))
+        results.append(_expect_refusal('(chamfer ...) corner names',
+                                       'J7', ['chamfer'],
+                                       lambda: flip(p, 'J7')))
+        p = _inject(tg, os.path.join(tmp, 'fandb.kicad_pcb'), 'J7',
+                    pad_layers='(layers "F&B.Cu" "F.Mask" "F.Paste")')
+        results.append(_expect_refusal('F&B.Cu in a pad (layers)',
+                                       'J7', ['F&B'], lambda: flip(p, 'J7')))
+        p = _inject(tg, os.path.join(tmp, 'inner.kicad_pcb'), 'J7',
+                    pad_layers='(layers "In1.Cu" "F.Mask" "F.Paste")')
+        results.append(_expect_refusal('In<n>.Cu in a pad (layers)',
+                                       'J7', ['In1.Cu'], lambda: flip(p, 'J7')))
+
+        # --- a coordinate literal outside the measured grammar. 148417 tokens
+        # on the corpus, 0 outside `-?\d+(\.\d+)?`; a sign toggle is an exact
+        # involution only over that shape, so anything else must refuse.
+        p = _inject(tg, os.path.join(tmp, 'expo.kicad_pcb'), 'J7',
+                    sub=(r'\(at -1\.5 -2\b', '(at -1.5 -2e0'))
+        results.append(_expect_refusal('coordinate outside the literal grammar',
+                                       'J7', ['2e0'], lambda: flip(p, 'J7')))
+
+        # --- a bad side vocabulary is a caller error, caught at the boundary
+        try:
+            flip(tg, 'J7', side='B.Cu')
+            results.append(('new_side="B.Cu" (the mistake a caller makes)',
+                            'NOT REFUSED', 'accepted a layer name as a side'))
+        except ValueError as exc:
+            results.append(('new_side="B.Cu" (the mistake a caller makes)',
+                            'OK', str(exc)))
+        except _ACCIDENTS as exc:
+            results.append(('new_side="B.Cu" (the mistake a caller makes)',
+                            'BROKEN TEST', f"{type(exc).__name__}: {exc}"))
+        except Exception as exc:                                 # noqa: BLE001
+            results.append(('new_side="B.Cu" (the mistake a caller makes)',
+                            'WRONG TYPE', f"{type(exc).__name__}: {exc}"))
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    bad = [r for r in results if r[1] != 'OK']
+    for label, status, detail in results:
+        print(f"  {status:<16} {label}")
+        if status != 'OK':
+            print(f"                   {detail}")
+    if bad:
+        print(f"FAIL: {len(bad)} of {len(results)} refusals did not hold")
+        return 1
+    print(f"PASS: {len(results)} refusals hold and name their construct")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_714_refusals.py
+++ b/tests/test_714_refusals.py
@@ -138,9 +138,22 @@ def main():
         p = _inject(tg, os.path.join(tmp, 'textbox.kicad_pcb'), 'J7',
                     extra='(fp_text_box "x" (start 0 0) (end 1 1) '
                           '(layer "F.SilkS"))')
-        results.append(_expect_refusal('unknown node kind (fp_text_box)',
+        results.append(_expect_refusal('named refusal (fp_text_box)',
                                        'J7', ['fp_text_box'],
                                        lambda: flip(p, 'J7')))
+        # A head that is in NEITHER the named-refusal table nor the whitelist,
+        # which is the arm that actually guards a KiCad we have not seen. The
+        # `fp_text_box` case above does NOT reach it -- that head is in
+        # `_FLIP_NAMED_REFUSALS`, so the named branch fires first, and the
+        # mutation battery caught this: `an-unknown-node-passes-through`
+        # SURVIVED because the only fixture aimed at it was answered by a
+        # different guard.
+        p = _inject(tg, os.path.join(tmp, 'unknown.kicad_pcb'), 'J7',
+                    extra='(fp_holographic_sticker "x" (at 0 0) '
+                          '(layer "F.SilkS"))')
+        results.append(_expect_refusal(
+            'a head in neither the refusal table nor the whitelist',
+            'J7', ['fp_holographic_sticker'], lambda: flip(p, 'J7')))
         p = _inject(tg, os.path.join(tmp, 'chamfer.kicad_pcb'), 'J7',
                     sub=(r'\(roundrect_rratio [^)]*\)',
                          '(chamfer top_left bottom_left)'))

--- a/tests/test_714_refusals.py
+++ b/tests/test_714_refusals.py
@@ -169,6 +169,39 @@ def main():
         results.append(_expect_refusal('In<n>.Cu in a pad (layers)',
                                        'J7', ['In1.Cu'], lambda: flip(p, 'J7')))
 
+        # --- four refusals added after an adversarial review found each of
+        # them SILENTLY SKIPPING instead. Every one leaves a half-mirrored
+        # footprint, which is the failure class this feature exists to remove,
+        # and none has a witness on the tracked corpus -- which is why they
+        # were skips for as long as they were.
+        p = _inject(tg, os.path.join(tmp, 'atunlocked.kicad_pcb'), 'J7',
+                    sub=(r'\(at 0 -3\.98 0\)', '(at 0 -3.98 0 unlocked)'))
+        results.append(_expect_refusal(
+            'a KiCad 6/7 four-token `(at x y a unlocked)`',
+            'J7', ['(at'], lambda: flip(p, 'J7')))
+
+        p = _inject(tg, os.path.join(tmp, 'nofont.kicad_pcb'), 'J7',
+                    sub=(r'\(effects\s*\n\s*\(font\s*\n\s*\(size 1 1\)\s*\n\s*'
+                         r'\(thickness 0\.15\)\s*\n\s*\)\s*\n\s*\)',
+                         '(effects)'))
+        results.append(_expect_refusal(
+            'a text with no (effects (font ...)) to carry the mirror flag',
+            'J7', ['font'], lambda: flip(p, 'J7')))
+
+        p = _inject(tg, os.path.join(tmp, 'padstack.kicad_pcb'), 'J7',
+                    sub=(r'\(size 0\.6 1\.55\)',
+                         '(size 0.6 1.55)\n\t\t\t(padstack (layer "F.Cu" '
+                         '(size 0.6 1.55)))'))
+        results.append(_expect_refusal(
+            'a pad child outside the whitelist (KiCad 9/10 padstack)',
+            'J7', ['padstack'], lambda: flip(p, 'J7')))
+
+        p = _inject(tg, os.path.join(tmp, 'nolayer.kicad_pcb'), 'J7',
+                    sub=(r'\(layer "F\.Cu"\)\n', ''))
+        results.append(_expect_refusal(
+            'a footprint block with no top-level (layer ...)',
+            'J7', ['layer'], lambda: flip(p, 'J7')))
+
         # --- a coordinate literal outside the measured grammar. 148417 tokens
         # on the corpus, 0 outside `-?\d+(\.\d+)?`; a sign toggle is an exact
         # involution only over that shape, so anything else must refuse.

--- a/tests/test_714_side_self_consistency.py
+++ b/tests/test_714_side_self_consistency.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""#714 SELF: a flipped board must not contradict itself about which face it is on.
+
+The failure mode #714 is written around is silent. `legality.footprint_side`
+decides a part's side from `Footprint.layer`'s first character ALONE, with no
+pad cross-check, so a block whose `(layer ...)` says B.Cu while its pads still
+say F.Cu reports side B and computes every overlap, courtyard and clearance
+number from F geometry. `perturb.py`'s module docstring names exactly this:
+
+    A "flip" through it produces a board whose pads contradict its side, which
+    corrupts `footprint_side` / `sides_occupied` and therefore every overlap
+    number downstream.
+
+This gate is the cheapest thing that can see it: no pcbnew, no golden file,
+milliseconds. It compares two derivations of a part's side that are wholly
+independent of each other and that NOTHING IN THE REPO COMPARES TODAY --
+
+    legality.PartPads.side       from fp.layer[0]          (legality.py:239-242)
+    legality.PartPads.pad_sides  from the pads' (layers)   (legality.py:2087-2159)
+
+THE ARM THAT MAKES IT RED, and the reason it is listed first: a *consistency*
+check alone passes vacuously on the shipped writer, because a writer that
+ignores the side key emits the input board, which is perfectly consistent about
+being on the front. So D4 -- "the flip actually took" -- is asserted BEFORE
+consistency, and it is what fails on `upstream/main`.
+
+THE COURTYARD ARM is the one that is easy to leave out and load-bearing.
+`parser.courtyard_for_side` FALLS BACK to the other side's box when only one is
+drawn, so a footprint whose F.CrtYd stayed on F while the block moved to B
+still hands every placement consumer a plausible box. That fallback is
+precisely how a half-done flip stays silent, so the geometry side is asserted
+directly rather than through the accessor.
+
+    python3 tests/test_714_side_self_consistency.py
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+
+TESTS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TESTS)
+sys.path.insert(0, os.path.join(REPO, 'py_router'))
+sys.path.insert(0, os.path.join(REPO, 'py_placer'))
+sys.path.insert(0, TESTS)
+
+RUN_ALL_TIMEOUT = 300
+
+# (board, ref). Chosen so the SMD-only floor below is met without counting a
+# through-hole part, whose pads legitimately occupy both faces and therefore
+# carry no side claim to contradict.
+FIXTURES = [
+    ('tigard', 'J7'),
+    ('tigard', 'U3'),
+    ('glasgow_revC', 'U7'),
+    ('glasgow_revC', 'SW1'),
+    ('glasgow_revC', 'U1'),
+    ('orangecrab_ext_pll', 'J4'),
+    ('orangecrab_ext_pll', 'U9'),
+    ('rp2350_fpga_eensy_prePlane', 'SW1'),
+]
+
+# A gate that graded two SMD parts is not a gate. Below the fixture count so
+# one board changing is not a failure; far above zero so a vacuous run is.
+MIN_SMD_GRADED = 6
+
+
+def _flip_one(src, dst, ref, new_side):
+    """Ask the writer for a side change, holding x/y/rot exactly."""
+    from kicad_parser import parse_kicad_pcb
+    from placement.writer import write_placed_output
+    fp = parse_kicad_pcb(src).footprints[ref]
+    write_placed_output(src, dst, [{
+        'reference': ref, 'new_x': round(fp.x, 6), 'new_y': round(fp.y, 6),
+        'new_rotation': fp.rotation, 'new_side': new_side}])
+    return dst
+
+
+def main():
+    from kicad_parser import parse_kicad_pcb
+    from placement import parser as pparser
+    from placement.legality import PartPads, footprint_side
+
+    tmp = tempfile.mkdtemp(prefix='krt714self')
+    problems, smd_graded, checked = [], 0, 0
+    try:
+        for board, ref in FIXTURES:
+            src = os.path.join(REPO, 'kicad_files', board + '.kicad_pcb')
+            if not os.path.isfile(src):
+                problems.append(f"{board}: fixture board missing")
+                continue
+            before = parse_kicad_pcb(src).footprints.get(ref)
+            if before is None:
+                problems.append(f"{board}:{ref} not in the board -- fixture stale")
+                continue
+            want = 'F' if footprint_side(before) == 'B' else 'B'
+
+            dst = os.path.join(tmp, f"{board}__{ref}.kicad_pcb")
+            _flip_one(src, dst, ref, want)
+            after = parse_kicad_pcb(dst).footprints.get(ref)
+            if after is None:
+                problems.append(f"{board}:{ref} vanished from the output")
+                continue
+            checked += 1
+
+            # ---- D4: the flip TOOK. Asserted first; this is the arm that is
+            # red on the shipped writer, and without it every check below
+            # passes on an untouched board.
+            got = footprint_side(after)
+            if got != want:
+                problems.append(
+                    f"{board}:{ref} asked for side {want}, got {got} "
+                    f"(layer {after.layer!r}) -- the writer did not flip")
+                continue
+
+            # ---- the contradiction check proper
+            pp = PartPads(after, clearance=0.2)
+            if pp.side != want:
+                problems.append(f"{board}:{ref} PartPads.side {pp.side} != {want}")
+            if pp.pad_sides == {'F', 'B'}:
+                # Through-hole or *.Cu: the pads legitimately occupy both
+                # faces and make no claim this gate can contradict.
+                pass
+            else:
+                smd_graded += 1
+                if pp.pad_sides != {want}:
+                    problems.append(
+                        f"{board}:{ref} SIDE CONTRADICTION: fp.layer says "
+                        f"{pp.side}, the pads' own (layers) say "
+                        f"{sorted(pp.pad_sides)} -- every overlap number for "
+                        f"this part is now computed from the wrong face")
+
+            # ---- the graphic channel. Asserted DIRECTLY, not through
+            # courtyard_for_side, whose fallback would hide it.
+            for label, fn in (('courtyard', pparser.extract_courtyard_sides),
+                              ('fab', pparser.extract_fab_sides)):
+                sides = fn(dst).get(ref)
+                if not sides:
+                    continue  # the library drew none; nothing to contradict
+                if want not in sides:
+                    problems.append(
+                        f"{board}:{ref} {label} geometry is on "
+                        f"{sorted(sides)} but the part is on {want} -- "
+                        f"courtyard_for_side will silently serve the other "
+                        f"side's box to every placement consumer")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    if checked < MIN_SMD_GRADED:
+        problems.append(f"only {checked} fixture(s) reached the checks -- "
+                        f"this gate cannot pass on what it did not grade")
+    if smd_graded < MIN_SMD_GRADED and not problems:
+        problems.append(f"only {smd_graded} SMD-only part(s) carried a side "
+                        f"claim; the contradiction check is near-vacuous")
+
+    if problems:
+        print(f"FAIL: {len(problems)} problem(s)")
+        for p in problems[:25]:
+            print("  " + p)
+        return 1
+    print(f"PASS: {checked} flipped parts self-consistent "
+          f"({smd_graded} SMD-only side claims graded)")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_714_side_self_consistency.py
+++ b/tests/test_714_side_self_consistency.py
@@ -58,13 +58,16 @@ FIXTURES = [
     ('glasgow_revC', 'SW1'),
     ('glasgow_revC', 'U1'),
     ('orangecrab_ext_pll', 'J4'),
-    ('orangecrab_ext_pll', 'U9'),
     ('rp2350_fpga_eensy_prePlane', 'SW1'),
 ]
 
-# A gate that graded two SMD parts is not a gate. Below the fixture count so
-# one board changing is not a failure; far above zero so a vacuous run is.
-MIN_SMD_GRADED = 6
+# A gate that graded two SMD parts is not a gate. Measured: of the seven
+# fixtures, four carry an SMD-only side claim and three do not -- a through-hole
+# or `*.Cu` pad occupies BOTH faces by construction, so it makes no side claim
+# for this gate to contradict. The floor is set at what actually carries the
+# claim, and the pass line names them, so a fixture quietly ceasing to
+# discriminate shows up as a number rather than as silence.
+MIN_SMD_GRADED = 4
 
 
 def _flip_one(src, dst, ref, new_side):
@@ -85,6 +88,7 @@ def main():
 
     tmp = tempfile.mkdtemp(prefix='krt714self')
     problems, smd_graded, checked = [], 0, 0
+    smd_refs = []
     try:
         for board, ref in FIXTURES:
             src = os.path.join(REPO, 'kicad_files', board + '.kicad_pcb')
@@ -125,6 +129,7 @@ def main():
                 pass
             else:
                 smd_graded += 1
+                smd_refs.append(f"{board}:{ref}")
                 if pp.pad_sides != {want}:
                     problems.append(
                         f"{board}:{ref} SIDE CONTRADICTION: fp.layer says "
@@ -160,8 +165,8 @@ def main():
         for p in problems[:25]:
             print("  " + p)
         return 1
-    print(f"PASS: {checked} flipped parts self-consistent "
-          f"({smd_graded} SMD-only side claims graded)")
+    print(f"PASS: {checked} flipped parts self-consistent; "
+          f"{smd_graded} SMD-only side claims graded: {', '.join(smd_refs)}")
     return 0
 
 


### PR DESCRIPTION
## A writer that rewrote poses could not say which face it was writing them on

`placement.writer.write_placed_output` rewrote a footprint's `(at x y rot)` and
its pad **angles** and nothing else. It wrote no `(layer ...)` and mirrored no
geometry, so board side was read-only throughout placement — a filter
everywhere, a variable nowhere. This gives it the missing half.

Closes #714
Refs #836
Refs #837

The two dependants stay open on purpose. #836 (side as a *search* variable) is
gated on its own pre-registered measurement, which was not **buildable** until
this writer existed; #837 says its own acting half is unshippable without both.

## Verified

Rebased onto `main` @ `bc0ca9bc`; the diff hash is identical before and after
the rebase, so only the base moved.

* **Full suite: 545 passed, 0 failed, 0 timed out, 0 skipped (+1
  self-skipped).** Reconciles exactly: `main` collects 540 `tests/test_*.py`
  (539 pass + the pre-existing `test_run8_starved_face_gate` self-skip), this
  adds 6, and 539 + 6 = 545.
* **Acceptance gate**: 45 passes over 15 fixtures — 1833 pads and 2502 non-pad
  nodes compared node-for-node against pcbnew 10.0.0, all five required
  surfaces present (`fp_arc`, `fp_curve`, `fp_poly`, `fp_circle`, `model`).
* **Mutation battery**: 24 rows, 20 killed, 4 survived, **0 broken, 0
  disagreeing with expectation**; 24/24 anchors match exactly once and
  `--selftest` proves the `.pyc` defence rather than asserting it.
* **CLI/GUI parity**: `test_manifest_plan_parity.py` and
  `test_cli_postpass_coverage.py` both run, both unchanged.
* The defect was live on `main`: `perturb --kind wrong_side` could only produce
  the wrong HALF, and `write_placed_output` had no way to express the other
  FACE at all.

## The API is one optional dict key

`new_side`, `'F'` or `'B'`. Absent or `None` and the layer is left alone and the
write is byte-identical to one built before this existed — which is what keeps
the ~20 producers of these dicts (`quench`, `seeder`, `portfolio`, `relocate`,
`perturb`, `fanout_clearance`, `place_reconstruct`, `place_seed`, `converge`,
`net_rescue`) unchanged. Anything other than `'F'`/`'B'` raises at the boundary;
`'B.Cu'` is the mistake a caller actually makes.

`new_rotation` still means the **final** orientation. pcbnew's `Flip` negates
it; this does not, because a hidden negation would make the same call mean
different things depending on the input side.

## Why the obvious test cannot see the bug

The issue proposes comparing resolved `Pad.global_x/global_y/size_x/size_y/
layers` plus `footprint.layer` through both parse paths. That is blind to
exactly the failure it is written for:

`local_to_global` has **no mirror term** — KiCad stores B-side children
pre-mirrored. Toggle the footprint `(layer ...)` to `B.Cu` and toggle the pad
`(layers)`, but forget the local y, and every pad's **global** position comes
out exactly as before, on **both** parse paths, while `footprint.layer` reads B.
Every field the issue names passes. `legality.footprint_side` reads `fp.layer[0]`
and nothing cross-checks the pads, so the board grades plausibly and wrongly
forever.

Three more reasons the comparison had to move down a level:

* Comparing two parsers over one file tests the parsers. The oracle has to be a
  different **document** — pcbnew's own flip of the original.
* PCBData models a minority of a block. Of 1319 pad-bearing tracked footprints,
  1206 carry `fp_line`, 1215 `model`, 1077 `fp_text`, 132 `fp_circle`, 85
  `fp_poly`, 54 `fp_arc`, 46 `fp_rect`. No pad field compares any of them.
* `fp_arc`'s start/end swap is **geometrically invisible**: mirroring
  start/mid/end without exchanging start and end gives the same curve through
  the same three points.

So the acceptance gate compares the emitted **block** against the block pcbnew
writes after `FOOTPRINT.Flip(pos, FLIP_DIRECTION_TOP_BOTTOM)` + `SaveBoard()`,
as canonical trees — numbers to integer nanometres (both sides are nm-quantised,
so the tolerance is exactly **zero**, not a float epsilon), children sorted
because pcbnew re-serialises in its own order, and the uuid multiset **asserted**
rather than normalised away.

## The gates were written first, against the writer that could not flip

Six of them, committed before the engine. Five were red then, one green, and
that is the evidence they are gates rather than decoration.

| gate | before | now |
|---|---|---|
| IDENT — no-side-key write byte-identical, 22 boards / 1349 footprints | GREEN | GREEN |
| SELF — a flipped part vs its own pads' layers | RED | GREEN |
| VAC — the mirror asserted numerically, on fixtures *proven* to discriminate | RED | GREEN |
| RT — flip and flip back, byte-identical | RED | GREEN |
| REF — 13 refusals, each naming its construct | RED | GREEN |
| PAR — 45 passes vs pcbnew, node for node (1833 pads, 2502 non-pad nodes) | RED | GREEN |

## The vacuity problem

Measured over the 22 tracked boards, the symmetric fraction depends on the
predicate, and the three answer different questions:

| predicate | | |
|---|---|---|
| position `{(x,y)}` closed under `y → -y` | 1198/1319 | **90.8%** |
| tuple `(num,type,shape,x,y,angle)`, angle negated | 532/1319 | **40.3%** |
| the same tuple, **angle held identical** | 1011/1319 | **76.6%** |

The third is the one an implementer needs — *how often is the y-mirror itself
unobservable*, against the mutant that negates angles and layers but forgets y.
**A fixture drawn from ordinary parts passes every geometric assertion with the
mirror deleted**, so VAC proves per surface that its fixtures can see what its
assertions claim to test, and refuses if they cannot.

## Two rounds of adversarial verification, and what they found

**Round 1** (against the phase-0 measurement) found a live bug — pcbnew adds
`(justify mirror)` only to a text on a *sided* layer, and this added it
unconditionally. 28 flip-eligible texts on the corpus sit on a User layer and
**none of the 13 parity fixtures carried one**, so the acceptance gate was green
with the bug in it. It also falsified four of my numbers, all four in the
feature's favour.

**Round 2** (against the whole branch diff) found a bug that was **already
shipping in this PR's own consumer**:

> Pads used the general angle composition `a' = R_new − (a − R_old)`; texts used
> the constant `180 − a`. Those agree **only** when `new_rot == −old_rot` —
> pcbnew's bare flip, which is the only thing the parity gate ever asked for.
> `perturb`'s `layer_flip` holds the pose, so its delta is 2R: **9 of tigard's
> 33 flipped parts shipped a reference designator rotated 180° from where KiCad
> puts it**, relative to their own pads, which had rotated correctly. Now 0/33.

Each fixture is now compared three times — bare flip, +90, +180 — against
`Flip` + `SetOrientationDegrees`. Reintroducing the old formula produces 90
differences, *every one on a composed pass and none on the bare one*.

Round 2 also turned **five silent skips into refusals** — an unparseable
four-token `(at … unlocked)`; a text with no `(effects (font …))`; a **pad
dispatch that was a blacklist**, so the head that refuses at footprint level was
emitted verbatim from inside a pad (KiCad 9/10's `padstack` is the live case); a
block with no top-level `(layer …)`; and `(\S+)\)` swallowing a closing paren,
which made every compactly-serialised `fp_poly` unflippable.

## Mutation battery: 24 rows, 20 killed, 4 survived, 0 broken

**Neither gate is sufficient alone**, and the rows prove it in both directions:

* `the-negation-goes-through-float` is killed by the **round trip alone** — every
  value test passes, because the numbers are right and only their spelling
  changed.
* `fp_arc-mirrors-without-the-start-end-swap` is killed by the **parity gate
  alone** — the round trip survives it (still an involution) and so does every
  geometric check.

**All four survivors carry their reason in the row above them**: two
redundant-guard pairs created by the round-2 fixes, the `zone` refusal covered
twice, and the #829 outline term that no tracked board can exercise.

The battery corrected one of my own justifications. The comment said a float
round trip would rewrite `0.500` as `0.5` — measured, **all 148417 coordinate
literals on the 22 tracked boards are already in `_fmt_mm` minimal form and none
carries more than six decimals**. The example was invented. The sign toggle is
still right (exact *by construction* over the declared grammar, where the float
path is exact only because of a property of these particular files), so the
discriminating input is now synthesised rather than found.

## Deliberate divergences, disclosed

**pcbnew loses a nanometre on an arc's mid point when it flips; this does not.**
A plain `LoadBoard` + `SaveBoard` preserves rp2350 SW1's `(mid 1.40384 0)`
exactly, but `fp.Flip(...)` + `SaveBoard` writes `1.403839` — pcbnew re-derives
mid from centre/angles. This transform never touches an arc's X. PAR waives that
rather than matching it (adopting the rounding would make the transform lossy
and break RT's byte identity); the waiver is `mid` only, one nanometre only,
every instance printed, and capped.

**`docs/floorplan-intent.md`'s `zone_side` row is unchanged and still correct.**
It says the quench never flips a side, and the quench gains no lever here.

## What it refuses rather than guesses

`SideFlipUnsupported`, raised and never skipped — `write_placed_output` returns
True unconditionally, so a construct quietly passed through is indistinguishable
from success at every call site. Both the footprint-level and pad-level
dispatches are whitelists, because you cannot test for a node kind you have not
thought of.

Refusing is cheap, measured: of 1349 tracked footprint blocks the refusal set
touches at most 7 (`primitives` 6, `zone` 1). `chamfer`, `rect_delta`,
`fp_text_box` and `group` have **no witness at all**, which is the argument
*for* refusing them — but only because they describe SHAPE. Twelve passthrough
heads also have no witness and are passed through deliberately: they are
scalars, identifiers and flags a reflection cannot act on, and that distinction
is now written down rather than left as an apparent inconsistency.

## CLI / GUI

No new CLI flag — the capability rides on a dict key — so
`tests/gui_parity/test_manifest_plan_parity.py` and
`test_cli_postpass_coverage.py` are unchanged. Both were **run** rather than
assumed: the first reports OK on placement-block flags, the second 8 registered
passes / 0 unreachable / 0 failures.

One GUI path does change behaviour without changing: `placement_gui._apply_pose`
already compares `fp.IsFlipped()` against the result board's parsed layer and
calls `fp.Flip(...)`. That branch has been **dead for CLI-produced boards**
because the writer never wrote a differing layer. It is now live.

`.gui-parity-checked` is not touched — this is a placement-only change with no
routing reach, matching how PR #867 was handled.

## Provenance

`record_write` derived `moved` from x/y/rot only and wrote `poses_written` as
`[x, y, rot]`, so a flip that holds its pose landed in `refs_written` and **not**
in `refs_moved`, with a pose claim byte-identical to the incumbent — the ledger
recorded the flip nowhere and `fence_audit` would grade a flipped board as
untouched. Found independently by both design reviews, which is why it is in
this PR rather than a follow-up.

Fixed additively: a side term in the `moved` predicate and a separate
`sides_written` key. `SCHEMA` does **not** move — `read_ledger` is shape-agnostic,
`poses_written` keeps its `[x, y, rot]` shape, and the new key is optional and
absent from every existing row.
