### PR TITLE
#876: 30 tests were defined where nothing could run them, and 7 files reported OK

### DIFF
--- a/tests/test_431_render_placement.py
+++ b/tests/test_431_render_placement.py
@@ -383,35 +383,6 @@ def test_ignore_nets_reproduces_place_optimize_exactly():
         shutil.rmtree(d, ignore_errors=True)
 
 
-TESTS = [
-    test_moved_parts_finds_the_tracked_delta,
-    test_rects_come_from_the_optimizers_own_model,
-    test_metrics_are_the_quenchs_own_numbers,
-    test_far_side_of_a_through_hole_part_is_its_drilled_pad_box,
-    test_union_view_pads_and_floors,
-    test_clusters_are_deterministic_and_ordered,
-    test_zoom_group_resolves_exactly_like_route_py,
-    test_no_edge_cuts_board_reports_oob_unavailable,
-    test_toggles_measurably_change_the_image,
-    test_ghosts_and_arrows_need_a_before_board,
-    test_rendering_is_reproducible_in_this_environment,
-    test_per_side_panels_differ_on_a_two_sided_board,
-    test_the_caption_carries_the_verdict_not_just_a_title,
-    test_cli_writes_a_png_and_a_machine_readable_summary,
-    test_an_unplaced_board_still_renders_and_says_so,
-    test_ratsnest_nets_draws_only_the_named_nets,
-    test_ratsnest_nets_uses_the_shared_net_filter,
-    test_ratsnest_nets_cli_reports_an_empty_match,
-    test_single_panel_accepts_a_directory_target,
-    test_ignore_nets_reproduces_place_optimize_exactly,
-]
-
-
-if __name__ == '__main__':
-    for t in TESTS:
-        print(f"--- {t.__name__}")
-        t()
-    print("ALL PASS")
 
 
 # --- run-4 G additions: file JSON, instrument echo, checklist, -o siblings --
@@ -455,9 +426,24 @@ def test_json_out_writes_a_file_with_instrument_and_checklist():
         cl = doc['checklist']
         # run-6: 'b_overlap_pairs' was renamed to its honest channel name
         # (it carried pad CLEARANCE pairs) and the body channel was added.
+        #
+        # The set is EXACT on purpose -- a checklist key that appears or
+        # vanishes changes what a reader of this JSON is told. It grew by five
+        # while this test was unregistered and therefore dead (#876): the
+        # run-23 courtyard channel added four (one of them the
+        # always-present `census_error`, None when clean) and the
+        # cross-side stack census
+        # one. Re-stated rather than relaxed to a subset, because a subset
+        # check is what would have let the drift through in the first place.
         assert set(cl) == {'a_off_outline', 'b_pad_clearance_pairs',
                            'b_body_overlap_pairs',
-                           'c_hole_conflicts', 'c_locked_refs', 'd_moved'}
+                           'b_courtyard_advisory_pairs',
+                           'b_courtyard_blocking_pairs',
+                           'b_courtyard_census_error',
+                           'b_courtyard_overlap_mm2',
+                           'b_cross_side_stacks',
+                           'c_hole_conflicts', 'c_locked_refs', 'd_moved'}, (
+            f'checklist keys moved to {sorted(cl)}')
         assert cl['d_moved'] == {'moved': 22, 'expected': 22, 'match': True}
         assert doc['moved_refs'] and all(
             set(m) == {'reference', 'dist'} for m in doc['moved_refs'])
@@ -582,3 +568,43 @@ def test_legality_findings_cached_once_per_model():
                 'pad_conflict_pairs_refs', 'hole_conflict_pairs_refs',
                 'locked_refs'):
         assert key in a
+
+
+TESTS = [
+    test_moved_parts_finds_the_tracked_delta,
+    test_rects_come_from_the_optimizers_own_model,
+    test_metrics_are_the_quenchs_own_numbers,
+    test_far_side_of_a_through_hole_part_is_its_drilled_pad_box,
+    test_union_view_pads_and_floors,
+    test_clusters_are_deterministic_and_ordered,
+    test_zoom_group_resolves_exactly_like_route_py,
+    test_no_edge_cuts_board_reports_oob_unavailable,
+    test_toggles_measurably_change_the_image,
+    test_ghosts_and_arrows_need_a_before_board,
+    test_rendering_is_reproducible_in_this_environment,
+    test_per_side_panels_differ_on_a_two_sided_board,
+    test_the_caption_carries_the_verdict_not_just_a_title,
+    test_cli_writes_a_png_and_a_machine_readable_summary,
+    test_an_unplaced_board_still_renders_and_says_so,
+    test_ratsnest_nets_draws_only_the_named_nets,
+    test_ratsnest_nets_uses_the_shared_net_filter,
+    test_ratsnest_nets_cli_reports_an_empty_match,
+    test_single_panel_accepts_a_directory_target,
+    test_ignore_nets_reproduces_place_optimize_exactly,
+    # Defined AFTER the runner and never registered until now (#876):
+    test_per_side_png_target_writes_sibling_files,
+    test_json_out_writes_a_file_with_instrument_and_checklist,
+    test_expect_moved_mismatch_is_reported_not_fatal,
+    test_focus_without_summary_json_clusters_legality_findings,
+    test_net_pattern_report_counts_declared_against_matched,
+    test_a_net_list_that_missed_is_reported_in_the_json_and_on_stderr,
+    test_a_fully_matching_net_list_stays_quiet,
+    test_legality_findings_cached_once_per_model,
+]
+
+
+if __name__ == '__main__':
+    for t in TESTS:
+        print(f"--- {t.__name__}")
+        t()
+    print("ALL PASS")

--- a/tests/test_458_loop_steering.py
+++ b/tests/test_458_loop_steering.py
@@ -577,35 +577,6 @@ def test_negative_screen_is_rejected():
     raise AssertionError("--ratsnest-screen -1 must be rejected")
 
 
-TESTS = [
-    test_swap_cap_held_while_displacement_widens,
-    test_swap_cap_held_when_quench_finds_nothing,
-    test_swap_cap_flag_overrides_the_base,
-    test_rotate_and_swap_flags_reach_quench,
-    test_kwargs_match_the_real_quench_signature,
-    test_swap_cap_above_displacement_is_rejected,
-    test_reconciliation_recoveries_are_not_counted_as_failures,
-    test_effort_counters_are_summed_across_passes,
-    test_blockers_are_unioned_across_both_passes,
-    test_pad_pairs_keep_the_whole_board_denominator,
-    test_pad_pairs_survive_a_sub_run_without_the_keys,
-    test_empty_structured_blockers_do_not_regress_to_the_regex,
-    test_blockers_filtered_to_still_failed_when_sub_run_omits_the_key,
-    test_single_summary_run_is_unchanged,
-    test_a_net_the_reconciliation_broke_is_reported_and_weighed,
-    test_aborted_reconciliation_falls_back_to_the_first_summary,
-    test_reconciliation_without_a_summary_degrades_to_the_first,
-    test_merge_returns_none_without_a_summary,
-    test_route_py_is_invoked_by_absolute_path_in_utf8_mode,
-    test_nonzero_exit_raises_and_names_the_real_error,
-    test_missing_summary_raises_with_the_log_tail,
-    test_screen_skips_the_routing_run_on_a_regressed_candidate,
-    test_screen_off_by_default_routes_every_candidate,
-    test_screen_lets_an_improving_candidate_through,
-    test_screen_is_inert_when_quench_reports_nothing,
-    test_loop_passes_metrics_out_to_quench,
-    test_negative_screen_is_rejected,
-]
 
 
 
@@ -635,6 +606,40 @@ def test_target_nets_gives_the_loop_something_to_move_on_a_clean_board():
         extra_targets=['QSPI_SD0', 'QSPI_SD3'])
     assert m2['failed_nets'] == ['QSPI_SD0', 'QSPI_SD3'], m2['failed_nets']
     print("  PASS: --target-nets seeds the move set, leaves the failure count alone")
+
+
+TESTS = [
+    test_swap_cap_held_while_displacement_widens,
+    test_swap_cap_held_when_quench_finds_nothing,
+    test_swap_cap_flag_overrides_the_base,
+    test_rotate_and_swap_flags_reach_quench,
+    test_kwargs_match_the_real_quench_signature,
+    test_swap_cap_above_displacement_is_rejected,
+    test_reconciliation_recoveries_are_not_counted_as_failures,
+    test_effort_counters_are_summed_across_passes,
+    test_blockers_are_unioned_across_both_passes,
+    test_pad_pairs_keep_the_whole_board_denominator,
+    test_pad_pairs_survive_a_sub_run_without_the_keys,
+    test_empty_structured_blockers_do_not_regress_to_the_regex,
+    test_blockers_filtered_to_still_failed_when_sub_run_omits_the_key,
+    test_single_summary_run_is_unchanged,
+    test_a_net_the_reconciliation_broke_is_reported_and_weighed,
+    test_aborted_reconciliation_falls_back_to_the_first_summary,
+    test_reconciliation_without_a_summary_degrades_to_the_first,
+    test_merge_returns_none_without_a_summary,
+    test_route_py_is_invoked_by_absolute_path_in_utf8_mode,
+    test_nonzero_exit_raises_and_names_the_real_error,
+    test_missing_summary_raises_with_the_log_tail,
+    test_screen_skips_the_routing_run_on_a_regressed_candidate,
+    test_screen_off_by_default_routes_every_candidate,
+    test_screen_lets_an_improving_candidate_through,
+    test_screen_is_inert_when_quench_reports_nothing,
+    test_loop_passes_metrics_out_to_quench,
+    test_negative_screen_is_rejected,
+    # Defined below this list and never registered (#876):
+    test_target_nets_gives_the_loop_something_to_move_on_a_clean_board,
+]
+
 
 if __name__ == '__main__':
     for fn in TESTS:

--- a/tests/test_549_floorplan_cli.py
+++ b/tests/test_549_floorplan_cli.py
@@ -384,6 +384,9 @@ TESTS = [
     test_the_summary_carries_the_keys_a_caller_branches_on,
     test_the_full_json_carries_the_measured_numbers,
     test_emit_writes_no_board_and_touches_nothing,
+    # Defined but never registered, so never run (#876):
+    test_a_round_board_now_grades_normally,
+    test_grading_knobs_resolve_from_the_board_and_are_disclosed,
 ]
 
 

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -362,10 +362,124 @@ def test_the_scanners_still_match_something():
           f'{joins} literal join(s)')
 
 
+def _guard_end(tree):
+    """Line of the last top-level `if __name__ == '__main__':` block's end."""
+    end = None
+    for node in tree.body:
+        if (isinstance(node, ast.If)
+                and isinstance(node.test, ast.Compare)
+                and isinstance(node.test.left, ast.Name)
+                and node.test.left.id == '__name__'):
+            end = max(end or 0, node.end_lineno or node.lineno)
+    return end
+
+
+def _defines_tests(node):
+    """Does this top-level node define test(s), and under what name?"""
+    if isinstance(node, ast.ClassDef):
+        if any(isinstance(b, ast.FunctionDef) and b.name.startswith('test')
+               for b in node.body):
+            return f'class {node.name}'
+    elif (isinstance(node, ast.FunctionDef)
+          and node.name.startswith('test')):
+        return f'def {node.name}'
+    return None
+
+
+def test_no_test_is_defined_after_its_own_runner():
+    """A test defined BELOW `if __name__ == '__main__':` never runs.
+
+    The guard executes the runner and the runner exits, so anything defined
+    after it does not exist yet -- `unittest.main()` discovers what is bound
+    at the moment it is called, and a hand-rolled `for t in TESTS` cannot list
+    a function defined later. Either way the file reports OK and `run_all`
+    records a PASS, which is indistinguishable from having checked.
+
+    Measured when this gate was written (#876): FIVE files, 27 dead tests.
+    `test_run6_body_overlap.py` ran 9 of 20 and hid four stale corpus
+    assertions; `test_431_render_placement.py` had 8 unregistered functions,
+    one of which was red the moment it ran. This is the same failure as
+    `test_every_test_in_this_file_is_registered` below, one file wider -- that
+    one caught the pattern in THIS file, and nothing looked at the others.
+    """
+    bad = {}
+    for rel, src in _py_files(only_tests=True):
+        try:
+            tree = ast.parse(src)
+        except SyntaxError:                                # pragma: no cover
+            continue
+        end = _guard_end(tree)
+        if end is None:
+            continue
+        after = [name for node in tree.body
+                 if node.lineno > end
+                 for name in [_defines_tests(node)] if name]
+        if after:
+            bad[rel] = after
+    assert not bad, (
+        'test(s) defined after the runner that would have run them, so they '
+        'never run:\n  ' + '\n  '.join(
+            f'{rel}: {", ".join(names)}' for rel, names in sorted(bad.items()))
+        + '\n  Move `if __name__ == ...` to the END of the file.')
+    print(f'  PASS: no test defined after its own runner, over '
+          f'{sum(1 for _ in _py_files(only_tests=True))} test file(s)')
+
+
+def test_every_test_is_registered_in_its_files_own_list():
+    """A file with a module-level `TESTS = [...]` must list every test it
+    defines.
+
+    The registry idiom is hand-maintained, so a function added to the bottom
+    of such a file runs only if someone also adds it to the list -- and one
+    that never runs is indistinguishable from one that passes. Measured at
+    #876: `test_431_render_placement.py` defined 28 tests and registered 20.
+
+    Scoped to files that HAVE such a list: a unittest file has no registry and
+    is covered by the gate above instead.
+    """
+    bad = {}
+    for rel, src in _py_files(only_tests=True):
+        try:
+            tree = ast.parse(src)
+        except SyntaxError:                                # pragma: no cover
+            continue
+        listed = None
+        for node in tree.body:
+            if (isinstance(node, ast.Assign)
+                    and any(getattr(t, 'id', None) == 'TESTS'
+                            for t in node.targets)
+                    and isinstance(node.value, (ast.List, ast.Tuple))):
+                listed = {e.id for e in node.value.elts
+                          if isinstance(e, ast.Name)}
+        if listed is None:
+            continue
+        # `TESTS.append(...)` is an accepted way to register one late.
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == 'append'
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == 'TESTS'):
+                listed |= {a.id for a in node.args if isinstance(a, ast.Name)}
+        defined = {node.name for node in tree.body
+                   if isinstance(node, ast.FunctionDef)
+                   and node.name.startswith('test')}
+        missing = sorted(defined - listed)
+        if missing:
+            bad[rel] = missing
+    assert not bad, (
+        'test(s) defined but absent from their file\'s own TESTS list, so '
+        'they never run:\n  ' + '\n  '.join(
+            f'{rel}: {", ".join(names)}' for rel, names in sorted(bad.items())))
+    print('  PASS: every registry-style test file lists all its tests')
+
+
 TESTS = [
     test_wk_dependent_tests_are_declared,
     test_no_test_spawns_a_script_that_moved,
     test_the_scanners_still_match_something,
+    test_no_test_is_defined_after_its_own_runner,
+    test_every_test_is_registered_in_its_files_own_list,
 ]
 
 

--- a/tests/test_run4_instruments.py
+++ b/tests/test_run4_instruments.py
@@ -152,8 +152,6 @@ class TestB3GradedAtAlways(unittest.TestCase):
             self.assertEqual(bs._graded_at(r.stdout), 0.15)
 
 
-if __name__ == '__main__':
-    unittest.main()
 
 
 class TestRun5RemainingBanners(unittest.TestCase):
@@ -182,3 +180,7 @@ class TestRun5RemainingBanners(unittest.TestCase):
                 self.assertTrue(r.stdout.startswith('CMD: '),
                                 f'{tool}: {r.stdout[:120]!r}')
                 self.assertIn('EXIT=', r.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_run4_reconstruct.py
+++ b/tests/test_run4_reconstruct.py
@@ -161,8 +161,6 @@ class TestF5FullCensus(unittest.TestCase):
             self.assertIn('all listed', r.stdout)
 
 
-if __name__ == '__main__':
-    unittest.main()
 
 
 class TestF2EdgeBands(unittest.TestCase):
@@ -368,3 +366,7 @@ class TestRepairEdgeSeating(unittest.TestCase):
             pcb = parse_kicad_pcb(out)
             j1 = pcb.footprints['J1']
             self.assertLess(j1.x, 34.0, 'J1 must end at the west edge')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_run6_body_overlap.py
+++ b/tests/test_run6_body_overlap.py
@@ -171,8 +171,6 @@ class TestIntentKey(unittest.TestCase):
             floorplan.load_intent(p)
 
 
-if __name__ == '__main__':
-    unittest.main()
 
 
 class TestContainment(unittest.TestCase):
@@ -283,7 +281,12 @@ class TestContainment(unittest.TestCase):
         correct -- fiducials under a connector body."""
         boards = sorted(glob.glob(os.path.join(ROOT, 'kicad_files',
                                                '*.kicad_pcb')))
-        self.assertGreaterEqual(len(boards), 30)
+        # 22, not 30. The floor is an anti-vacuity guard -- a sweep
+        # over an empty glob passes every assertion below it -- and it
+        # was written when kicad_files/ held 30+ boards. The corpus is
+        # 22 tracked now, and these four tests were defined after this
+        # file's own runner (#876) so nothing ever reported the drift.
+        self.assertGreaterEqual(len(boards), 22)
         gating = {os.path.basename(b): [(q.a, q.b, q.waiver)
                                         for q in _grade(b)['containment_blocking_pairs']]
                   for b in boards}
@@ -299,11 +302,19 @@ class TestContainment(unittest.TestCase):
         self.assertEqual(len(g['fab_unjudged_refs']), g['fab_unjudged'])
 
     def test_the_bodyless_hole_is_exactly_what_was_measured(self):
-        """144 of 1583 footprints draw no .Fab body, and that is the FINAL
-        answer, not a TODO.
+        """140 footprints draw no .Fab body, and that is the FINAL answer,
+        not a TODO.
 
-        Measured over all 33 boards: every one of those 144 draws ZERO .Fab
-        geometric primitives -- there is no footprint whose .Fab geometry the
+        It was 144 over 33 boards. The count is a census of whatever
+        `kicad_files/` holds, and as the next test says, the generated
+        fixtures that made up 11 of those 33 come and go -- the corpus is 22
+        tracked boards now. This test was defined after this file's own
+        runner (#876), so it never ran and the drift was never reported. The
+        INVARIANT below, which does not depend on corpus membership, is the
+        claim that actually licenses the conclusion.
+
+        Measured over the boards present: every one of those 140 draws ZERO
+        .Fab geometric primitives -- there is no footprint whose .Fab geometry the
         parser fails to read. So a tolerance or polygon-closure fix moves
         nothing (313 footprints DO have non-closing .Fab chains, tigard Q1
         among them, and all 313 are judged correctly because a bbox is a
@@ -316,9 +327,14 @@ class TestContainment(unittest.TestCase):
         """
         boards = sorted(glob.glob(os.path.join(ROOT, 'kicad_files',
                                                '*.kicad_pcb')))
-        self.assertGreaterEqual(len(boards), 30)
+        # 22, not 30. The floor is an anti-vacuity guard -- a sweep
+        # over an empty glob passes every assertion below it -- and it
+        # was written when kicad_files/ held 30+ boards. The corpus is
+        # 22 tracked now, and these four tests were defined after this
+        # file's own runner (#876) so nothing ever reported the drift.
+        self.assertGreaterEqual(len(boards), 22)
         total_unjudged = sum(_grade(b)['fab_unjudged'] for b in boards)
-        self.assertEqual(total_unjudged, 144,
+        self.assertEqual(total_unjudged, 140,
                          f'corpus fab_unjudged moved to {total_unjudged}; if '
                          f'that was deliberate, re-measure the 4-pair census '
                          f'below and this number together')
@@ -340,7 +356,12 @@ class TestContainment(unittest.TestCase):
         from placement.parser import extract_fab_sides
         boards = sorted(glob.glob(os.path.join(ROOT, 'kicad_files',
                                                '*.kicad_pcb')))
-        self.assertGreaterEqual(len(boards), 30)
+        # 22, not 30. The floor is an anti-vacuity guard -- a sweep
+        # over an empty glob passes every assertion below it -- and it
+        # was written when kicad_files/ held 30+ boards. The corpus is
+        # 22 tracked now, and these four tests were defined after this
+        # file's own runner (#876) so nothing ever reported the drift.
+        self.assertGreaterEqual(len(boards), 22)
         readable, checked = [], 0
         for b in boards:
             sides = extract_fab_sides(b)
@@ -372,7 +393,12 @@ class TestContainment(unittest.TestCase):
         from placement.legality import CONTAINMENT_FRAC
         boards = sorted(glob.glob(os.path.join(ROOT, 'kicad_files',
                                                '*.kicad_pcb')))
-        self.assertGreaterEqual(len(boards), 30)
+        # 22, not 30. The floor is an anti-vacuity guard -- a sweep
+        # over an empty glob passes every assertion below it -- and it
+        # was written when kicad_files/ held 30+ boards. The corpus is
+        # 22 tracked now, and these four tests were defined after this
+        # file's own runner (#876) so nothing ever reported the drift.
+        self.assertGreaterEqual(len(boards), 22)
         census = []
         for b in boards:
             for p in _grade(b)['pairs']:
@@ -383,3 +409,7 @@ class TestContainment(unittest.TestCase):
         offenders = [c for c in census
                      if c[3] >= CONTAINMENT_FRAC and not c[4]]
         self.assertEqual(offenders, [], offenders)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_run6_body_overlap.py
+++ b/tests/test_run6_body_overlap.py
@@ -15,6 +15,12 @@ import unittest
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+#: run_utils is imported for the TRACKED corpus (see `_corpus`),
+#: which would otherwise mark this file integration and drop it
+#: from `--fast`. These checks spawn nothing.
+RUN_ALL_FAST_OK = True
 
 sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # placement split
 sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # placement split
@@ -30,12 +36,30 @@ def _grade(board, **kw):
                               pcb_file=board, **kw)
 
 
+
+#: The TRACKED corpus, not a glob of `kicad_files/`.
+#:
+#: The glob is not deterministic: other tests generate boards into that
+#: directory and they are gitignored, so `git status` stays clean while the
+#: count moves. Measured on one tree, one commit, minutes apart -- 22 boards
+#: before a suite run and 32 after, which took the `fab_unjudged` census below
+#: from 140 to 154 with nothing in the repo having changed. The four sweeps
+#: here were defined after this file's own runner (#876) and had never run, so
+#: nothing reported it.
+#:
+#: `run_utils.corpus_boards()` shells `git ls-files`, which is why
+#: `RUN_ALL_FAST_OK` is declared above: the run_utils import would otherwise
+#: classify this file as integration and `--fast` would stop running it.
+def _corpus():
+    import run_utils
+    return run_utils.corpus_boards()
+
+
 class TestCorpusCalibration(unittest.TestCase):
     def test_all_healthy_boards_grade_zero_blocking(self):
         """THE calibration gate: pad_intersection must be 0 on every corpus
         board, or the channel may not gate anywhere (run-6 invariant)."""
-        boards = sorted(glob.glob(os.path.join(ROOT, 'kicad_files',
-                                               '*.kicad_pcb')))
+        boards = _corpus()
         # The TRACKED corpus is 22 boards; generated fixture chains add more on a
         # developed tree. Guard against an empty or half-checked-out corpus, not
         # against the generated surplus (a fresh clone has exactly 22).
@@ -279,8 +303,7 @@ class TestContainment(unittest.TestCase):
         """0 boards may gate. The only corpus containments are orangecrab's
         FID2/J5 (frac 1.000) and FID1/J4 (0.867), both marker_class and both
         correct -- fiducials under a connector body."""
-        boards = sorted(glob.glob(os.path.join(ROOT, 'kicad_files',
-                                               '*.kicad_pcb')))
+        boards = _corpus()
         # 22, not 30. The floor is an anti-vacuity guard -- a sweep
         # over an empty glob passes every assertion below it -- and it
         # was written when kicad_files/ held 30+ boards. The corpus is
@@ -325,8 +348,7 @@ class TestContainment(unittest.TestCase):
         is a FALLBACK body for bodyless parts: measured, that adds 77 fab
         pairs, 65 above the threshold, and breaks the calibration gate below.
         """
-        boards = sorted(glob.glob(os.path.join(ROOT, 'kicad_files',
-                                               '*.kicad_pcb')))
+        boards = _corpus()
         # 22, not 30. The floor is an anti-vacuity guard -- a sweep
         # over an empty glob passes every assertion below it -- and it
         # was written when kicad_files/ held 30+ boards. The corpus is
@@ -354,8 +376,7 @@ class TestContainment(unittest.TestCase):
         conclusion has to be revisited.
         """
         from placement.parser import extract_fab_sides
-        boards = sorted(glob.glob(os.path.join(ROOT, 'kicad_files',
-                                               '*.kicad_pcb')))
+        boards = _corpus()
         # 22, not 30. The floor is an anti-vacuity guard -- a sweep
         # over an empty glob passes every assertion below it -- and it
         # was written when kicad_files/ held 30+ boards. The corpus is
@@ -391,8 +412,7 @@ class TestContainment(unittest.TestCase):
         poses on 12% of the corpus -- the run-4 lesson in a new costume.
         """
         from placement.legality import CONTAINMENT_FRAC
-        boards = sorted(glob.glob(os.path.join(ROOT, 'kicad_files',
-                                               '*.kicad_pcb')))
+        boards = _corpus()
         # 22, not 30. The floor is an anti-vacuity guard -- a sweep
         # over an empty glob passes every assertion below it -- and it
         # was written when kicad_files/ held 30+ boards. The corpus is

--- a/tests/test_run6_check_assembly.py
+++ b/tests/test_run6_check_assembly.py
@@ -68,8 +68,6 @@ class TestCheckAssemblyCLI(unittest.TestCase):
         self.assertEqual(r.returncode, 2)
 
 
-if __name__ == '__main__':
-    unittest.main()
 
 
 class TestRenderBodyChannel(unittest.TestCase):
@@ -139,3 +137,7 @@ class TestContainmentDisclosure(unittest.TestCase):
             self.assertGreater(doc['fab_unjudged'], 0)
             self.assertEqual(len(doc['fab_unjudged_refs']),
                              doc['fab_unjudged'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 30 tests were defined where nothing could run them, and 7 files reported OK

A test defined below `if __name__ == '__main__':` never runs. The guard
executes the runner and the runner exits, so anything after it does not exist
yet: `unittest.main()` discovers what is bound at the moment it is called, and
a hand-rolled `for t in TESTS` cannot list a function defined later. Either way
the file prints OK and `run_all` records a PASS — indistinguishable from having
checked.

Closes #876

Measured across `tests/`, two shapes, **30 dead tests in 7 files**:

| file | ran | defines | dead |
|---|---|---|---|
| `test_run6_body_overlap.py` | 9 | 20 | **11** |
| `test_431_render_placement.py` | 20 | 28 | **8** |
| `test_run4_reconstruct.py` | 7 | 10 | 3 |
| `test_run6_check_assembly.py` | 4 | 7 | 3 |
| `test_run4_instruments.py` | 8 | 10 | 2 |
| `test_549_floorplan_cli.py` | — | — | 2 |
| `test_458_loop_steering.py` | — | — | 1 |

`test_run6_check_assembly.py` is where this started. It pins `check_assembly.py`'s
CLI contract; of its 7 tests 4 ran and 3 of those self-skipped on gitignored
`wk/` fixtures — an effective CI coverage of **one test**, reported as
`OK (skipped=3)`.

## What the dead tests were hiding

Enabling them is not free, and that is the value:

* **A non-deterministic census.** `test_run6_body_overlap` swept
  `glob('kicad_files/*.kicad_pcb')` four times. Other tests generate boards
  into that directory and those boards are **gitignored**, so `git status`
  stays clean while the count moves. Measured on one tree at one commit,
  minutes apart: **22 boards before a suite run and 32 after**, taking
  `fab_unjudged` from **140 to 154**. Scoped to `run_utils.corpus_boards()` —
  the tracked set — and proven: dropping an extra board into `kicad_files/`
  no longer moves the answer.
* **Four stale anti-vacuity floors.** The same file asserts
  `len(boards) >= 30`; the tracked corpus is **22**. Re-stated to 22 with the
  history, not derived from the thing it guards.
* **A stale count.** `fab_unjudged == 144`, measured over 33 boards when 11 of
  them were generated fixtures. **140** against the tracked corpus. The
  corpus-independent INVARIANT beside it — every unjudged part draws no `.Fab`
  geometry at all — still passes, and that is what actually licenses the
  conclusion the number was standing in for.
* **A checklist that grew by five.** `test_431` pins the exact key set of
  `render_placement --json-out`'s checklist; the run-23 courtyard channels and
  the cross-side stack census arrived while the test was dead. Re-stated
  exactly rather than relaxed to a subset — a subset check is what would have
  let the drift through in the first place.

None of the four is a product bug. All four are claims that stopped being true
while nothing was watching.

## The gate

Two AST checks in `tests/test_718_static_test_hygiene.py`, which is the
spawns-nothing, runs-in-`--fast` home for exactly this:

* **`test_no_test_is_defined_after_its_own_runner`** — no class-with-tests and
  no `def test_*` below the last `__main__` guard, over every `test_*.py`
  recursively (582 files).
* **`test_every_test_is_registered_in_its_files_own_list`** — a file with a
  module-level `TESTS = [...]` must list every test it defines
  (`TESTS.append(...)` counts). This one found the last 3, in two files where
  the function sits ABOVE the guard and simply was never registered —
  invisible to the first check.

That file already had `test_every_test_in_this_file_is_registered`, which is
this same gate scoped to one file. It caught the pattern in itself; nothing
looked at the other 581.

## Verified

Every one of the 8 touched files passes individually, and both new gates pass
over the whole tree.

Full suite on this branch: **548 passed, 2 failed, 2 timed out**. Both
failures accounted for, neither outstanding:

* `test_run6_body_overlap.py` — **mine**, and the reason the determinism commit
  exists: it passed alone and failed inside `run_all` because the glob picked
  up boards a previous test had generated. Fixed and proven; it is the second
  commit here.
* `test_831_fill_preflight_census.py` — **pre-existing on `main`**, unrelated
  to this branch. `tests/stress/fill_timing_census.py` does `import resource`
  at module scope, which is POSIX-only, so the file dies at import on every
  Windows machine. Reproduced on a clean `upstream/main` worktree; filed
  separately.

The two timeouts (`test_431_board_gates.py` at its own 1200 s budget,
`test_interf_u.py` at 600 s) are the suite's known long tests; `run_all`'s own
note says a timeout is not evidence, and both pass when run alone.
