### PR TITLE
#672: a lone sliver is not a soft joint with itself -- and the sliver trim that measured worse ships opt-in

### DIFF
--- a/docs/api-pcb-modification.md
+++ b/docs/api-pcb-modification.md
@@ -102,10 +102,18 @@ the routing pipeline applies both so the model and the output file agree.
 > every landing site, #473): a protected net still loses a dead-end piece
 > SHORTER than `sliver_eps` when `check_net_connectivity` grades the net no
 > worse without it. The cleanup pipeline passes one routing cell
-> (`config.grid_step`): no A* span is shorter, so such a piece can only be
-> rip/restore/prune debris, and a stub shorter than a cell offers no landing
-> its root does not. Measured motive: a 0.02 mm sliver of a net retried across
-> an iteration ladder shipped 0.054 mm from a foreign track. The same change
+> (`config.grid_step`) -- but **only under `KICAD_SLIVER_TRIM=1`; the default
+> is 0.0, i.e. off**. The epsilon's rationale is sound (no A* span is shorter,
+> so such a piece can only be rip/restore/prune debris, and a stub shorter
+> than a cell offers no landing its root does not) and the motive is real
+> (a 0.02 mm sliver of a net retried across an iteration ladder shipped
+> 0.054 mm from a foreign track) -- but taking copper off a net the ladder is
+> still retrying MEASURED AS A LOST NET: on orangecrab's recorded route step,
+> paired from the same input board, `RAM_UDQS+` went from routed to
+> `failed_single` (run verdict 9 -> 10, 14 DRC either way), while the
+> self-pair half of this change alone reproduced the base copper EXACTLY
+> (6097 segments and 625 vias compared, all identical). It stays opt-in until
+> a corpus A/B says it pays. The same change
 > teaches every soft-joint detector (`_soft_joint_pairs`, `close_soft_joints`,
 > `check_drc`, `check_weird`) that the two ends of ONE segment are not a joint:
 > a lone sub-cap sliver used to pair with itself, which made

--- a/docs/api-pcb-modification.md
+++ b/docs/api-pcb-modification.md
@@ -97,6 +97,20 @@ the routing pipeline applies both so the model and the output file agree.
 > and the whole-net dead-end trim `sweep_dead_ends` (#84). The residual same-net
 > self-crossings are tracked in #162.
 
+> **#672 -- sub-cell slivers.** `sweep_dead_ends(..., sliver_eps=mm)` is the one
+> exception to its `protect_net_ids` exemption (nets with unfinished pads keep
+> every landing site, #473): a protected net still loses a dead-end piece
+> SHORTER than `sliver_eps` when `check_net_connectivity` grades the net no
+> worse without it. The cleanup pipeline passes one routing cell
+> (`config.grid_step`): no A* span is shorter, so such a piece can only be
+> rip/restore/prune debris, and a stub shorter than a cell offers no landing
+> its root does not. Measured motive: a 0.02 mm sliver of a net retried across
+> an iteration ladder shipped 0.054 mm from a foreign track. The same change
+> teaches every soft-joint detector (`_soft_joint_pairs`, `close_soft_joints`,
+> `check_drc`, `check_weird`) that the two ends of ONE segment are not a joint:
+> a lone sub-cap sliver used to pair with itself, which made
+> `_restore_soft_joint_bridges` put a just-removed dead neighbour back.
+
 ## `geometry_utils.py`
 
 Pure functions; no PCB context needed.

--- a/py_router/check_drc.py
+++ b/py_router/check_drc.py
@@ -2363,12 +2363,17 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
             # only an art-MEETS-art pair is dropped, never the actionable
             # TRACK end paired with art (#337, #722).
             _dangles[(s.net_id, s.layer)].append(
-                (x, y, s.width, getattr(s, 'graphic', False)))
+                (x, y, s.width, getattr(s, 'graphic', False), id(s)))
     for (net_id, layer), ends in _dangles.items():
         for i in range(len(ends)):
-            xi, yi, wi, gi = ends[i]
+            xi, yi, wi, gi, oi = ends[i]
             for j in range(i + 1, len(ends)):
-                xj, yj, wj, gj = ends[j]
+                xj, yj, wj, gj, oj = ends[j]
+                if oi == oj:
+                    # #672: a lone segment shorter than its cap is not a
+                    # joint with itself (same rule as the repair pass's
+                    # _soft_joint_pairs -- the two must agree).
+                    continue
                 gap = math.hypot(xi - xj, yi - yj)
                 cap = (wi + wj) / 2.0
                 if gi and gj:

--- a/py_router/check_weird.py
+++ b/py_router/check_weird.py
@@ -194,14 +194,17 @@ def _check_soft_joints(net_id, name, net_segs, net_vias, net_pads,
             # or make the art real copper). So a graphic is carried as a
             # flag and only an art-MEETS-art pair is dropped.
                 continue  # its copper reaches a via / own pad = legitimate
-            dangles[s.layer].append((x, y, s.width, getattr(s, 'graphic', False)))
+            dangles[s.layer].append((x, y, s.width, getattr(s, 'graphic', False),
+                                     id(s)))
 
     soft_pts = set()
     for layer, ends in dangles.items():
         for i in range(len(ends)):
-            xi, yi, wi, gi = ends[i]
+            xi, yi, wi, gi, oi = ends[i]
             for j in range(i + 1, len(ends)):
-                xj, yj, wj, gj = ends[j]
+                xj, yj, wj, gj, oj = ends[j]
+                if oi == oj:
+                    continue  # #672: one segment's own two ends are not a joint
                 gap = math.hypot(xi - xj, yi - yj)
                 cap = (wi + wj) / 2.0
                 if gi and gj:

--- a/py_router/cleanup_pipeline.py
+++ b/py_router/cleanup_pipeline.py
@@ -405,7 +405,12 @@ def run_post_route_cleanup(results, pcb_data, scope_net_ids, config, *,
         # slivers -- rip/restore/prune debris no landing needs. One routing
         # cell is the epsilon: no A* span is shorter. Plane-flow namespace
         # configs carry no grid_step, which disables the pass there.
-        sliver_eps=float(getattr(config, 'grid_step', 0.0) or 0.0))
+        # #672: OPT-IN (env_knobs.SLIVER_TRIM). One routing cell is the
+        # epsilon -- no A* span is shorter -- but trimming sub-cell debris
+        # off a net the ladder is still retrying measured as a LOST NET on
+        # orangecrab, so it is off by default. See the knob's note.
+        sliver_eps=(float(getattr(config, 'grid_step', 0.0) or 0.0)
+                    if env_knobs.SLIVER_TRIM else 0.0))
     counts['dead_ends_swept'] = _de_segs
     counts['dead_end_vias'] = _de_vias
     _trace('sweep')

--- a/py_router/cleanup_pipeline.py
+++ b/py_router/cleanup_pipeline.py
@@ -397,9 +397,15 @@ def run_post_route_cleanup(results, pcb_data, scope_net_ids, config, *,
               + (f", {_oi_nv} via(s)" if _oi_nv else "") + ")")
 
     _prog("dead-end sweep")
-    _de_segs, _de_vias, _de_strip = sweep_dead_ends(results, pcb_data, scope_net_ids,
-                                                    protect_net_ids=protect_net_ids,
-                                                    keep_input_copper=keep_input_copper)
+    _de_segs, _de_vias, _de_strip = sweep_dead_ends(
+        results, pcb_data, scope_net_ids,
+        protect_net_ids=protect_net_ids,
+        keep_input_copper=keep_input_copper,
+        # #672: protected (unfinished) nets still shed sub-CELL dead-end
+        # slivers -- rip/restore/prune debris no landing needs. One routing
+        # cell is the epsilon: no A* span is shorter. Plane-flow namespace
+        # configs carry no grid_step, which disables the pass there.
+        sliver_eps=float(getattr(config, 'grid_step', 0.0) or 0.0))
     counts['dead_ends_swept'] = _de_segs
     counts['dead_end_vias'] = _de_vias
     _trace('sweep')

--- a/py_router/env_knobs.py
+++ b/py_router/env_knobs.py
@@ -285,6 +285,15 @@ def refresh() -> None:
     g['TAP_CROSS_SCAN'] = _truthy('KICAD_TAP_CROSS_SCAN')
     g['OBSTACLE_AUDIT'] = _truthy('KICAD_OBSTACLE_AUDIT')
     g['PLANE_MAP_PARITY'] = _truthy('KICAD_PLANE_MAP_PARITY')
+    # #672 sub-cell sliver trim on PROTECTED (still-being-retried) nets.
+    # The self-pair half of #672 is a correctness fix and is always on;
+    # this half REMOVES COPPER, and measured on orangecrab's recorded
+    # route step (paired, same input board, chains otherwise identical)
+    # it cost a net: RAM_UDQS+ went from routed to failed_single, the
+    # run verdict 9 -> 10, while the self-pair fix alone reproduced the
+    # base copper EXACTLY (6097 segments and 625 vias compared, all
+    # identical). Opt-in until a corpus A/B says it pays.
+    g['SLIVER_TRIM'] = _opt_in('KICAD_SLIVER_TRIM')
     g['SETTLE_DEBUG'] = _truthy('KICAD_SETTLE_DEBUG')
     g['LEGACY_GATE_ORACLE'] = _truthy('KICAD_LEGACY_GATE_ORACLE')
     # route.py's end-of-run oracle summary check (one staged

--- a/py_router/pcb_modification.py
+++ b/py_router/pcb_modification.py
@@ -576,7 +576,7 @@ def close_soft_joints(results, pcb_data: PCBData, scope_net_ids, config,
             if at_anchor(s.net_id, x, y, s.layer, s.width):
                 continue
             dangles[(s.net_id, s.layer)].append(
-                (x, y, s.width, getattr(s, 'graphic', False)))
+                (x, y, s.width, getattr(s, 'graphic', False), id(s)))
 
     def clears(nid, x1, y1, x2, y2, layer, w):
         d = min(_seg_foreign_pad_dist(pcb_data, nid, x1, y1, x2, y2, layer,
@@ -601,11 +601,13 @@ def close_soft_joints(results, pcb_data: PCBData, scope_net_ids, config,
         for i in range(len(ends)):
             if i in used:
                 continue
-            xi, yi, wi, gi = ends[i]
+            xi, yi, wi, gi, oi = ends[i]
             for j in range(i + 1, len(ends)):
                 if j in used:
                     continue
-                xj, yj, wj, gj = ends[j]
+                xj, yj, wj, gj, oj = ends[j]
+                if oi == oj:
+                    continue  # #672: one segment's own two ends (see _soft_joint_pairs)
                 if gi and gj:
                     continue  # art meets art: #337 forbids touching either end
                 gap = math.hypot(xi - xj, yi - yj)
@@ -1535,13 +1537,21 @@ def _soft_joint_pairs(segs, vias, pads):
                 continue
             seen.add(key)
             dangles[s.layer].append((key, x, y, s.width,
-                                     getattr(s, 'graphic', False)))
+                                     getattr(s, 'graphic', False), id(s)))
     pairs = set()
     for layer, ends in dangles.items():
         for i in range(len(ends)):
-            ki, xi, yi, wi, gi = ends[i]
+            ki, xi, yi, wi, gi, oi = ends[i]
             for j in range(i + 1, len(ends)):
-                kj, xj, yj, wj, gj = ends[j]
+                kj, xj, yj, wj, gj, oj = ends[j]
+                if oi == oj:
+                    # #672: the two ends of ONE segment are not a joint --
+                    # the segment itself connects them. A lone sub-cap
+                    # sliver (a 0.02mm bridge whose neighbours were ripped
+                    # or pruned) used to pair with ITSELF here, which made
+                    # _restore_soft_joint_bridges read a clean removal as
+                    # "created a soft joint" and put a dead neighbour back.
+                    continue
                 if gi and gj:
                     # Art meets art: nothing anyone can act on (#337 forbids
                     # touching it), and check_weird/check_drc drop the same
@@ -1599,10 +1609,90 @@ def _restore_soft_joint_bridges(kept, removed, vias, pads):
     return kept, removed
 
 
+def _prune_sub_cell_slivers(net_id, prunable, vias, pads, zones, eps,
+                            anchor_segments=None, tol=None,
+                            zone_credit_validator=None,
+                            fill_anchor_validator=None, pcb_data=None):
+    """#672: drop a net's dead-end pieces SHORTER THAN ``eps`` -- and only
+    those -- when the net grades no worse without them.
+
+    This is the sliver-only twin of ``_safe_prune_net`` for nets the sweep
+    otherwise leaves untouched (the #473 unfinished-net exemption). The
+    candidate set is every dead end ``prune_dead_end_segments`` reports --
+    an ISOLATED fragment, a spur off a through-path or a T-junction, or a
+    stub off a pad/via -- filtered to length < ``eps``: a stub shorter than
+    one routing cell offers no landing its root does not already offer, so
+    the escape exemption the full sweep's per-commit mode keeps does not
+    apply. A piece whose free end lands on a same-net fill, or that bridges
+    two neighbours (no free end), is never a dead end and so never offered.
+    Locked and graphic copper is never removed. Each round is gated by the
+    authoritative ``check_net_connectivity`` (disconnected-pad count AND
+    component count
+    must not rise, the same two terms the dangling-via drop grades), first
+    as a batch, then per piece when the batch is refused; removing one
+    piece can expose the next, so it iterates to a fixpoint. Returns
+    ``(kept, removed)`` over ``prunable``."""
+    if tol is None:
+        from connectivity import COINCIDENCE_TOL
+        tol = COINCIDENCE_TOL
+    from check_connected import check_net_connectivity
+    anchor = list(anchor_segments or [])
+    _fa = fill_anchor_validator or zone_credit_validator
+
+    def _short(s):
+        return (math.hypot(s.end_x - s.start_x, s.end_y - s.start_y) < eps
+                and not getattr(s, 'graphic', False)
+                and not getattr(s, 'locked', False))
+
+    def _grade(segs):
+        r = check_net_connectivity(net_id, anchor + list(segs), vias, pads,
+                                   zones,
+                                   zone_credit_validator=zone_credit_validator,
+                                   pcb_data=pcb_data)
+        return (len(r.get('disconnected_pads') or []),
+                r.get('num_components') or 1)
+
+    kept = list(prunable)
+    removed = []
+    base = None
+    rejected = set()
+    for _ in range(64):
+        _, cands = prune_dead_end_segments(kept, anchor_segments=anchor or None,
+                                           vias=vias, pads=pads, tol=tol,
+                                           keep_terminal_escapes=False,
+                                           fill_anchor=_fa)
+        cands = [c for c in cands if _short(c) and id(c) not in rejected]
+        if not cands:
+            break
+        if base is None:
+            base = _grade(kept)
+        cid = {id(c) for c in cands}
+        trial = [s for s in kept if id(s) not in cid]
+        g = _grade(trial)
+        if g[0] <= base[0] and g[1] <= base[1]:
+            kept = trial
+            removed.extend(cands)
+            continue
+        progress = False
+        for c in cands:
+            trial = [s for s in kept if s is not c]
+            g = _grade(trial)
+            if g[0] <= base[0] and g[1] <= base[1]:
+                kept = trial
+                removed.append(c)
+                progress = True
+            else:
+                rejected.add(id(c))
+        if not progress:
+            break
+    return kept, removed
+
+
 def sweep_dead_ends(results, pcb_data: PCBData, scope_net_ids=None,
                     protect_net_ids=None,
                     tol: float = None,
-                    keep_input_copper: bool = False) -> Tuple[int, int, List[Segment]]:
+                    keep_input_copper: bool = False,
+                    sliver_eps: float = 0.0) -> Tuple[int, int, List[Segment]]:
     """Final whole-net dead-end sweep, after routing has settled (issue #84).
 
     the per-commit self-intersection clean (removed #159) used to fix
@@ -1627,6 +1717,20 @@ def sweep_dead_ends(results, pcb_data: PCBData, scope_net_ids=None,
     it still anchors degree / T-junction / connectivity decisions (as
     ``anchor_segments``) but is never a removal candidate — for chained flows
     whose earlier stages author escape stubs that a later run must still see.
+
+    ``sliver_eps`` (#672) is the one exception to the ``protect_net_ids``
+    exemption: a PROTECTED net still loses a dead-end piece SHORTER THAN
+    ``sliver_eps`` -- an isolated fragment, or a spur off a through-path --
+    when the authoritative connectivity check grades the net no worse without
+    it. The caller passes one routing cell (``config.grid_step``): no A* span
+    is shorter than a cell, so such a piece can only be rip/restore/prune
+    debris, and it is too short to be the landing site the exemption exists
+    to keep (its root, which stays, is). Measured motive: a 0.02mm same-net
+    sliver of a net being retried across an iteration ladder shipped
+    overlapping a foreign track as a real seg-seg violation, because the
+    exemption kept it every step. A piece with no free end (bridging two
+    neighbours, or pad-to-track) or whose free end lands on a fill is never
+    a candidate; a removal the gate refuses is kept. 0 disables the pass.
     Returns ``(segments_removed, vias_removed, original_segments_to_remove)``.
     """
     from collections import defaultdict
@@ -1658,7 +1762,8 @@ def sweep_dead_ends(results, pcb_data: PCBData, scope_net_ids=None,
         # ERODED failed nets across a chain (the #473 USB_D_N trunk decay:
         # rip gaps -> fragments graded dead -> swept -> next step starts
         # with less copper, repeat).
-        if protect_net_ids and net_id in protect_net_ids:
+        _protected = bool(protect_net_ids and net_id in protect_net_ids)
+        if _protected and not (sliver_eps and sliver_eps > 0):
             kept_segs_by_net[net_id] = net_segs
             continue
         vias = [v for v in pcb_data.vias if v.net_id == net_id]
@@ -1682,12 +1787,21 @@ def sweep_dead_ends(results, pcb_data: PCBData, scope_net_ids=None,
             # connectivity in the pruner) instead of offering it as a candidate.
             anchor = [s for s in net_segs if id(s) not in routed_seg_ids]
             net_segs = [s for s in net_segs if id(s) in routed_seg_ids]
-        kept, removed = _safe_prune_net(net_id, net_segs, vias, pads, zones,
-                                        anchor_segments=anchor or None,
-                                        zone_credit_validator=_zcv,
-                                        fill_anchor_validator=_zfa,
-                                        aggressive=True, tol=tol,
-                                        pcb_data=pcb_data)
+        if _protected:
+            # #672: the exemption keeps every landing site; a sub-cell
+            # sliver is not one. Everything else on this net stays.
+            kept, removed = _prune_sub_cell_slivers(
+                net_id, net_segs, vias, pads, zones, sliver_eps,
+                anchor_segments=anchor or None, tol=tol,
+                zone_credit_validator=_zcv, fill_anchor_validator=_zfa,
+                pcb_data=pcb_data)
+        else:
+            kept, removed = _safe_prune_net(net_id, net_segs, vias, pads, zones,
+                                            anchor_segments=anchor or None,
+                                            zone_credit_validator=_zcv,
+                                            fill_anchor_validator=_zfa,
+                                            aggressive=True, tol=tol,
+                                            pcb_data=pcb_data)
         # #319: never delete a coincident bridge and leave a soft joint.
         kept, removed = _restore_soft_joint_bridges(list(kept) + anchor, removed,
                                                     vias, pads)

--- a/tests/test_672_rip_fragments.py
+++ b/tests/test_672_rip_fragments.py
@@ -218,6 +218,59 @@ kept, removed = _prune_sub_cell_slivers(NET, net_segs, [], pcb4.pads_by_net[NET]
 check(n4['link'] in kept and n4['sliver'] in removed and n4['spur'] in removed,
       "_prune_sub_cell_slivers: keeps the only-link piece, drops the two debris pieces")
 
+# ---------------------------------------------------------------------------
+# The PIPELINE default: the trim is OPT-IN, and the knob is really read.
+# Measured on orangecrab (paired route step, same input board): trimming a
+# still-being-retried net's sub-cell debris cost RAM_UDQS+ (verdict 9 -> 10),
+# while the self-pair fix alone reproduced the base copper exactly. So the
+# pipeline must pass 0.0 unless KICAD_SLIVER_TRIM is set. Observe the VALUE
+# the call site computes, not the source text: a source grep would pass on a
+# gate wired to the wrong knob.
+import importlib
+_seen = {}
+import pcb_modification as _pm
+_real_sweep = _pm.sweep_dead_ends
+
+
+def _spy(*a, **kw):
+    _seen['eps'] = kw.get('sliver_eps')
+    return _real_sweep(*a, **kw)
+
+
+import cleanup_pipeline as _cp
+import env_knobs as _ek
+for _want, _val in (('off', None), ('on', '1')):
+    if _val is None:
+        os.environ.pop('KICAD_SLIVER_TRIM', None)
+    else:
+        os.environ['KICAD_SLIVER_TRIM'] = _val
+    _ek.refresh()
+    importlib.reload(_cp)
+    _cp.sweep_dead_ends = _spy
+    _seen.clear()
+    pcb5, n5 = _fixture()
+
+    from routing_config import GridRouteConfig as _GRC
+    cfg5 = _GRC(track_width=0.15, clearance=0.15, via_size=0.4,
+                via_drill=0.2, grid_step=GRID, layers=['F.Cu', 'B.Cu'])
+    try:
+        _cp.run_post_route_cleanup([], pcb5, {NET}, cfg5,
+                                   protect_net_ids={NET})
+    except Exception as _e:            # the pipeline wants more of a board
+        _seen.setdefault('exc', repr(_e))
+    if 'eps' not in _seen:             # a vacuous pass is not a pass
+        check(False, f"pipeline reached sweep_dead_ends ({_want}) "
+                     f"[aborted: {_seen.get('exc')}]")
+    elif _want == 'off':
+        check(_seen.get('eps') in (0.0, 0),
+              f"pipeline default: sliver trim OFF (eps={_seen.get('eps')!r})")
+    else:
+        check(bool(_seen.get('eps')),
+              f"KICAD_SLIVER_TRIM=1 is READ: the pipeline passes a real "
+              f"epsilon (eps={_seen.get('eps')!r})")
+os.environ.pop('KICAD_SLIVER_TRIM', None)
+_ek.refresh()
+
 print()
 if FAILS:
     print(f"FAILED ({len(FAILS)}):")

--- a/tests/test_672_rip_fragments.py
+++ b/tests/test_672_rip_fragments.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Issue #672: sub-cell same-net slivers left by rip/restore/prune churn must
+not ship as real seg-seg violations against foreign copper.
+
+Two defects, each pinned with a negative control so the test cannot pass
+vacuously:
+
+1. SELF-PAIR in every soft-joint detector. A "soft joint" is two DANGLING free
+   ends of one net whose caps overlap (gap in (SOFT_JOINT_MIN_GAP, cap)). None
+   of the four detectors excluded the two ends of ONE segment, so a lone
+   sliver shorter than its cap -- a 0.02mm close_soft_joints bridge whose
+   neighbours were ripped or pruned -- paired with ITSELF. Consequences:
+     * ``_restore_soft_joint_bridges`` read a clean removal of the neighbours
+       as "created a soft joint" and put a DEAD neighbour back (the very
+       segment a pass had just removed for grazing foreign copper);
+     * ``close_soft_joints`` offered to bridge the sliver to itself;
+     * ``check_drc`` / ``check_weird`` reported a phantom
+       ``segment-endpoint-gap`` on a lone segment.
+   Negative control: two distinct segments whose free ends are 0.02mm apart
+   still pair, and removing a genuine bridge is still reverted (#319).
+
+2. The #473 unfinished-net exemption kept EVERY piece of a net still being
+   retried -- including a 0.02mm isolated sliver 0.054mm from a foreign
+   track. ``sweep_dead_ends(sliver_eps=grid_step)`` now drops sub-CELL dead
+   ends on protected nets when the authoritative connectivity check grades
+   the net no worse; the epsilon is one routing cell because no A* span is
+   shorter, so such a piece can only be debris, and a stub shorter than a
+   cell offers no landing its root does not. Negative controls: a real
+   landing stub (0.5mm, longer than a cell) on the same protected net stays;
+   a sub-cell piece with no free end (BRIDGING two neighbours, or pad-to-
+   track) stays; a sliver that is the net's only link between two pads stays
+   (connectivity gate); ``sliver_eps=0`` restores the old keep-everything
+   behaviour.
+
+    python3 tests/test_672_rip_fragments.py
+"""
+import math
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+for _d in ('', 'py_router', 'py_tools', 'rust_router'):
+    sys.path.insert(0, os.path.join(_ROOT, _d))
+sys.path.insert(0, _HERE)
+
+from kicad_parser import BoardInfo  # noqa: E402
+from synth import make_pad, make_seg, make_pcb, make_net  # noqa: E402
+from pcb_modification import (_soft_joint_pairs, _restore_soft_joint_bridges,  # noqa: E402
+                              sweep_dead_ends, _prune_sub_cell_slivers)
+
+W = 0.0762          # the orangecrab track width the issue was observed at
+GRID = 0.05         # its routing cell
+NET = 7
+LAYER = 'F.Cu'
+FAILS = []
+
+
+def check(cond, msg):
+    print(('  ok   ' if cond else '  FAIL ') + msg)
+    if not cond:
+        FAILS.append(msg)
+
+
+def seg(x1, y1, x2, y2, net=NET, w=W, layer=LAYER):
+    return make_seg(x1, y1, x2, y2, net_id=net, width=w, layer=layer)
+
+
+def _len(s):
+    return math.hypot(s.end_x - s.start_x, s.end_y - s.start_y)
+
+
+# --------------------------------------------------------------------------
+print("1. soft-joint detectors: one segment's two ends are not a joint")
+A = seg(160.0, 102.87, 163.99, 102.87)
+B = seg(163.99, 102.87, 164.01, 102.87)          # the 0.02mm bridge
+C = seg(164.01, 102.87, 168.0, 102.87)
+check(_len(B) < W, f"fixture: bridge {_len(B):.3f}mm is shorter than its cap {W}")
+check(_soft_joint_pairs([B], [], []) == set(),
+      "a lone sub-cap sliver forms NO soft joint with itself")
+check(len(_soft_joint_pairs([A, C], [], [])) == 1,
+      "NEGATIVE CONTROL: two distinct dangles 0.02mm apart still pair")
+kept, removed = _restore_soft_joint_bridges([B], [A, C], [], [])
+check(len(kept) == 1 and len(removed) == 2,
+      "removing both neighbours of a sliver no longer resurrects one of them")
+kept, removed = _restore_soft_joint_bridges([A, C], [B], [], [])
+check(len(kept) == 3 and not removed,
+      "NEGATIVE CONTROL (#319): removing a genuine bridge is still reverted")
+
+# The same rule in check_drc / check_weird, through their real entry points.
+import tempfile  # noqa: E402
+from synth import board_text, write_board  # noqa: E402
+
+
+def _board_with(segs):
+    """A KiCad board text holding `segs` on net 1, written to a temp file
+    (run_drc parses text). `board_text` takes the body as a TEXT blob."""
+    segtxt = ''.join(
+        f'\t(segment (start {s.start_x} {s.start_y}) (end {s.end_x} {s.end_y}) '
+        f'(width {s.width}) (layer "{s.layer}") (net 1))\n' for s in segs)
+    return write_board(board_text(segtxt, nets=(0, 1)),
+                       os.path.join(tempfile.mkdtemp(prefix='t672_'), 'b.kicad_pcb'))
+
+
+try:
+    from check_drc import run_drc
+    # Gap 0.05: above COINCIDENCE_TOL (0.02, which run_drc demotes to a
+    # warning) and below the 0.1 cap, so a pair here is a returned VIOLATION.
+    lone = _board_with([seg(10.0, 10.0, 10.05, 10.0, net=1, w=0.1)])
+    two = _board_with([seg(9.0, 10.0, 9.975, 10.0, net=1, w=0.1),
+                       seg(10.025, 10.0, 11.0, 10.0, net=1, w=0.1)])
+    r_lone = run_drc(lone, clearance=0.1, quiet=True)
+    r_two = run_drc(two, clearance=0.1, quiet=True)
+
+    def _sj(r):
+        return [x for x in (r or []) if isinstance(x, dict)
+                and x.get('type') == 'segment-endpoint-gap']
+    check(not _sj(r_lone), "check_drc: no phantom soft joint on a lone sliver")
+    check(len(_sj(r_two)) == 1,
+          "NEGATIVE CONTROL: check_drc still reports a real soft joint")
+except Exception as e:  # the detector must be reachable, or this half is vacuous
+    check(False, f"check_drc soft-joint probe did not run: {type(e).__name__}: {e}")
+
+# --------------------------------------------------------------------------
+print("2. sweep_dead_ends: sub-cell debris on a PROTECTED net")
+FOREIGN = 9
+
+
+def _fixture():
+    """Net NET: pad P1 at x=150 -> trunk -> pad P2 at x=170, still OPEN
+    (a third pad P3 at (160,110) is unrouted, so the net is protected). Debris
+    on it: an isolated 0.02mm sliver at y=102.87 (0.13mm from a foreign
+    track at y=103.00, i.e. a 0.054mm graze at W=0.0762 / clearance 0.0889)
+    and a second isolated 0.03mm piece. (A spur off a trunk's INTERIOR that
+    is shorter than the trunk's half-width is not debris: its free end lies
+    inside the trunk's copper and _point_anchored counts it as landed, so
+    no dead-end pass sees it.) Legit copper that must survive: a 0.5mm
+    landing stub off the trunk, a 0.04mm piece BRIDGING two trunk halves, a
+    0.03mm piece touching P2, and a 0.02mm piece that is the ONLY link
+    between two halves of a second branch reaching P1 -- the connectivity
+    gate must refuse that one."""
+    p1 = make_pad(NET, 150.0, 100.0, ref='U1', num='1', size_x=0.3, size_y=0.3)
+    p2 = make_pad(NET, 170.0, 100.0, ref='U2', num='1', size_x=0.3, size_y=0.3)
+    p3 = make_pad(NET, 160.0, 110.0, ref='U3', num='1', size_x=0.3, size_y=0.3)
+    p4 = make_pad(NET, 150.0, 96.0, ref='U4', num='1', size_x=0.3, size_y=0.3)
+    trunk_a = seg(150.0, 100.0, 159.98, 100.0)
+    bridge = seg(159.98, 100.0, 160.02, 100.0)              # 0.04, bridging
+    trunk_b = seg(160.02, 100.0, 169.97, 100.0)
+    pad_touch = seg(169.97, 100.0, 170.0, 100.0)             # 0.03, touches P2
+    landing = seg(165.0, 100.0, 165.0, 100.5)                # 0.5mm spur: a landing site
+    spur = seg(156.0, 101.5, 156.03, 101.5)                  # 0.03 isolated: debris
+    sliver = seg(163.99, 102.87, 164.01, 102.87)             # the issue's fragment
+    # second branch: P1 -> (150,98) ... 0.02 link ... -> P4 at (150,96)
+    br1 = seg(150.0, 100.0, 150.0, 98.01)
+    link = seg(150.0, 98.01, 150.0, 97.99)                   # 0.02, load-bearing
+    br2 = seg(150.0, 97.99, 150.0, 96.0)
+    foreign = seg(163.30, 103.0, 168.60, 103.0, net=FOREIGN)
+    segs = [trunk_a, bridge, trunk_b, pad_touch, landing, spur, sliver,
+            br1, link, br2, foreign]
+    bi = BoardInfo(layers={}, copper_layers=['F.Cu', 'B.Cu'],
+                   board_bounds=(140.0, 90.0, 180.0, 120.0))
+    pcb = make_pcb(board_info=bi, segments=segs,
+                   nets={NET: make_net(NET, 'RAM_ODT', pads=[p1, p2, p3, p4]),
+                         FOREIGN: make_net(FOREIGN, 'RAM_D11')},
+                   pads_by_net={NET: [p1, p2, p3, p4], FOREIGN: []},
+                   zones=[])
+    names = {'trunk_a': trunk_a, 'bridge': bridge, 'trunk_b': trunk_b,
+             'pad_touch': pad_touch, 'landing': landing, 'spur': spur,
+             'sliver': sliver, 'br1': br1, 'link': link, 'br2': br2,
+             'foreign': foreign}
+    return pcb, names
+
+
+def _conn(pcb):
+    from check_connected import check_net_connectivity
+    r = check_net_connectivity(NET, [s for s in pcb.segments if s.net_id == NET],
+                               [], pcb.pads_by_net[NET], [], pcb_data=pcb)
+    return len(r.get('disconnected_pads') or []), r.get('num_components') or 1
+
+
+pcb, n = _fixture()
+results = [{'new_segments': [n['sliver'], n['spur'], n['landing']], 'new_vias': []}]
+before = _conn(pcb)
+check(before[0] == 1, f"fixture: net is OPEN before (P3 unrouted): {before}")
+segs_removed, vias_removed, strip = sweep_dead_ends(
+    results, pcb, scope_net_ids={NET}, protect_net_ids={NET}, sliver_eps=GRID)
+left = {id(s) for s in pcb.segments}
+check(id(n['sliver']) not in left, "isolated 0.02mm sliver on the protected net is dropped")
+check(id(n['spur']) not in left, "second isolated 0.03mm piece is dropped")
+check(id(n['landing']) in left, "NEGATIVE CONTROL: the 0.5mm landing stub stays (protection holds)")
+check(id(n['bridge']) in left, "NEGATIVE CONTROL: a sub-cell piece BRIDGING two neighbours stays")
+check(id(n['pad_touch']) in left, "NEGATIVE CONTROL: a sub-cell piece touching a pad stays")
+check(id(n['link']) in left, "NEGATIVE CONTROL: a sub-cell piece that is the only link stays")
+check(id(n['foreign']) in left, "foreign copper untouched")
+check(_conn(pcb) == before, f"connectivity unchanged by the sweep: {before} -> {_conn(pcb)}")
+check(all(id(s) in left for s in results[0]['new_segments']),
+      "write-list mirrors the board (dropped pieces left the result too)")
+check(segs_removed == 2, f"reported count is the two pieces ({segs_removed})")
+
+pcb2, n2 = _fixture()
+sweep_dead_ends([{'new_segments': [n2['sliver']], 'new_vias': []}], pcb2,
+                scope_net_ids={NET}, protect_net_ids={NET}, sliver_eps=0.0)
+check(id(n2['sliver']) in {id(s) for s in pcb2.segments},
+      "NEGATIVE CONTROL: sliver_eps=0 keeps everything on a protected net (old behaviour)")
+
+pcb3, n3 = _fixture()
+sweep_dead_ends([{'new_segments': [n3['sliver']], 'new_vias': []}], pcb3,
+                scope_net_ids={NET}, protect_net_ids=None, sliver_eps=GRID)
+l3 = {id(s) for s in pcb3.segments}
+check(id(n3['sliver']) not in l3 and id(n3['landing']) not in l3,
+      "unprotected net: the full sweep still takes the sliver AND the dead landing stub")
+
+# The helper alone, on the load-bearing link: refused by the gate.
+pcb4, n4 = _fixture()
+net_segs = [s for s in pcb4.segments if s.net_id == NET]
+kept, removed = _prune_sub_cell_slivers(NET, net_segs, [], pcb4.pads_by_net[NET],
+                                        [], GRID, pcb_data=pcb4)
+check(n4['link'] in kept and n4['sliver'] in removed and n4['spur'] in removed,
+      "_prune_sub_cell_slivers: keeps the only-link piece, drops the two debris pieces")
+
+print()
+if FAILS:
+    print(f"FAILED ({len(FAILS)}):")
+    for f in FAILS:
+        print("  - " + f)
+    sys.exit(1)
+print("test_672_rip_fragments: all checks passed")


### PR DESCRIPTION
Closes #672

## Mechanism

Sub-0.1 mm same-net fragments (0.02 mm on the issue's board) survived cleanup and shipped 0.054 mm from a foreign track. Two general defects, both in the shared engine (GUI inherits them):

1. **Every soft-joint detector paired a lone segment with ITSELF.** A soft joint is two dangling free ends whose caps overlap (gap in `(0.010, (w1+w2)/2)`). None of the four detectors (`pcb_modification._soft_joint_pairs`, `close_soft_joints`, `check_drc.run_drc`, `check_weird`) excluded the two ends of ONE segment, so a lone sliver shorter than its cap -- e.g. a 0.02 mm `close_soft_joints` bridge whose neighbours were ripped or pruned -- formed a "joint" with itself. The load-bearing consequence: `_restore_soft_joint_bridges` (#319) read a clean removal of the neighbours as "created a soft joint" and **put a just-removed dead neighbour back** -- the segment a pass had removed for grazing foreign copper. Measured on the base tree with the A-B-C fixture from the issue's coordinates: self-pairs on lone B = 1, kept after removing A and C = 2 (A resurrected); after the fix 0 and 1. The other sites bridged a segment to itself or reported a phantom `segment-endpoint-gap`.
2. **The #473 unfinished-net exemption kept every piece of a net still being retried** -- exactly the net an iteration ladder rips and reroutes each step -- so a sub-grid sliver on it could never be swept, whatever minted it.

## Fix

- Each dangle carries its owning segment id; same-owner pairs are skipped in all four detectors (they stay byte-identical, as their docstrings require).
- `sweep_dead_ends(..., sliver_eps=)` (default 0 = old behaviour); the cleanup pipeline passes **one routing cell (`config.grid_step`)**. On a protected net, `_prune_sub_cell_slivers` offers only dead ends shorter than a cell (isolated fragments, spurs, stubs) and removes them only when `check_net_connectivity` grades the net no worse (disconnected pads AND component count; batch, then per piece, to a fixpoint). Epsilon rationale: no A* span is shorter than a cell, so such a piece can only be rip/restore/prune debris, and a stub shorter than a cell offers no landing its root does not. Never candidates: pieces with no free end (bridging / pad-to-track), pieces landing on a fill, locked and graphic copper. Plane-flow namespace configs carry no `grid_step`, so they are untouched. No new CLI post-pass (the change is inside `sweep_dead_ends`; `test_cli_postpass_coverage` unchanged).
- Docs: `docs/api-pcb-modification.md` note.

## Reproduction, honestly

The issue's board (`modern_0817_tuned/orangecrab/m_iter6.kicad_pcb`) is not on disk and its recipe lived in a session scratchpad. Census (pad-free segments < 0.1 mm, foreign overlap at 0.0889 mm, T-junction aware) over the recorded orangecrab chain: step2 / iter1 / iter2 / step4 = 4358 / 3755 / 3907 / 4049 segments, 486 / 408 / 444 / 492 short pieces, **0 foreign overlaps on every board**; and 845 SEGMENT-SEGMENT entries across 60 corpus DRC logs, 221 with a sub-0.1 mm participant, all in human-routed `*original*` logs or ordinary 0.0707 mm diagonal staircases. A fresh route step with current code from `step2a_diffpairs` (r0): 4617 segments, 625 short pad-free pieces, 10 dead-ends, 0 isolated, 0 overlaps. So the defect was reproduced **synthetically** (the self-pair mechanism is deterministic and measured on the base tree), not on a replay; the exact rip site that minted the issue's 0.02 mm piece is not pinned.

## Tests

`tests/test_672_rip_fragments.py` (wx-free, ~2 s, 21 checks): lone sliver forms no pair / two genuine dangles still pair / removing both neighbours no longer resurrects one / a genuine bridge's removal is still reverted (#319) / `check_drc` no phantom on a lone sliver and still reports a real joint / on a PROTECTED net the 0.02 mm isolated sliver and a 0.03 mm piece are dropped while the 0.5 mm landing stub, a bridging sub-cell piece, a pad-touching piece and an only-link piece all stay, connectivity unchanged, write-list mirrored, `sliver_eps=0` keeps everything, unprotected nets unchanged. Base tree fails the self-pair checks (change detector).

## Gates

- `tests/gui_parity/test_manifest_plan_parity.py`: OK.
- `tests/gui_parity/test_cli_postpass_coverage.py`: 8 registered, 0 unreachable, 0 failures.
- `python3 tests/run_all.py --fast` on this branch: **377 passed, 0 failed, 0 timed out**, 164 skipped (412 s).
- Paired A/B, splitflap_driver (`route.py --nets '*'` defaults, before = exported base 2828476c, after = this branch): identical -- 1422 segments / 168 vias, DRC OK, connected OK, census 49 pad-free short pieces (all bridging), 0 overlaps, both arms.
- Paired one-step A/B, orangecrab: three-arm attribution, all from the same fresh current-code `r0` board with the recorded chain's flags (clearance 0.0889, `--max-ripup 5`), chains otherwise identical:

| arm | verdict | failed_single | DRC | conn issues | copper |
|---|---|---|---|---|---|
| base (`2828476c`) | 9 | 8 | 14 | 11 | 6097 seg / 625 via |
| self-pair fix only | **9** | 8 (the same nets) | 14 | 11 | **6097 seg / 625 via** |
| self-pair + sliver trim | 10 | 9 (**+RAM_UDQS+**) | 14 | 12 | 6007 seg / 626 via |

The self-pair fix is not merely "the same counts" — it is the same copper: 6097 segments and 625 vias compared field by field (start, end, layer, net, width; via x/y/size/drill/net), **all identical**. Population stated because `0 differences` means nothing without it.

The sliver trim is the entire difference. The dead-end sweep trimmed 5 pieces in the base and self-pair arms and **42** with the trim on, and `RAM_UDQS+` — a net the ladder ripped as PRE-EXISTING and requeued — went from routed to `failed_single`. **So the trim ships opt-in** (`KICAD_SLIVER_TRIM=1`, default 0.0 = old behaviour), by the rule `KICAD_ORACLE_SUMMARY` records a few lines above it in `env_knobs`: disclosure may depend on the environment, copper may not. The self-pair fix stays on: it is the load-bearing correctness fix, and it is measurably inert.

## Open

- **The sliver trim is off by default and unproven.** The corpus A/B that would decide it has not been run; the knob and its connectivity gate are there for it.
- The minting rip site is not pinned (no board). The birth-watch trace machinery (`KICAD_ROUTE_TRACE=1`) is the way to catch it when the ladder recipe resurfaces.
- `_prune_sub_cell_slivers` is not applied to the in-loop `trim_net_stub_debris` (its multipoint exemption is load-bearing, see its docstring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
