### PR TITLE
#882: a POSIX-only import at module scope made the suite permanently red on Windows

### DIFF
--- a/tests/stress/fill_timing_census.py
+++ b/tests/stress/fill_timing_census.py
@@ -41,9 +41,24 @@ import json
 import multiprocessing as mp
 import os
 import platform
-import resource
 import sys
 import time
+
+#: `resource` is POSIX-only. Imported at module scope it made this file
+#: unimportable on Windows, which took `tests/test_831_fill_preflight_census.py`
+#: -- a collected test that only calls the pure `analyse()` -- down with it at
+#: IMPORT time, so the suite carried a standing failure on every Windows
+#: machine (#882).
+#:
+#: Guarded rather than moved into `_child_cpu`, so the absence is a value this
+#: module can report rather than an exception at the call site. Same shape as
+#: `py_router/memory_debug.py`, which already does this for the same module.
+try:
+    import resource
+    _HAS_RESOURCE = True
+except ImportError:                                        # pragma: no cover
+    resource = None
+    _HAS_RESOURCE = False
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(os.path.dirname(HERE))
@@ -101,6 +116,16 @@ def board_features(board_file):
 
 
 def _child_cpu():
+    """(cpu seconds, peak RSS) charged to reaped children, or (None, None).
+
+    None rather than 0.0 where `resource` is absent. A zero here would be
+    written into the recorded rows as `child_cpu_s: 0.0`, indistinguishable
+    from a fill that genuinely cost nothing -- and those rows are compared
+    against ones recorded on a POSIX machine. An absent measurement has to
+    look absent.
+    """
+    if not _HAS_RESOURCE:                                  # pragma: no cover
+        return None, None
     ru = resource.getrusage(resource.RUSAGE_CHILDREN)
     return ru.ru_utime + ru.ru_stime, ru.ru_maxrss
 
@@ -129,8 +154,18 @@ def measure_one(args):
         'wall_s': round(wall, 2),
         'fill_elapsed_s': (round(st.elapsed_s, 2)
                            if st.elapsed_s is not None else None),
-        'child_cpu_s': round(cpu1 - cpu0, 2),
-        'child_maxrss_mb': round(maxrss / (1024 * 1024), 1),
+        # None all the way through where the platform cannot measure it, and
+        # SAID so in the row rather than left for a reader to infer from a
+        # null. `analyse()` reads neither field -- it separates on
+        # `fill_elapsed_s` / `timeout_s` -- so a census recorded without them
+        # still answers the question this module exists for.
+        'child_cpu_s': (round(cpu1 - cpu0, 2)
+                        if cpu0 is not None and cpu1 is not None else None),
+        'child_maxrss_mb': (round(maxrss / (1024 * 1024), 1)
+                            if maxrss is not None else None),
+        'cpu_source': ('resource.RUSAGE_CHILDREN' if _HAS_RESOURCE else
+                       f'not measured: no `resource` module on '
+                       f'{platform.system()}'),
         'n_islands': (sum(len(v) for v in islands.values())
                       if islands else 0),
         'timeout_s': timeout,
@@ -295,7 +330,12 @@ def report(path, budget=PRODUCTION_TIMEOUT_S, top=25):
           f"zone_mm2 segs vias  board):")
     for r in timed[:top]:
         s = r['timeout_s'] if r['status'] == 'timeout' else r['fill_elapsed_s']
-        print(f"  {s:7.1f} {r['child_cpu_s']:7.1f} {r['status']:8s} "
+        # `{None:7.1f}` raises, and a row recorded on a platform without
+        # `resource` carries None here (#882). Printed as `-` so the column
+        # stays readable and an unmeasured cost cannot be read as a small one.
+        _cpu = r.get('child_cpu_s')
+        _cpu = f"{_cpu:7.1f}" if isinstance(_cpu, (int, float)) else f"{'-':>7}"
+        print(f"  {s:7.1f} {_cpu} {r['status']:8s} "
               f"{r['n_zones']:4d} {r['n_pads']:5d} {r['n_footprints']:4d} "
               f"{r['bbox_area_mm2']:9.0f} {r['zone_outline_area_mm2']:9.0f} "
               f"{r['n_segments']:6d} {r['n_vias']:5d}  "

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -362,10 +362,97 @@ def test_the_scanners_still_match_something():
           f'{joins} literal join(s)')
 
 
+#: Modules the standard library ships on POSIX and NOT on Windows. Imported at
+#: module scope, any of these makes its file unimportable there -- and a file
+#: that cannot be imported takes down everything that imports it, at import
+#: time, before a single assertion runs.
+_POSIX_ONLY = ('resource', 'fcntl', 'termios', 'pwd', 'grp', 'posix',
+               'crypt', 'syslog', 'nis', 'spwd')
+
+
+def test_no_module_scope_posix_only_import():
+    """A POSIX-only module imported at top level is a Windows-wide outage.
+
+    #882: `tests/stress/fill_timing_census.py` imported `resource` at module
+    scope, so `tests/test_831_fill_preflight_census.py` -- a collected test
+    that only calls the pure `analyse()` and never touches CPU accounting --
+    died at IMPORT on every Windows machine. The suite carried a standing
+    failure there, which is the expensive part: a permanent red teaches the
+    reader to skim the failure list.
+
+    The repo already had the right shape in both available forms --
+    `py_router/memory_debug.py` guards with a `_HAS_RESOURCE` flag, and
+    `tests/stress/redo_stress_test.py` imports inside the one function that
+    needs it. This gate is what stops the third instance being written.
+
+    Scoped to the WHOLE repo, not just `tests/`, deliberately: the same import
+    in `py_router/` would break the router itself on Windows rather than one
+    test, so the cheaper place to catch it is everywhere.
+    """
+    roots = [TESTS_DIR] + [os.path.join(ROOT, d) for d in
+                           ('py_router', 'py_placer', 'py_tools',
+                            'kicad_routing_plugin')]
+    bad, scanned, unparseable = [], 0, []
+    for root in roots:
+        if not os.path.isdir(root):
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in sorted(dirnames)
+                           if d not in ('__pycache__', '.pytest_cache')]
+            for fname in sorted(filenames):
+                if not fname.endswith('.py'):
+                    continue
+                path = os.path.join(dirpath, fname)
+                try:
+                    with open(path, encoding='utf-8', errors='replace') as fh:
+                        tree = ast.parse(fh.read())
+                except SyntaxError as exc:
+                    # REPORTED, not skipped. A file this gate cannot parse is
+                    # a file it cannot clear, and swallowing that is how the
+                    # gate would go quiet on exactly the file someone just
+                    # broke -- caught when a deliberate mutation of
+                    # fill_timing_census.py produced a SyntaxError and this
+                    # check printed PASS over one file FEWER. `_code_only`
+                    # above already states the rule: a gate that goes quiet on
+                    # a file it cannot parse is worse than one that is
+                    # slightly noisy.
+                    unparseable.append(
+                        f'{os.path.relpath(path, ROOT)}: {exc.__class__.__name__}'
+                        f' line {exc.lineno}')
+                    continue
+                except OSError:                            # pragma: no cover
+                    continue
+                scanned += 1
+                # TOP-LEVEL only. An import inside a function or a try/except
+                # is the correct shape and must not be flagged.
+                for node in tree.body:
+                    names = []
+                    if isinstance(node, ast.Import):
+                        names = [a.name.split('.')[0] for a in node.names]
+                    elif isinstance(node, ast.ImportFrom) and node.module:
+                        names = [node.module.split('.')[0]]
+                    for name in names:
+                        if name in _POSIX_ONLY:
+                            bad.append(
+                                f'{os.path.relpath(path, ROOT)}'
+                                f':{node.lineno}: {name}')
+    assert not bad, (
+        'POSIX-only module(s) imported at module scope, so these files cannot '
+        'be imported on Windows:\n  ' + '\n  '.join(bad)
+        + '\n  Guard with try/except and a _HAS_X flag (see '
+          'py_router/memory_debug.py), or import inside the function that '
+          'needs it (see tests/stress/redo_stress_test.py).')
+    assert not unparseable, (
+        'file(s) this gate could not parse, so it cleared them without '
+        'looking:\n  ' + '\n  '.join(unparseable))
+    print(f'  PASS: no module-scope POSIX-only import, over {scanned} file(s)')
+
+
 TESTS = [
     test_wk_dependent_tests_are_declared,
     test_no_test_spawns_a_script_that_moved,
     test_the_scanners_still_match_something,
+    test_no_module_scope_posix_only_import,
 ]
 
 


### PR DESCRIPTION
## The suite was permanently red on Windows, at import, before a single assertion

`tests/stress/fill_timing_census.py` imported `resource` — a POSIX-only
standard-library module — at module scope. Windows has no such module, so the
file could not be imported there at all, and
`tests/test_831_fill_preflight_census.py` died taking it with it:

```
  File "tests\test_831_fill_preflight_census.py", line 23, in <module>
    import fill_timing_census as ftc
  File "tests\stress\fill_timing_census.py", line 44, in <module>
    import resource
ModuleNotFoundError: No module named 'resource'
```

That test is collected by `run_all.py`. The expensive part is not the one test:
a permanent red teaches the reader to skim the failure list, which is where the
next real failure goes unnoticed.

Closes #882

## The dependency was spurious for what the test does

`resource` is used in exactly one function — `_child_cpu` — reached only from
`measure_one`, the census-**running** path. Everything the failing test touches
is `analyse()`, a pure function over already-recorded rows that separates on
`fill_elapsed_s` / `timeout_s` and reads neither CPU field. Real for *recording*
a census; entirely spurious for *analysing* one.

## Guarded, and the absence is a value rather than a zero

`_HAS_RESOURCE` with a try/except — the shape `py_router/memory_debug.py`
already uses for this same module.

`_child_cpu()` returns `(None, None)` where it is unavailable, **not `0.0`**.
A zero would be written into the recorded rows as `child_cpu_s: 0.0`,
indistinguishable from a fill that genuinely cost nothing — and those rows get
compared against ones recorded on a POSIX machine. The row also carries
`cpu_source`, so it states *not measured: no `resource` module on Windows*
rather than leaving a reader to infer it from a null.

Two printers would then have raised on the `None` — `run_census`'s progress
line and `report()`'s `{r['child_cpu_s']:7.1f}` — and print `-` instead, so an
unmeasured cost cannot be read as a small one.

## The gate, because a sweep cannot prevent the next one

`test_718_static_test_hygiene.py` says exactly this in its own docstring:
*"A sweep cannot prevent that — only a standing gate can."*

`test_no_module_scope_posix_only_import` walks **967 files** — the whole repo,
not just `tests/`, because the same import in `py_router/` would break the
router itself on Windows rather than one test — and refuses a top-level import
of `resource`, `fcntl`, `termios`, `pwd`, `grp`, `posix`, `crypt`, `syslog`,
`nis` or `spwd`. An import inside a function or a try/except is the correct
shape and is not flagged; this was the only unguarded instance in the tree.

## Both arms mutation-checked, and the second one exists because I got it wrong

| mutation | result |
|---|---|
| restore the unguarded `import resource` | gate fails, naming `tests/stress/fill_timing_census.py:56: resource` |
| append a syntax error to that file | gate fails, naming it **UNPARSEABLE** |

The second arm is there because the first draft was wrong in a way worth
recording. My initial mutation happened to produce a `SyntaxError`, and the
gate printed **PASS over one file fewer** — silently skipping the very file I
had just broken, because it swallowed the parse error and moved on. `_code_only`
in the same file already states the rule: *a gate that goes quiet on a file it
cannot parse is worse than one that is slightly noisy.* The check now refuses
to clear what it could not read.

## Verified

* `tests/test_831_fill_preflight_census.py` — was dying at import on Windows,
  now **15/15 checks passed**
* `tests/test_718_static_test_hygiene.py` — passes, 5 registered checks
* Full suite on this branch is RUNNING as this opens; I will post the result
  as a comment rather than quote a number I do not yet have. The last full run
  on `main` from this machine was 545 passed / 0 failed, and the run that
  exposed this bug carried it as one of two failures.
* Nothing changes on POSIX: `_child_cpu` still returns real numbers,
  `run_census` still records them, and `analyse` never read them either way.

## One thing noticed and deliberately NOT fixed

`measure_one` computes `child_maxrss_mb` as `maxrss / (1024 * 1024)`.
`ru_maxrss` is in **bytes on macOS and kilobytes on Linux**, so that line is
correct on the platform this is developed on and off by 1024× on Linux.
Out of scope here — correcting it changes the meaning of already-recorded rows
and wants its own re-measurement — but flagged rather than silently left, and I
am happy to file it.
