### PR TITLE
#837 follow-up: quench's absent-rule count said six while nine were absent (the commit that missed #873's merge)

### DIFF
--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -70,13 +70,21 @@ EPS_IMPROVE = 1e-6
 #: re-typing it: a rule added here enters the A/B signal automatically, and a
 #: rule removed to flatter a row trips a test rather than passing quietly.
 #:
-#: The other six floorplan rules are deliberately absent, each for its own
+#: The other NINE floorplan rules are deliberately absent, each for its own
 #: reason -- `must_lock` and `edge_connector` are enforced by FREEZING the ref
 #: (no pose satisfies or violates them), `zone_side` is invariant under every
-#: move this engine can make, `envelope` is a claim about the intent file,
+#: move this engine can make and `assembly_side` (#837) is invariant for the
+#: same reason one level up, `envelope` is a claim about the intent file,
 #: `decap_distance` is graded in a currency this engine does not carry (pad
-#: centroid to an inflated pad bbox, not courtyard to courtyard), and
-#: `legality` is a whole-board budget rather than a per-pose predicate.
+#: centroid to an inflated pad bbox, not courtyard to courtyard),
+#: `decap_ungraded` and `decap_pin_distance` are claims about what the GRADE
+#: covers rather than about any pose, and `legality` is a whole-board budget
+#: rather than a per-pose predicate.
+#:
+#: The count said "six" and named six while nine were absent: `decap_ungraded`
+#: (#794) and `decap_pin_distance` (#705) arrived without being added here, and
+#: #837 made it three. Stated as a number AND an enumeration so the next
+#: addition is visibly missing from both.
 INTENT_ENFORCED_RULES = ('zone_containment', 'zone_exclusive', 'keepout')
 
 


### PR DESCRIPTION
## The commit that missed #873's merge

`INTENT_ENFORCED_RULES` names the three floorplan rules the quench gates on, and
the comment under it explains why the others are not enforced. It said **"the
other six"** and enumerated six — while **nine** were absent.

It was already wrong by two before #837: `decap_ungraded` (#794) and
`decap_pin_distance` (#705) both arrived without being added here.
`assembly_side` (#837) made it three.

Stated as a number **and** an enumeration now, with the drift recorded, so the
next rule added to `RULES` is visibly missing from both rather than from
neither.

Comment-only — no line outside a `#:` block changes, and the diff is 12
insertions / 4 deletions in one file.

## Why this is a separate PR

It was the last commit on `fix/837-836-714-board-sides`. #873 was merged at
`b802c0a4` and this landed on the branch a moment later, so it is not in `main`:

```
$ git merge-base --is-ancestor 5828b839 upstream/main
NOT in main
$ grep -c "The other NINE floorplan rules" py_placer/placement/quench.py
0
```

`Refs #837` rather than `Closes #837` — that issue is already closed by #873's
merge, so there is nothing here for a closing keyword to act on. Flagging that
explicitly because the linkage is the thing worth getting right.

## Verified

`test_702_quench_intent_gate.py`, `test_549_floorplan_schema.py` and
`test_837_assembly_sides.py` all pass on `upstream/main` @ `4b487455` with this
applied. The first two are the gates that read `RULES` / `INTENT_ENFORCED_RULES`
directly.

Refs #837
