### PR TITLE
#806: the diff-pair working obstacle map is stale, not unbalanced -- invariant E, and the refresh that fixes it

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -168,9 +168,15 @@ for how they fit together.
   `precompute_all_net_obstacles` build `NetObstacleData`;
   `add_net_obstacles_from_cache` / `remove_net_obstacles_from_cache` /
   `update_net_obstacles_after_routing` keep a working map in sync cell-for-cell
-  (ref-counted). `precompute_via_placement_obstacles` does the same for via
-  placement. `KICAD_OBSTACLE_LEDGER=1` audits add/remove balance via
-  `run_obstacle_audit` / `obstacle_ledger_report`.
+  (ref-counted); `refresh_net_obstacles(working, cache, pcb_data, config,
+  net_ids)` is the remove -> recompute -> add cycle every commit, rip and
+  restore must run for the nets it touched (#806: the diff-pair engine's
+  commit sites go through it). `precompute_via_placement_obstacles` does the
+  same for via placement. `KICAD_OBSTACLE_LEDGER=1` audits add/remove balance
+  via `run_obstacle_audit` / `obstacle_ledger_report`; with `pcb_data` and
+  `config` the audit also runs `run_obstacle_content_audit`, which recomputes
+  every cached net from the board and counts the cells the map should block
+  but does not -- the invariant ref-count balance cannot see.
 
 - **`fab_tiers`** — JLCPCB fab-capability floors as selectable cost tiers
   (issue #237). `fab_floor_ladder` / `fab_floors` / `fab_floor_for_param` give

--- a/py_router/diff_pair_custody.py
+++ b/py_router/diff_pair_custody.py
@@ -559,7 +559,9 @@ def run_casualty_reconcile(state, progress_callback=None,
                     state.remaining_net_ids, state.routed_net_ids,
                     state.routed_net_paths, state.routed_results,
                     state.diff_pair_by_net_id, state.track_proximity_cache,
-                    state.layer_map)
+                    state.layer_map,
+                    working_obstacles=state.working_obstacles,    # #806
+                    net_obstacles_cache=state.net_obstacles_cache)
                 record_pair_diag(state, pair_name, casualty='rerouted')
                 rerouted = True
         else:
@@ -614,6 +616,10 @@ def run_casualty_reconcile(state, progress_callback=None,
             pruned['partial_restore_134'] = True
             add_route_to_pcb_data(pcb_data, pruned,
                                   debug_lines=config.debug_lines)
+            from obstacle_cache import refresh_net_obstacles  # #806
+            refresh_net_obstacles(state.working_obstacles,
+                                  state.net_obstacles_cache, pcb_data, config,
+                                  sorted(set(ripped_ids or []) | {net_id}))
             state.results.append(pruned)
             print(f"  {RED}PARTIAL{RESET} {name}: reroute failed; restored "
                   f"{len(keep_segs)} segment(s) + {len(keep_vias)} via(s) of "

--- a/py_router/diff_pair_loop.py
+++ b/py_router/diff_pair_loop.py
@@ -20,6 +20,7 @@ from diff_pair_routing import (route_diff_pair_with_obstacles, get_diff_pair_end
                                _route_direct_coupled_middle, _seg_to_seglist_min_edge)
 from blocking_analysis import analyze_frontier_blocking, print_blocking_analysis, filter_rippable_blockers, invalidate_obstacle_cache
 from rip_up_reroute import rip_up_net, restore_net
+from obstacle_cache import refresh_net_obstacles  # #806
 from polarity_swap import apply_polarity_swap, get_canonical_net_id
 from layer_swap_fallback import try_fallback_layer_swap, add_own_stubs_as_obstacles_for_diff_pair
 from diff_pair_multipoint import (
@@ -316,6 +317,10 @@ def route_diff_pairs(
                 diff_pair_by_net_id[pair.n_net_id] = (pair_name, pair)
                 invalidate_obstacle_cache(obstacle_cache, pair.p_net_id)
                 invalidate_obstacle_cache(obstacle_cache, pair.n_net_id)
+                # #806: the legs are on the board (committed per leg inside the
+                # multipoint router); the working map must see them too.
+                refresh_net_obstacles(state.working_obstacles, state.net_obstacles_cache,
+                                      pcb_data, config, (pair.p_net_id, pair.n_net_id))
             else:
                 # No leg was coupled - every leg was electrically short and
                 # deferred (peeled set above). Not a failure: the single-ended
@@ -626,6 +631,12 @@ def route_diff_pairs(
             apply_polarity_swap(pcb_data, result, pad_swaps, pair_name, polarity_swapped_pairs)
 
             add_route_to_pcb_data(pcb_data, result, debug_lines=config.debug_lines)
+            # #806: keep the persistent working map in step with the commit
+            # (the single-ended loop's contract), or every later search on
+            # that map -- a ripped victim's reroute, a terminal restore --
+            # runs blind to this pair's copper.
+            refresh_net_obstacles(state.working_obstacles, state.net_obstacles_cache,
+                                  pcb_data, config, (pair.p_net_id, pair.n_net_id))
 
             if pair.p_net_id in remaining_net_ids:
                 remaining_net_ids.remove(pair.p_net_id)
@@ -923,6 +934,8 @@ def route_diff_pairs(
                             apply_polarity_swap(pcb_data, retry_result, pad_swaps, pair_name, polarity_swapped_pairs)
 
                             add_route_to_pcb_data(pcb_data, retry_result, debug_lines=config.debug_lines)
+                            refresh_net_obstacles(state.working_obstacles, state.net_obstacles_cache,  # #806
+                                                  pcb_data, config, (pair.p_net_id, pair.n_net_id))
                             if pair.p_net_id in remaining_net_ids:
                                 remaining_net_ids.remove(pair.p_net_id)
                             if pair.n_net_id in remaining_net_ids:
@@ -1012,7 +1025,9 @@ def route_diff_pairs(
                         all_swap_vias, all_segment_modifications,
                         None, None,
                         routed_net_paths, routed_results, diff_pair_by_net_id, layer_map,
-                        target_swaps, results=results, obstacle_cache=obstacle_cache)
+                        target_swaps, results=results, obstacle_cache=obstacle_cache,
+                        working_obstacles=state.working_obstacles,          # #806
+                        net_obstacles_cache=state.net_obstacles_cache)
 
                     if swap_success and swap_result:
                         # Calculate actual routed length from segments (includes connectors and via barrels)
@@ -1063,6 +1078,8 @@ def route_diff_pairs(
 
                         apply_polarity_swap(pcb_data, swap_result, pad_swaps, pair_name, polarity_swapped_pairs)
                         add_route_to_pcb_data(pcb_data, swap_result, debug_lines=config.debug_lines)
+                        refresh_net_obstacles(state.working_obstacles, state.net_obstacles_cache,  # #806
+                                              pcb_data, config, (pair.p_net_id, pair.n_net_id))
                         if pair.p_net_id in remaining_net_ids:
                             remaining_net_ids.remove(pair.p_net_id)
                         if pair.n_net_id in remaining_net_ids:
@@ -1107,6 +1124,8 @@ def route_diff_pairs(
                         print(f"  HYBRID ESCAPE: direct coupled middle + point-to-point "
                               f"terminal legs")
                         add_route_to_pcb_data(pcb_data, hyb, debug_lines=config.debug_lines)
+                        refresh_net_obstacles(state.working_obstacles, state.net_obstacles_cache,  # #806
+                                              pcb_data, config, (pair.p_net_id, pair.n_net_id))
                         results.append(hyb)
                         successful += 1
                         total_iterations += hyb.get('iterations', 0)

--- a/py_router/layer_swap_fallback.py
+++ b/py_router/layer_swap_fallback.py
@@ -26,6 +26,23 @@ from obstacle_costs import (
 from blocking_analysis import analyze_frontier_blocking
 from history_congestion import add_history_source, record_rip   # #590
 from polarity_swap import get_canonical_net_id
+from obstacle_cache import refresh_net_obstacles as _refresh_map   # #806
+
+
+def stamp_result_copper(obstacles, result: dict, config, extra_clearance: float) -> None:
+    """Stamp a routing RESULT's copper -- segments and EVERY via it carries --
+    as obstacles on `obstacles`. For copper that is not in pcb_data yet (a
+    result the caller commits later) the pcb_data-driven stampers cannot see
+    it, so it must come from the result itself. #806: the victim-reroute
+    map inside try_fallback_layer_swap stamped the result's GND vias only,
+    dropping the pair's own P/N barrels, so a victim could land a via on
+    (or a track across) a barrel that was about to be committed."""
+    segs = (result or {}).get('new_segments') or []
+    vias = (result or {}).get('new_vias') or []
+    if segs:
+        add_segments_list_as_obstacles(obstacles, segs, config, extra_clearance)
+    if vias:
+        add_vias_list_as_obstacles(obstacles, vias, config, extra_clearance)
 
 
 def add_own_stubs_as_obstacles_for_diff_pair(obstacles, pcb_data, p_net_id: int, n_net_id: int,
@@ -199,10 +216,18 @@ def try_fallback_layer_swap(pcb_data, pair, pair_name: str, config,
                             layer_map: dict = None,
                             target_swaps: dict = None,
                             results: list = None,
-                            obstacle_cache: dict = None):
+                            obstacle_cache: dict = None,
+                            working_obstacles=None,
+                            net_obstacles_cache: dict = None):
     """
     Try to swap the blocked side's stubs to another layer as a fallback when routing fails.
     After applying the swap, attempts rip-up and reroute if the initial route fails.
+
+    working_obstacles / net_obstacles_cache (#806): the run's persistent map
+    and per-net cache. This function rips and restores victims INLINE (not
+    through rip_up_net / restore_net, which do their own map bookkeeping),
+    so every place it changes a victim's copper on the board refreshes that
+    victim's map entry here. None = the caller keeps no persistent map.
 
     Returns:
         (success, result, vias, mods) - success bool, routing result if successful,
@@ -458,6 +483,8 @@ def try_fallback_layer_swap(pcb_data, pair, pair_name: str, config,
                             if was_in_results:
                                 results.remove(saved_result)
                             remove_route_from_pcb_data(pcb_data, saved_result)
+                            _refresh_map(working_obstacles, net_obstacles_cache,
+                                         pcb_data, config, rip_net_ids)   # #806
                             # #590: a blocker rip, done inline here rather than
                             # through rip_up_net -- charge it the same way, or
                             # this path's conflicts are invisible to history.
@@ -526,13 +553,14 @@ def try_fallback_layer_swap(pcb_data, pair, pair_name: str, config,
                                         add_net_vias_as_obstacles(reroute_obstacles, pcb_data, pair.n_net_id, config, diff_pair_extra_clearance)
                                         if gnd_net_id is not None:
                                             add_net_vias_as_obstacles(reroute_obstacles, pcb_data, gnd_net_id, config, diff_pair_extra_clearance)
-                                            # Also add GND vias from rip_result (the just-routed pair) which aren't in pcb_data yet
-                                            gnd_vias_from_result = [v for v in rip_result.get('new_vias', []) if v.net_id == gnd_net_id]
-                                            if gnd_vias_from_result:
-                                                add_vias_list_as_obstacles(reroute_obstacles, gnd_vias_from_result, config, diff_pair_extra_clearance)
-                                        # Also add segments from rip_result (the just-routed pair) which aren't in pcb_data yet
-                                        if rip_result.get('new_segments'):
-                                            add_segments_list_as_obstacles(reroute_obstacles, rip_result['new_segments'], config, diff_pair_extra_clearance)
+                                        # The just-routed pair's copper (rip_result) is NOT in
+                                        # pcb_data yet -- the caller commits it after we return
+                                        # -- so stamp it from the result: segments AND every
+                                        # via it carries (its own P/N barrels and any GND
+                                        # return vias). #806: this used to stamp GND vias only,
+                                        # so a victim rerouted blind to the pair's own barrels.
+                                        stamp_result_copper(reroute_obstacles, rip_result, config,
+                                                            diff_pair_extra_clearance)
                                         reroute_stub_net_ids = [nid for nid in all_unrouted_net_ids
                                                                 if nid not in routed_net_ids
                                                                 and nid != ripped_pair.p_net_id
@@ -554,6 +582,8 @@ def try_fallback_layer_swap(pcb_data, pair, pair_name: str, config,
                                         reroute_result = route_diff_pair_with_obstacles(pcb_data, ripped_pair, config, reroute_obstacles, base_obstacles, reroute_stubs)
                                         if reroute_result and not reroute_result.get('failed') and not reroute_result.get('probe_blocked'):
                                             add_route_to_pcb_data(pcb_data, reroute_result, debug_lines=config.debug_lines)
+                                            _refresh_map(working_obstacles, net_obstacles_cache,
+                                                         pcb_data, config, ripped_ids)   # #806
                                             # Add to results list if the ripped result was in it
                                             if ripped_was_in_results and results is not None:
                                                 results.append(reroute_result)
@@ -604,6 +634,8 @@ def try_fallback_layer_swap(pcb_data, pair, pair_name: str, config,
                                                     results.remove(new_result)
                                             # Now restore the old route
                                             add_route_to_pcb_data(pcb_data, ripped_saved, debug_lines=config.debug_lines)
+                                            _refresh_map(working_obstacles, net_obstacles_cache,
+                                                         pcb_data, config, ripped_ids)   # #806
                                             if ripped_was_in_results and results is not None:
                                                 # Only append if not already in results (prevent duplicates)
                                                 if ripped_saved not in results:
@@ -624,6 +656,8 @@ def try_fallback_layer_swap(pcb_data, pair, pair_name: str, config,
                     for ripped_blocker, ripped_saved, ripped_ids, ripped_was_in_results in ripped_items:
                         if ripped_saved and ripped_ids[0] not in routed_net_ids:
                             add_route_to_pcb_data(pcb_data, ripped_saved, debug_lines=config.debug_lines)
+                            _refresh_map(working_obstacles, net_obstacles_cache,
+                                         pcb_data, config, ripped_ids)   # #806
                             if ripped_was_in_results and results is not None and ripped_saved not in results:
                                 results.append(ripped_saved)
                             for rid in ripped_ids:

--- a/py_router/obstacle_cache.py
+++ b/py_router/obstacle_cache.py
@@ -220,7 +220,7 @@ def ledger_raw_delta(obstacles, site_tag: str, d_cells: int, d_vias: int) -> Non
 
 def run_obstacle_audit(base_obstacles, working_obstacles,
                        net_obstacles_cache: Dict[int, "NetObstacleData"],
-                       label: str = "") -> None:
+                       label: str = "", pcb_data=None, config=None) -> None:
     """End-of-run ref-count integrity audit (issue #309), shared by every
     front-end that maintains a persistent working map + per-net cache dict.
 
@@ -228,6 +228,13 @@ def run_obstacle_audit(base_obstacles, working_obstacles,
     map, removes every net's CURRENT cache, and compares entry counts to the
     base. Any residual in the ref-counted sets is a leak (an add not mirrored
     by a remove) or an over-decrement. Fully defensive; env-gated by callers.
+
+    With `pcb_data` and `config` it also runs the CONTENT audit (#806,
+    invariant E): the ref-count invariants above say nothing about whether
+    the cells in the map are the RIGHT cells -- a cache entry computed before
+    a net was routed, never refreshed, and removed/re-added in balance passes
+    A/B/C while the routed copper is invisible to every search on the map.
+    See `run_obstacle_content_audit`.
     """
     try:
         if base_obstacles is None or working_obstacles is None:
@@ -268,6 +275,114 @@ def run_obstacle_audit(base_obstacles, working_obstacles,
             obstacle_ledger_report(net_obstacles_cache)
     except Exception as e:
         print(f"[OBSTACLE AUDIT] skipped ({e})")
+    if pcb_data is not None and config is not None:
+        run_obstacle_content_audit(working_obstacles, net_obstacles_cache,
+                                   pcb_data, config, label=label)
+
+
+def _cache_cells_and_vias(cd: "NetObstacleData"):
+    """A cache entry's (N,3) blocked cells and (M,2) blocked via cells, with
+    the #815 spans expanded -- the cell multiset the map actually holds."""
+    cells = [np.asarray(cd.blocked_cells, dtype=np.int64).reshape(-1, 3)]
+    spans = getattr(cd, 'blocked_cell_spans', None)
+    if spans is not None and len(spans):
+        s = np.asarray(spans, dtype=np.int64).reshape(-1, 4)
+        n = (s[:, 2] - s[:, 1] + 1)
+        gx = np.repeat(s[:, 0], n)
+        li = np.repeat(s[:, 3], n)
+        gy = np.concatenate([np.arange(lo, hi + 1) for lo, hi in zip(s[:, 1], s[:, 2])]) \
+            if len(s) else np.empty(0, dtype=np.int64)
+        cells.append(np.stack([gx, gy, li], axis=1))
+    vias = [np.asarray(cd.blocked_vias, dtype=np.int64).reshape(-1, 2)]
+    vspans = getattr(cd, 'blocked_via_spans', None)
+    if vspans is not None and len(vspans):
+        vias.append(np.asarray(expand_via_spans(np.asarray(vspans, dtype=np.int32)),
+                               dtype=np.int64).reshape(-1, 2))
+    return np.concatenate(cells), np.concatenate(vias)
+
+
+def run_obstacle_content_audit(working_obstacles, net_obstacles_cache,
+                               pcb_data, config, label: str = "") -> Optional[Dict]:
+    """Invariant E (#806): the working map BLOCKS every cell the board's
+    CURRENT copper says it should, for every net the cache tracks.
+
+    Recomputes each cached net's footprint from `pcb_data` exactly as
+    rip_up_net / restore_net do, and queries the working map cell by cell.
+    A cell the fresh footprint holds that the map does not block is an
+    UNDER-BLOCK: copper a later search on this map (a ripped victim's
+    reroute, a terminal restore, the mincut probe) will route straight
+    through. Distinct from A/B/C, which only check that adds and removes
+    balance -- a stale-but-balanced entry passes them.
+
+    Returns the counts (also printed), or None when nothing could be checked.
+    """
+    try:
+        if working_obstacles is None or not net_obstacles_cache:
+            return None
+        n_nets = n_cells = n_missing = n_vias = n_vmissing = 0
+        n_entry_stale = 0
+        stale_nets = []
+        stale_entries = []
+        for nid in sorted(net_obstacles_cache):
+            fresh = precompute_net_obstacles(pcb_data, nid, config)
+            cells, vias = _cache_cells_and_vias(fresh)
+            if len(cells):
+                cells = _unique_rows(cells.astype(np.int32))
+            if len(vias):
+                vias = _unique_rows(vias.astype(np.int32))
+            n_nets += 1
+            # Bookkeeping staleness, independent of what ELSE covers a cell:
+            # cells the board's copper says this net owns that its cache
+            # entry (= what the map was told) does not carry.
+            ent_cells, _ent_vias = _cache_cells_and_vias(net_obstacles_cache[nid])
+            ent_keys = set(map(tuple, ent_cells.tolist()))
+            entry_missing = sum(1 for c in cells.tolist() if tuple(c) not in ent_keys)
+            miss = 0
+            for gx, gy, li in cells:
+                if not working_obstacles.is_blocked(int(gx), int(gy), int(li)):
+                    miss += 1
+            vmiss = 0
+            for gx, gy in vias:
+                if not working_obstacles.is_via_blocked(int(gx), int(gy)):
+                    vmiss += 1
+            n_cells += len(cells)
+            n_vias += len(vias)
+            n_missing += miss
+            n_vmissing += vmiss
+            n_entry_stale += entry_missing
+            name = getattr(pcb_data.nets.get(nid), 'name', None) or str(nid)
+            if entry_missing:
+                stale_entries.append((name, entry_missing, len(cells)))
+            if miss or vmiss:
+                stale_nets.append((name, miss, len(cells), vmiss, len(vias)))
+        print("\n" + "=" * 60)
+        print(f"[OBSTACLE CONTENT{' ' + label if label else ''}] "
+              f"{n_nets} nets recomputed from pcb_data: {n_cells} cells checked, "
+              f"{n_missing} NOT blocked in working map; {n_vias} via cells checked, "
+              f"{n_vmissing} NOT via-blocked; {n_entry_stale} cells absent from "
+              f"their net's cache entry ({len(stale_entries)} stale entries)")
+        for name, em, c in stale_entries[:12]:
+            print(f"    stale entry {name}: {em}/{c} current cells not in its entry")
+        if len(stale_entries) > 12:
+            print(f"    ... and {len(stale_entries) - 12} more stale entries")
+        if stale_nets:
+            print(f"  UNDER-BLOCK: {len(stale_nets)} net(s) whose current copper "
+                  f"the working map does not block:")
+            for name, m, c, vm, vc in stale_nets[:12]:
+                print(f"    {name}: {m}/{c} cells, {vm}/{vc} via cells missing")
+            if len(stale_nets) > 12:
+                print(f"    ... and {len(stale_nets) - 12} more")
+        else:
+            print("  CONTENT OK: every cached net's current copper is blocked "
+                  "in the working map.")
+        print("=" * 60)
+        return {'nets': n_nets, 'cells': n_cells, 'missing': n_missing,
+                'vias': n_vias, 'via_missing': n_vmissing,
+                'entry_stale': n_entry_stale, 'stale_entries': stale_entries,
+                'stale_nets': stale_nets}
+    except Exception as e:
+        print(f"[OBSTACLE CONTENT] skipped ({e})")
+        return None
 
 
 def obstacle_ledger_report(final_cache: Dict[int, "NetObstacleData"]) -> None:
@@ -1123,6 +1238,35 @@ def update_net_obstacles_after_routing(pcb_data, net_id: int, result: Dict,
         pcb_data, net_id, config,
         extra_clearance=0.0, diagonal_margin=defaults.DIAGONAL_MARGIN
     )
+
+
+def refresh_net_obstacles(working_obstacles, net_obstacles_cache, pcb_data,
+                          config, net_ids) -> None:
+    """Bring the working map's view of `net_ids` back in line with the copper
+    that is on the board NOW: remove each net's current entry, recompute it
+    from `pcb_data`, add the new entry. This is the single-ended loop's
+    contract after every commit (and rip_up_net's / restore_net's after
+    every rip and restore), spelled once.
+
+    #806: the diff-pair engine committed copper at eight sites without doing
+    this, so a routed pair's entry stayed the pre-route (stubs-only) one it
+    was built with. The ref-count invariants A/B/C held -- the stale entry
+    was removed and re-added in balance -- while measured on
+    dual_ipex_csi_interposer 30862 of 47448 cells the board's copper owned
+    were NOT blocked in the map a ripped victim's reroute searched.
+
+    A net absent from the cache gets an entry (mirrors rip_up_net, which
+    recomputes unconditionally), so restored copper of a net the run had not
+    tracked is stamped rather than silently invisible. No-op when the caller
+    has no persistent map (GUI dry paths, tests).
+    """
+    if working_obstacles is None or net_obstacles_cache is None:
+        return
+    for nid in net_ids:
+        if nid in net_obstacles_cache:
+            remove_net_obstacles_from_cache(working_obstacles, net_obstacles_cache[nid])
+        net_obstacles_cache[nid] = precompute_net_obstacles(pcb_data, nid, config)
+        add_net_obstacles_from_cache(working_obstacles, net_obstacles_cache[nid])
 
 
 # =============================================================================

--- a/py_router/reroute_loop.py
+++ b/py_router/reroute_loop.py
@@ -33,7 +33,7 @@ from routing_context import (
     record_single_ended_success, record_diff_pair_success,
     prepare_obstacles_inplace, restore_obstacles_inplace
 )
-from obstacle_cache import update_net_obstacles_after_routing
+from obstacle_cache import update_net_obstacles_after_routing, refresh_net_obstacles
 from diff_pair_custody import (classify_diff_pair_failure, record_casualty,
                                record_pair_diag, blocker_names)
 from terminal_colors import RED, GREEN, RESET
@@ -876,7 +876,9 @@ def run_reroute_loop(
                 record_diff_pair_success(
                     pcb_data, result, ripped_pair, ripped_pair_name, config,
                     remaining_net_ids, routed_net_ids, routed_net_paths, routed_results,
-                    diff_pair_by_net_id, track_proximity_cache, layer_map
+                    diff_pair_by_net_id, track_proximity_cache, layer_map,
+                    working_obstacles=state.working_obstacles,            # #806
+                    net_obstacles_cache=state.net_obstacles_cache,
                 )
                 # Allow re-queuing if this pair gets ripped again later
                 queued_net_ids.discard(ripped_pair.p_net_id)
@@ -1099,6 +1101,9 @@ def run_reroute_loop(
                                 rerouted_pairs.add(ripped_pair_name)
                                 apply_polarity_swap(pcb_data, retry_result, pad_swaps, ripped_pair_name, polarity_swapped_pairs)
                                 add_route_to_pcb_data(pcb_data, retry_result, debug_lines=config.debug_lines)
+                                refresh_net_obstacles(state.working_obstacles, state.net_obstacles_cache,  # #806
+                                                      pcb_data, config,
+                                                      (ripped_pair.p_net_id, ripped_pair.n_net_id))
                                 from plane_fragility import fragility_on_copper_change  # #466
                                 fragility_on_copper_change(config, pcb_data,
                                                            retry_result.get('new_segments'),
@@ -1203,7 +1208,9 @@ def run_reroute_loop(
                             all_swap_vias, all_segment_modifications,
                             None, None,  # all_stubs_by_layer, stub_endpoints_by_layer
                             routed_net_paths, routed_results, diff_pair_by_net_id, layer_map,
-                            target_swaps, results=results, obstacle_cache=obstacle_cache)
+                            target_swaps, results=results, obstacle_cache=obstacle_cache,
+                            working_obstacles=state.working_obstacles,        # #806
+                            net_obstacles_cache=state.net_obstacles_cache)
 
                         if swap_success and swap_result:
                             print(f"  {GREEN}FALLBACK LAYER SWAP SUCCESS{RESET}")
@@ -1214,6 +1221,9 @@ def run_reroute_loop(
 
                             apply_polarity_swap(pcb_data, swap_result, pad_swaps, ripped_pair_name, polarity_swapped_pairs)
                             add_route_to_pcb_data(pcb_data, swap_result, debug_lines=config.debug_lines)
+                            refresh_net_obstacles(state.working_obstacles, state.net_obstacles_cache,  # #806
+                                                  pcb_data, config,
+                                                  (ripped_pair.p_net_id, ripped_pair.n_net_id))
                             from plane_fragility import fragility_on_copper_change  # #466
                             fragility_on_copper_change(config, pcb_data,
                                                        swap_result.get('new_segments'),
@@ -1278,7 +1288,9 @@ def run_reroute_loop(
                         record_diff_pair_success(
                             pcb_data, hyb, ripped_pair, ripped_pair_name, config,
                             remaining_net_ids, routed_net_ids, routed_net_paths, routed_results,
-                            diff_pair_by_net_id, track_proximity_cache, layer_map)
+                            diff_pair_by_net_id, track_proximity_cache, layer_map,
+                            working_obstacles=state.working_obstacles,    # #806
+                            net_obstacles_cache=state.net_obstacles_cache)
                         queued_net_ids.discard(ripped_pair.p_net_id)
                         queued_net_ids.discard(ripped_pair.n_net_id)
                         invalidate_obstacle_cache(obstacle_cache, ripped_pair.p_net_id)

--- a/py_router/rip_restore.py
+++ b/py_router/rip_restore.py
@@ -234,7 +234,17 @@ def try_terminal_restore(pcb_data: PCBData, config: GridRouteConfig,
             return 'full_open'
         return 'full'
 
-    stub_segs, stub_vias = _stub_subset(pcb_data, net_id, segments, vias)
+    # #806: a pair payload carries BOTH members' copper under two ids
+    # (ripped_ids); walking only `net_id`'s pads kept the P stub and dropped
+    # the N stub. Collect the escape subset per member id.
+    stub_segs, stub_vias = [], []
+    _seen_s, _seen_v = set(), set()
+    for _nid in sorted(own):
+        _ss, _sv = _stub_subset(pcb_data, _nid, segments, vias)
+        stub_segs += [s for s in _ss if id(s) not in _seen_s]
+        _seen_s.update(id(s) for s in _ss)
+        stub_vias += [v for v in _sv if id(v) not in _seen_v]
+        _seen_v.update(id(v) for v in _sv)
     kept_s = [s for s in stub_segs
               if not _copper_conflicts(pcb_data, config, own, [s], [])]
     kept_v = [v for v in stub_vias
@@ -263,22 +273,15 @@ def try_terminal_restore(pcb_data: PCBData, config: GridRouteConfig,
     # obstacles for every later net this run, the cache entry keeps
     # mirroring the board, and every map op is a complete-entry add/remove
     # -- #309 ref-counts balanced by construction.
-    if working_obstacles is not None and net_obstacles_cache is not None \
-            and net_id in net_obstacles_cache:
-        from obstacle_cache import (add_net_obstacles_from_cache,
-                                    precompute_net_obstacles,
-                                    remove_net_obstacles_from_cache)
-        remove_net_obstacles_from_cache(working_obstacles,
-                                        net_obstacles_cache[net_id])
-        pcb_data.segments.extend(kept_s)
-        pcb_data.vias.extend(kept_v)
-        net_obstacles_cache[net_id] = precompute_net_obstacles(
-            pcb_data, net_id, config)
-        add_net_obstacles_from_cache(working_obstacles,
-                                     net_obstacles_cache[net_id])
-    else:
-        pcb_data.segments.extend(kept_s)
-        pcb_data.vias.extend(kept_v)
+    # #806: EVERY member id of the payload (P and N of a pair), and a net
+    # with no entry yet gets one -- rip_up_net recomputes unconditionally, so
+    # any net with a payload has an entry; this mirrors that rather than
+    # extending pcb_data with copper the map never sees.
+    pcb_data.segments.extend(kept_s)
+    pcb_data.vias.extend(kept_v)
+    from obstacle_cache import refresh_net_obstacles
+    refresh_net_obstacles(working_obstacles, net_obstacles_cache, pcb_data,
+                          config, sorted(own))
     name = pcb_data.nets[net_id].name if net_id in pcb_data.nets else str(net_id)
     print(f"  RIP-RESTORE (#468): {name} remains UNROUTED -- kept only its "
           f"escape stub ({len(kept_s)} seg(s), {len(kept_v)} via(s)) so the "

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -4292,7 +4292,8 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
     if env_knobs.OBSTACLE_AUDIT:
         from obstacle_cache import run_obstacle_audit
         run_obstacle_audit(base_obstacles, state.working_obstacles,
-                           state.net_obstacles_cache)
+                           state.net_obstacles_cache,
+                           pcb_data=pcb_data, config=config)
 
     # #348 (glasgow /SCL): END-OF-RUN RECONCILIATION. Mid-run rip churn can
     # leave a victim net partially connected whose gap is trivially routable

--- a/py_router/route_diff.py
+++ b/py_router/route_diff.py
@@ -1216,6 +1216,16 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
     total_time += rq_time
     total_iterations += rq_iterations
 
+    # #806: content audit of the working map at the point its in-run consumers
+    # (a ripped victim's reroute, a terminal restore) have just used it --
+    # BEFORE sync_pcb_data_segments recomputes every routed net's entry at the
+    # end and hides whatever the loops left stale. Env-gated, prints only.
+    if env_knobs.OBSTACLE_AUDIT:
+        from obstacle_cache import run_obstacle_content_audit
+        run_obstacle_content_audit(state.working_obstacles,
+                                   state.net_obstacles_cache, pcb_data, config,
+                                   label="route_diff pre-sync")
+
     # ----- Casualties-only final reconciliation (depth 1) -------------------
     # Nets ripped during diff-pair routing whose reroute never landed used to
     # ship at ZERO copper with no custody. Restore-first: verify actually
@@ -1716,7 +1726,8 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
     if env_knobs.OBSTACLE_AUDIT:
         from obstacle_cache import run_obstacle_audit
         run_obstacle_audit(base_obstacles, state.working_obstacles,
-                           state.net_obstacles_cache, label="route_diff")
+                           state.net_obstacles_cache, label="route_diff",
+                           pcb_data=pcb_data, config=config)
 
     if return_results:
         return successful, failed, total_time, results_data

--- a/py_router/routing_context.py
+++ b/py_router/routing_context.py
@@ -723,7 +723,9 @@ def record_diff_pair_success(
     routed_results: Dict,
     diff_pair_by_net_id: Dict,
     track_proximity_cache: Dict,
-    layer_map: Dict
+    layer_map: Dict,
+    working_obstacles=None,
+    net_obstacles_cache: Dict = None,
 ):
     """
     Record a successful diff pair route.
@@ -741,8 +743,15 @@ def record_diff_pair_success(
         diff_pair_by_net_id: Dict mapping net ID to (pair_name, pair)
         track_proximity_cache: Cache of track proximity costs
         layer_map: Layer name to index mapping
+        working_obstacles / net_obstacles_cache: the run's persistent map and
+            per-net cache (#806). When given, both members' entries are
+            refreshed from the committed copper, the same contract
+            record_single_ended_success's callers keep. None = no map.
     """
     add_route_to_pcb_data(pcb_data, result, debug_lines=config.debug_lines)
+    from obstacle_cache import refresh_net_obstacles
+    refresh_net_obstacles(working_obstacles, net_obstacles_cache, pcb_data,
+                          config, (pair.p_net_id, pair.n_net_id))
 
     if pair.p_net_id in remaining_net_ids:
         remaining_net_ids.remove(pair.p_net_id)

--- a/tests/release/check_obstacle_balance.py
+++ b/tests/release/check_obstacle_balance.py
@@ -38,6 +38,17 @@ THE INVARIANTS, and which are enforced:
   B. no unbalanced cache OBJECT             ENFORCED
   C. no cells unaccounted for by any cache  ENFORCED
   D. raw add/remove op deltas cancel        RECORDED, NOT ENFORCED
+  E. map CONTENT matches the board (#806)   RECORDED, NOT ENFORCED here
+
+E is the invariant A/B/C cannot see: an entry computed before its net was
+routed and never refreshed is removed and re-added in BALANCE while the
+routed copper is invisible to every search on the map. `run_obstacle_content_
+audit` recomputes every cached net from pcb_data and queries the map cell by
+cell. It is enforced at ZERO on route_diff's PRE-SYNC line by
+tests/test_806_diff_pair_working_map.py (that is where the map's in-run
+consumers use it); the END-of-run line is recorded here only, because
+route.py's post-passes (reconciliation, plane finalize) legitimately move
+copper after the last map consumer ran.
 
 D is a REAL, SEPARATE, PRE-EXISTING leak, recorded here rather than dropped so
 it stays a change detector instead of folklore. It is NOT caused by the trim --
@@ -90,6 +101,18 @@ def parse_audit(text):
             r"^\s+cells ([+-]?\d+) vias ([+-]?\d+)\s+(\S+ @ \S+)", text, re.M),
         "repairs": sum(int(m) for m in
                        re.findall(r"\[RESIDENCY\] map repairs performed: (\d+)", text)),
+        # E (#806): CONTENT -- cells the board's copper owns that the working
+        # map does not block, per audit label. RECORDED, not enforced here:
+        # the end-of-run map of route.py legitimately drifts after its own
+        # post-passes; the pre-sync line of route_diff is enforced at zero by
+        # tests/test_806_diff_pair_working_map.py.
+        "content": [(lab, int(c), int(m), int(v), int(vm), int(se)) for
+                    lab, c, m, v, vm, se in re.findall(
+                        r"\[OBSTACLE CONTENT ([^\]]*)\] \d+ nets recomputed from "
+                        r"pcb_data: (\d+) cells checked, (\d+) NOT blocked in "
+                        r"working map; (\d+) via cells checked, (\d+) NOT "
+                        r"via-blocked; \d+ cells absent from their net's cache "
+                        r"entry \((\d+) stale entries\)", text)],
     }
 
 
@@ -110,6 +133,12 @@ def report(a):
               f" {len(a['raw_ops'])}")
         for cells, vias, site in a["raw_ops"][:4]:
             print(f"    cells {cells} vias {vias}  {site}")
+    if a["content"]:
+        print(f"  [recorded, invariant E not enforced here] content audits:"
+              f" {len(a['content'])}")
+        for lab, c, m, v, vm, se in a["content"]:
+            print(f"    {lab}: {m}/{c} cells NOT blocked, {vm}/{v} via cells NOT "
+                  f"via-blocked, {se} stale entries")
 
 
 def verdict(a):
@@ -309,6 +338,7 @@ def self_test():
   cache-object ledger BALANCED (leak, if any, is in raw ops below)
     cells +19529 vias +5984  add_segments_list @ phase3_routing.py:try_phase3_ripup:1117
 [RESIDENCY] map repairs performed: 3
+[OBSTACLE CONTENT route_diff pre-sync] 41 nets recomputed from pcb_data: 47448 cells checked, 30862 NOT blocked in working map; 71537 via cells checked, 31330 NOT via-blocked; 31613 cells absent from their net's cache entry (20 stale entries)
 """
     bad = """
 [OBSTACLE AUDIT] working - sum(caches) vs base (226 net caches removed)
@@ -335,6 +365,11 @@ def self_test():
     # D is RECORDED, never enforced: good text has a raw-op site and still passes.
     if not ga["raw_ops"]:
         fails.append("parser missed the recorded raw-op site")
+    # E (#806) is RECORDED here, never enforced: the good text carries the
+    # measured pre-fix dual_ipex line (30862 of 47448 NOT blocked) and still
+    # passes; the parser must read its real counts.
+    if ga["content"] != [("route_diff pre-sync", 47448, 30862, 71537, 31330, 20)]:
+        fails.append(f"parser misread the content audit: {ga['content']}")
     # An empty log is a BROKEN GATE, not a pass.
     ok_e, f_e = verdict(parse_audit(""))
     if ok_e or "BROKEN GATE" not in f_e[0]:

--- a/tests/test_806_diff_pair_working_map.py
+++ b/tests/test_806_diff_pair_working_map.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""#806: the diff-pair engine keeps the persistent working obstacle map in
+step with the copper it commits -- and rip/restore stays balanced AND correct
+for BOTH halves of a pair.
+
+WHAT WAS WRONG. route_diff builds one persistent working map + per-net cache
+(`state.working_obstacles` / `state.net_obstacles_cache`) and hands them to
+rip_up_net / restore_net / try_terminal_restore, but the diff loop's success
+paths never refreshed a routed pair's entry, so every entry stayed the
+PRE-ROUTE (stubs-only) one it was built with. The ref-count invariants A/B/C
+(tests/release/check_obstacle_balance.py) HELD throughout -- the stale entry
+was removed and re-added in balance -- while the map's CONTENT was wrong.
+Measured on dual_ipex_csi_interposer (recorded diff stage, 10 pairs, rip
+churn) at the point the map's in-run consumers use it: 30862 of 47448 cells
+the board's copper owned were NOT blocked, 31330 of 71537 via cells were not
+via-blocked, 20 stale entries (= every routed member). After the fix: 0 / 0
+/ 0 on the same population.
+
+THREE CHECKS, each asserting the REASON (tests/run_utils.check conventions):
+
+  1. end-to-end control: route the in-repo esp_prog USB pair with the audit
+     armed and read the PRE-SYNC content line (the one taken before
+     sync_pcb_data_segments recomputes every entry at the end and hides what
+     the loops left stale). Population is printed and asserted non-zero, so
+     a run that routed nothing cannot pass vacuously. A/B/C are asserted
+     with the release gate's own parser.
+  2. try_terminal_restore on a PAIR payload takes the 'stub' path and keeps
+     the N member's escape stub too (it walked only P's pads), and refreshes
+     BOTH members' map entries (it refreshed net_id's only).
+  3. stamp_result_copper stamps a result's own P/N via barrels (the victim-
+     reroute map inside try_fallback_layer_swap stamped GND vias only).
+
+NEGATIVE CONTROL (measured, fix stashed, instrumentation kept): check 1
+fails on E with 1180 of 23100 cells NOT blocked, 1420 of 23671 via cells NOT
+via-blocked and 2 stale entries (/D_P, /D_N: 1187 cells absent) while A/B/C
+still PASS; check 2 fails on "N escape stub restored" and "N entry grew";
+check 3 reports stamp_result_copper missing. Recorded in the PR.
+
+Run:  python3 tests/test_806_diff_pair_working_map.py [-v]
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TESTS = os.path.join(ROOT, 'tests')
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))
+sys.path.insert(0, TESTS)
+sys.path.insert(0, os.path.join(TESTS, 'release'))
+
+import numpy as np
+
+from run_utils import check as run_check, evidence, tool
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'esp_prog.kicad_pcb')
+NETS = ['/D_P', '/D_N']
+GEOM = ['--track-width', '0.2', '--diff-pair-gap', '0.25', '--clearance', '0.1778',
+        '--via-size', '0.45', '--via-drill', '0.3', '--no-gnd-vias']
+
+CONTENT_RE = re.compile(
+    r"\[OBSTACLE CONTENT (?P<label>[^\]]*)\] (?P<nets>\d+) nets recomputed from "
+    r"pcb_data: (?P<cells>\d+) cells checked, (?P<missing>\d+) NOT blocked in "
+    r"working map; (?P<vias>\d+) via cells checked, (?P<vmissing>\d+) NOT "
+    r"via-blocked; (?P<stale_cells>\d+) cells absent from their net's cache "
+    r"entry \((?P<stale_entries>\d+) stale entries\)")
+
+FAILS = []
+
+
+def check(name, cond, detail=""):
+    print(("  PASS  " if cond else "  FAIL  ") + name
+          + (f"  [{detail}]" if detail and not cond else ""))
+    if not cond:
+        FAILS.append(name)
+
+
+# ---------------------------------------------------------------------------
+# 1. End-to-end control on a real route (seconds).
+# ---------------------------------------------------------------------------
+def test_end_to_end(verbose):
+    print("\n[1] route_diff esp_prog with KICAD_OBSTACLE_AUDIT=1: pre-sync content")
+    evidence(BOARD, 'esp_prog board')
+    env = dict(os.environ, KICAD_OBSTACLE_AUDIT='1', KICAD_OBSTACLE_LEDGER='1')
+    with tempfile.TemporaryDirectory(prefix='t806_') as d:
+        out = os.path.join(d, 'esp_806.kicad_pcb')
+        argv = [sys.executable, '-X', 'utf8', tool('route_diff.py'), BOARD,
+                '--output', out, '--nets', *NETS, *GEOM]
+        # run_utils.check with accept=True: a traceback / ImportError is a
+        # BROKEN TEST, not a verdict.
+        import subprocess
+        r = subprocess.run(argv, capture_output=True, text=True, cwd=ROOT,
+                           env=env, encoding='utf-8', errors='replace')
+        txt = (r.stdout or '') + (r.stderr or '')
+        if verbose:
+            print(txt)
+        check("route_diff exited 0 (no traceback)", r.returncode == 0
+              and 'Traceback' not in txt, txt[-600:])
+        # The pair actually routed: the population must contain routed copper.
+        routed = []
+        for line in txt.splitlines():
+            if line.startswith('JSON_SUMMARY:'):
+                try:
+                    routed = json.loads(line[len('JSON_SUMMARY:'):]).get(
+                        'routed_diff_pairs', [])
+                except Exception:
+                    routed = []
+        check("the pair routed (population carries routed copper)", bool(routed),
+              f"routed_diff_pairs={routed}")
+        pre = [m for m in CONTENT_RE.finditer(txt) if 'pre-sync' in m.group('label')]
+        check("pre-sync content audit line present", len(pre) == 1,
+              f"found {len(pre)}")
+        if pre:
+            m = pre[0].groupdict()
+            cells, vias = int(m['cells']), int(m['vias'])
+            print(f"        population: {m['nets']} nets, {cells} cells, "
+                  f"{vias} via cells checked")
+            check("population non-zero (not vacuous)", cells > 0 and vias > 0)
+            check("E: 0 cells NOT blocked in the working map",
+                  int(m['missing']) == 0, f"{m['missing']} of {cells} NOT blocked")
+            check("E: 0 via cells NOT via-blocked",
+                  int(m['vmissing']) == 0, f"{m['vmissing']} of {vias}")
+            check("E: 0 stale cache entries (every routed member refreshed)",
+                  int(m['stale_entries']) == 0,
+                  f"{m['stale_entries']} stale entries, "
+                  f"{m['stale_cells']} cells absent from their entry")
+        # A/B/C with the RELEASE GATE's own parser and verdict.
+        from check_obstacle_balance import parse_audit, verdict
+        a = parse_audit(txt)
+        ok, failures = verdict(a)
+        check("A/B/C hold (release-gate verdict)", ok, "; ".join(failures))
+        check("ledger recorded events (instrument engaged)",
+              any(int(x) > 0 for x in re.findall(r"\[OBSTACLE LEDGER\] (\d+) events", txt)))
+
+
+# ---------------------------------------------------------------------------
+# 2. try_terminal_restore: both halves of a pair payload.
+# ---------------------------------------------------------------------------
+def _fixture():
+    from kicad_parser import parse_kicad_pcb, Segment
+    from routing_config import GridRouteConfig
+    pcb = parse_kicad_pcb(BOARD)
+    ids = {n.name: nid for nid, n in pcb.nets.items()}
+    p_id, n_id = ids['/D_P'], ids['/D_N']
+    layers = list(pcb.board_info.copper_layers)
+    config = GridRouteConfig(layers=layers, grid_step=0.05, track_width=0.2,
+                             clearance=0.1778, via_size=0.45, via_drill=0.3)
+
+    def pad(nid, ref):
+        return next(p for p in pcb.nets[nid].pads if p.component_ref == ref)
+
+    def seg(nid, x0, y0, x1, y1):
+        return Segment(start_x=x0, start_y=y0, end_x=x1, end_y=y1,
+                       width=0.2, layer='F.Cu', net_id=nid)
+
+    # A saved pair payload: a short escape stub off each U1 pad (walked by
+    # _stub_subset as "starts at a pad centre, <= 2 mm") plus a long run to
+    # the USB pad. A foreign track across both long runs makes the FULL
+    # restore conflict, so try_terminal_restore must take the 'stub' path.
+    pu, nu = pad(p_id, 'U1'), pad(n_id, 'U1')
+    pc, nc = pad(p_id, 'USB1'), pad(n_id, 'USB1')
+    p_stub = seg(p_id, pu.global_x, pu.global_y, pu.global_x, pu.global_y + 0.9)
+    n_stub = seg(n_id, nu.global_x, nu.global_y, nu.global_x, nu.global_y + 1.1)
+    p_long = seg(p_id, pu.global_x, pu.global_y + 0.9, pc.global_x, pc.global_y)
+    n_long = seg(n_id, nu.global_x, nu.global_y + 1.1, nc.global_x, nc.global_y)
+    foreign_id = next(nid for nid in pcb.nets if nid not in (p_id, n_id, 0))
+    xm = (pu.global_x + pc.global_x) / 2
+    pcb.segments.append(seg(foreign_id, xm, 98.0, xm, 106.0))
+    payload = {'new_segments': [p_stub, p_long, n_stub, n_long], 'new_vias': []}
+    pcb._rip_saved = {p_id: (payload, [p_id, n_id], True)}
+    return pcb, config, p_id, n_id, p_stub, n_stub, p_long, n_long
+
+
+def test_terminal_restore_pair(verbose):
+    print("\n[2] try_terminal_restore on a pair payload: N half + both map entries")
+    from obstacle_map import GridObstacleMap
+    from obstacle_cache import (precompute_net_obstacles, build_working_obstacle_map,
+                                remove_net_obstacles_from_cache)
+    from rip_restore import try_terminal_restore
+    pcb, config, p_id, n_id, p_stub, n_stub, p_long, n_long = _fixture()
+    base = GridObstacleMap(len(config.layers))
+    cache = {p_id: precompute_net_obstacles(pcb, p_id, config),
+             n_id: precompute_net_obstacles(pcb, n_id, config)}
+    working = build_working_obstacle_map(base, cache)
+    before = {nid: len(cache[nid].blocked_cells) + len(cache[nid].blocked_cell_spans)
+              for nid in cache}
+
+    outcome = try_terminal_restore(pcb, config, p_id, working, cache)
+    check("full restore conflicts -> 'stub' path taken", outcome == 'stub',
+          f"outcome={outcome!r}")
+    present = {id(s) for s in pcb.segments}
+    check("P escape stub restored", id(p_stub) in present)
+    check("N escape stub restored (was dropped: only P's pads were walked)",
+          id(n_stub) in present)
+    check("long runs NOT restored (they conflict)",
+          id(p_long) not in present and id(n_long) not in present)
+    for nid, label in ((p_id, 'P'), (n_id, 'N')):
+        fresh = precompute_net_obstacles(pcb, nid, config)
+        same = (np.array_equal(np.sort(cache[nid].blocked_cells, axis=0),
+                               np.sort(fresh.blocked_cells, axis=0))
+                and np.array_equal(np.sort(cache[nid].blocked_cell_spans, axis=0),
+                                   np.sort(fresh.blocked_cell_spans, axis=0)))
+        grew = (len(cache[nid].blocked_cells) + len(cache[nid].blocked_cell_spans)
+                > before[nid])
+        check(f"{label} cache entry refreshed from the board (== fresh recompute)",
+              same, f"entry rows {len(cache[nid].blocked_cells)}"
+                    f"+{len(cache[nid].blocked_cell_spans)} vs fresh "
+                    f"{len(fresh.blocked_cells)}+{len(fresh.blocked_cell_spans)}")
+        check(f"{label} entry grew by the restored stub", grew)
+    # A/B/C on this map: working - sum(caches) == base.
+    probe = working.clone_fresh()
+    for cd in cache.values():
+        remove_net_obstacles_from_cache(probe, cd)
+    bs, ps = base.get_stats(), probe.get_stats()
+    check("ref-counts balanced after the restore (working - caches == base)",
+          bs[:2] == ps[:2] and bs[7] == ps[7], f"base {bs} probe {ps}")
+
+
+# ---------------------------------------------------------------------------
+# 3. stamp_result_copper: a result's own via barrels are stamped.
+# ---------------------------------------------------------------------------
+def test_stamp_result_copper(verbose):
+    print("\n[3] stamp_result_copper stamps the pair's OWN via barrels")
+    from kicad_parser import Via, Segment
+    from routing_config import GridRouteConfig, GridCoord
+    from obstacle_map import GridObstacleMap
+    try:
+        from layer_swap_fallback import stamp_result_copper
+    except ImportError as e:
+        # Pre-fix tree: the stamp is still the inline GND-only filter. Report
+        # it as the defect it is, not as a crashed test.
+        check("layer_swap_fallback.stamp_result_copper exists (victim-reroute "
+              "map stamps the result's own vias)", False, str(e))
+        return
+    layers = ['F.Cu', 'B.Cu']
+    config = GridRouteConfig(layers=layers, grid_step=0.05, track_width=0.2,
+                             clearance=0.15, via_size=0.45, via_drill=0.3)
+    coord = GridCoord(config.grid_step)
+    p_via = Via(x=125.0, y=100.0, size=0.45, drill=0.3, layers=layers, net_id=16)
+    gnd_via = Via(x=130.0, y=100.0, size=0.45, drill=0.3, layers=layers, net_id=9)
+    segm = Segment(start_x=120.0, start_y=100.0, end_x=122.0, end_y=100.0,
+                   width=0.2, layer='F.Cu', net_id=16)
+    m = GridObstacleMap(len(layers))
+    stamp_result_copper(m, {'new_segments': [segm], 'new_vias': [p_via, gnd_via]},
+                        config, 0.0)
+    gx, gy = coord.to_grid(p_via.x, p_via.y)
+    check("P via cell is via-blocked (the GND-only filter dropped it)",
+          m.is_via_blocked(gx, gy))
+    check("P via cell is track-blocked on F.Cu", m.is_blocked(gx, gy, 0))
+    ggx, ggy = coord.to_grid(gnd_via.x, gnd_via.y)
+    check("GND via still stamped (what the old filter kept)", m.is_via_blocked(ggx, ggy))
+    sx, sy = coord.to_grid(121.0, 100.0)
+    check("result segment stamped", m.is_blocked(sx, sy, 0))
+    check("an empty result stamps nothing (no crash)",
+          stamp_result_copper(GridObstacleMap(2), {}, config, 0.0) is None)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('-v', '--verbose', action='store_true')
+    args = ap.parse_args()
+    test_end_to_end(args.verbose)
+    test_terminal_restore_pair(args.verbose)
+    test_stamp_result_copper(args.verbose)
+    print()
+    if FAILS:
+        print(f"FAIL: {len(FAILS)} check(s): " + "; ".join(FAILS))
+        return 1
+    print("PASS: #806 working-map content, pair terminal restore, via stamp")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Closes #806

## The defect, measured

#806's headline was that the diff-pair engine never maintains `state.working_obstacles` / `net_obstacles_cache`, so rip/restore removes a footprint that was never added. The measurement says the shape is slightly different, and worse than "under-block by an unbalanced remove": **the entries exist, and they are STALE.**

A pair's cache entry is built before the pair is routed (stubs only). Every commit site then puts copper on the board without refreshing it. `rip_up_net` / `restore_net` remove and re-add that stale entry *in balance*, so the ref-count invariants **A/B/C hold the whole way** — and the copper is invisible to every search on that map.

Measured on `dual_ipex_csi_interposer`'s recorded diff stage, at the **pre-sync point** (after the reroute loop, before `sync_pcb_data_segments` recomputes every entry and hides what the loops left stale — this is where the map's in-run consumers, a ripped victim's reroute and a terminal restore, have just used it):

| | cells NOT blocked | via cells NOT via-blocked | stale entries |
|---|---|---|---|
| before | **30862** / 47448 | **31330** / 71537 | 20 / 41 |
| after (7 commit sites) | 2418 / 47448 | 2066 / 71537 | 2 / 41 |
| after (+ hybrid-escape site) | **0** / 47448 | **0** / 71537 | **0** / 41 |

`picodvi` steps 3a / 3b / 3c: 1289 / 691 / 0 cells NOT blocked → **0 / 0 / 0**.

A/B/C were **balanced in every one of those runs** (97 ledger events on the dual board). That is the point: the existing invariants cannot see this, by construction.

## What was added: invariant E

`run_obstacle_content_audit` (in `obstacle_cache.py`, env-gated by the existing `KICAD_OBSTACLE_AUDIT`) recomputes every cached net's footprint from `pcb_data` and queries the working map cell by cell. It reports two distinct things: cells the board's copper owns that the **map** does not block (the under-block a later search walks through), and cells absent from the net's **own cache entry** (the bookkeeping staleness, independent of what else happens to cover a cell). `route_diff` runs it at the pre-sync point and at the end, `route.py` at the end. The release gate `tests/release/check_obstacle_balance.py` records E; it is **not enforced** there, because `route.py`'s end-of-run map legitimately drifts after its post-passes.

## The fix

`refresh_net_obstacles(working_obstacles, cache, pcb_data, config, net_ids)` spells the remove → recompute → add cycle once — the contract the single-ended loop has always kept — and is a no-op when the caller has no persistent map (GUI dry paths, tests). Every site that commits a pair's copper now calls it for **both** members:

- the diff loop's main, retry, layer-swap and hybrid-escape successes, and the multipoint merged success;
- the reroute loop's plain, retry, layer-swap and hybrid reroutes (`record_diff_pair_success` takes the map now, so custody's reroute inherits it);
- custody's piece-level partial restore.

Two related sites from the issue, both fixed with a measurement behind them:

- **`layer_swap_fallback.py`** rips and restores victims *inline* (not through `rip_up_net`/`restore_net`), so it refreshes at its rip, at its victim-reroute commit, and on both restore paths. Its victim-reroute map stamped **GND vias only**, dropping the just-routed pair's own P/N barrels — the pair's copper is not in `pcb_data` yet, so it must come from the result. `stamp_result_copper` now stamps the result's segments and *every* via it carries.
- **`rip_restore.try_terminal_restore`** walked only `net_id`'s pads and refreshed only that entry, so a pair payload kept the **P** stub and dropped the **N** stub. It now collects the escape subset per member id and refreshes both.

The third related site in the issue — `sync_pcb_data_segments` never syncing `pcb_data.vias` after length-matching meanders — is **left open**: it is a length-matching question, it needs an original-via keep-alive threaded through both callers, and the issue's own note that meandered via coordinates may never differ materially is still unverified. Nothing here depends on it.

## Tests

`tests/test_806_diff_pair_working_map.py` (wx-free, seconds): routes the in-repo `esp_prog` USB pair with the audit armed and asserts the **pre-sync content line at zero on a printed, non-zero population** (17 nets, 23100 cells, 23671 via cells) plus A/B/C through the release gate's own parser; drives `try_terminal_restore` on a pair payload and asserts both stubs restored with ref-counts balanced; asserts `stamp_result_copper` stamps the result's own P/N barrels.

**Negative control**, measured with the fix stashed and the instrumentation kept: test 1 fails on E (1180/23100 cells, 1420/23671 via cells, 2 stale entries) **while A/B/C pass**; test 2 fails on the N stub; test 3 reports the helper missing.

## Grading

- `dual_ipex_csi_interposer` and `picodvi`, both arms: **DRC clean on both boards in both arms; connectivity identical** (dual: all 20 pair members connected in both arms; picodvi: the same two single-ended-fallback members open in both). The fix removes an under-block; it does not move the route on these boards.
- Diff-pair test family, all rc=0: `test_tigard_usb_diff`, `test_qfn_csi_underpad_diff`, `test_766_intra_pair_every_pair`, `test_618_coupled_via_site_gate`, `test_764_needs_fanout`, `test_530_pair_gap_class_clearance`, `test_multipoint_diff_route`, `test_esp_prog_diff`.
- `tests/test_obstacle_map_balance.py`: PASS (route_diff cache-object ledger balanced; route_planes every via map balanced vs a fresh rebuild).
- `tests/gui_parity/test_manifest_plan_parity.py`: OK (no flags added). `tests/gui_parity/test_cli_postpass_coverage.py`: 0 failures (nothing added to a CLI `main()` — the fix is inside the shared engine functions, so `differential_gui.py` inherits it).
- `python3 tests/run_all.py --fast` on this branch: **376 passed, 0 failed, 0 timed out**, 165 skipped (804 s).

## Left open

- `routing_common.sync_pcb_data_segments` / `pcb_data.vias` after length matching (above).
- Invariant E is recorded but not enforced at the end of `route.py`, where post-pass drift is legitimate. The enforceable point is `route_diff`'s pre-sync line, which this PR pins at zero in a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWe4Edkc51Qu8xaQP6fuBH
