### PR TITLE
#879: a committed baseline nothing re-derived, and the registry that finds the next one

### DIFF
--- a/tests/713_abstention_census.py
+++ b/tests/713_abstention_census.py
@@ -58,9 +58,16 @@ WITHHELD_MARK = 'the emitter WITHHELD'
 #: HAND-MIRRORED, and it has already fallen out of step once: #837 added
 #: `assembly_side` to `RULES` and this set was not updated, so a board with no
 #: pad-bearing part had an honest skip classified as a real abstention.
-#: `test_713_abstention_drift.py` asserts the two sets are equal in BOTH
-#: directions in milliseconds, so the next one fails a gate rather than
-#: silently changing a census (#879).
+#: `test_713_abstention_drift.py` compares the two in BOTH directions in
+#: milliseconds, so the next one fails a gate rather than silently changing a
+#: census (#879).
+#:
+#: They are equal EXCEPT for `'not requested'`, which is deliberate and is why
+#: the gate names it rather than subtracting it quietly: it is not a
+#: `_SKIP_REASON` value at all but `floorplan.grade`'s `.get(name, 'not
+#: requested')` fallback, for a rule that was skipped with no reason recorded.
+#: (`_SKIP_REASON` also has 12 keys and 11 distinct values -- `decap_distance`
+#: and `decap_ungraded` share one -- so a count comparison would be wrong too.)
 NOT_ASKED = {
     'the intent declares no envelope.rect',
     'no block declares a zone',
@@ -87,7 +94,7 @@ def classify(reason):
 
 
 def tracked_boards(repo):
-    """The TRACKED board names, via git -- not os.listdir.
+    """The TRACKED board names ONLY, via git -- not os.listdir.
 
     Running the suite leaves 11 gitignored routing artifacts in kicad_files/
     (fanout_output*, interf_u_routed, sonde_u_routed*, ...), so a listdir
@@ -107,6 +114,19 @@ def run(argv, repo):
     return subprocess.run([sys.executable, '-X', 'utf8'] + argv,
                           capture_output=True, text=True, encoding='utf-8',
                           errors='replace', cwd=repo, timeout=900)
+
+
+def refusal_text(text, tmp):
+    """The tail of a refusal, with the per-run temp path taken out.
+
+    The raw tail embeds the `tempfile.mkdtemp` directory, which changes every
+    run -- so a board that starts refusing would make this census flap forever
+    on a random string, and the gate would report it as DRIFT every time. No
+    board refuses today (0 of 22), which is exactly why it is worth removing
+    now: the first one to refuse would otherwise turn the gate into noise at
+    the moment it finally had something to say.
+    """
+    return (text.strip()[-300:]).replace(tmp, '<tmp>')
 
 
 def summary_of(text):
@@ -141,7 +161,7 @@ def census(repo, quiet=False):
             e = run([check, board, '--emit-intent', intent, '-q'], repo)
             row['emit_rc'] = e.returncode
             if not os.path.isfile(intent):
-                row['emit_refused'] = (e.stdout + e.stderr).strip()[-300:]
+                row['emit_refused'] = refusal_text(e.stdout + e.stderr, tmp)
                 rows.append(row)
                 say(f"  {name:42s} emit rc={e.returncode} NO INTENT",
                     flush=True)
@@ -151,7 +171,7 @@ def census(repo, quiet=False):
             row['grade_rc'] = g.returncode
             s = summary_of(g.stdout)
             if s is None:
-                row['grade_refused'] = (g.stdout + g.stderr).strip()[-300:]
+                row['grade_refused'] = refusal_text(g.stdout + g.stderr, tmp)
                 rows.append(row)
                 say(f"  {name:42s} grade rc={g.returncode} NO SUMMARY",
                     flush=True)
@@ -222,10 +242,21 @@ def census(repo, quiet=False):
 
 
 def write(doc, path):
-    """The ONE place the serialization lives, so the gate cannot come to
-    disagree with the recorder about formatting."""
-    with open(path, 'w', encoding='utf-8') as f:
+    """The one place the census FILE is serialized, so the gate cannot come to
+    disagree with the recorder about formatting.
+
+    (`main` also prints a summary through `json.dumps` for the console; that is
+    a different document -- no `rows`, unsorted -- and deliberately not this.)
+
+    Written to a temp file and moved into place. The default `--out` IS the
+    committed baseline, so a plain `'w'` truncates it before serialising and a
+    Ctrl-C in that window leaves it destroyed. Cheap insurance on the one file
+    this whole gate exists to protect.
+    """
+    tmp = path + '.tmp'
+    with open(tmp, 'w', encoding='utf-8') as f:
         json.dump(doc, f, indent=1, sort_keys=True)
+    os.replace(tmp, path)
 
 
 def main(argv=None):
@@ -243,7 +274,30 @@ def main(argv=None):
                    help='suppress the per-board progress lines')
     a = p.parse_args(argv)
 
+    # Fail on an unwritable --out BEFORE spending 42 s, not after. A
+    # `FileNotFoundError` traceback from `write()` at the end of a full census
+    # is the same information delivered at the worst possible moment.
+    out_dir = os.path.dirname(os.path.abspath(a.out))
+    if not os.path.isdir(out_dir):
+        p.error(f"--out directory does not exist: {out_dir}")
+    if os.path.isdir(a.out):
+        p.error(f"--out is a directory, not a file: {a.out}")
+
     doc = census(a.repo, quiet=a.quiet)
+
+    # REFUSE to write a census of nothing. `tracked_boards` asks git from
+    # `repo`, so a plausible-but-wrong root -- `tests/` instead of the repo,
+    # say -- returns no boards, and every count below is then a truthful zero
+    # about a set nobody censused. Writing that to the DEFAULT out path
+    # replaces the committed baseline with an empty document at exit 0, which
+    # is the #879 failure in its purest form: a file that reads as
+    # authoritative and measured nothing.
+    if not doc['boards_total']:
+        print(f"REFUSED to write a census of 0 boards. `git ls-files "
+              f"kicad_files/*.kicad_pcb` found nothing under {a.repo!r} -- "
+              f"is that the repo root?", file=sys.stderr)
+        return 2
+
     if not a.quiet:
         print('\nCENSUS: ' + json.dumps(
             {k: v for k, v in doc.items() if k != 'rows'}, indent=1))

--- a/tests/713_abstention_census.py
+++ b/tests/713_abstention_census.py
@@ -45,51 +45,47 @@ import sys
 import tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path[:0] = [os.path.join(ROOT, 'py_router'),
+                os.path.join(ROOT, 'py_placer')]
+
+from placement.floorplan import (_WITHHELD_MARK,                # noqa: E402
+                                 _is_not_asked)
+
 #: The committed baseline. Derived, never hardcoded: this file is committed and
 #: an absolute path from the machine that first ran it would make the census
 #: unrunnable anywhere else.
 DEFAULT_OUT = os.path.join(HERE, '713_abstention_census.json')
 
-WITHHELD_MARK = 'the emitter WITHHELD'
 
-#: Every `_SKIP_REASON` value, verbatim from floorplan.py. A skip whose reason
-#: is one of these (and carries no WITHHELD note) means nobody asked.
-#:
-#: HAND-MIRRORED, and it has already fallen out of step once: #837 added
-#: `assembly_side` to `RULES` and this set was not updated, so a board with no
-#: pad-bearing part had an honest skip classified as a real abstention.
-#: `test_713_abstention_drift.py` compares the two in BOTH directions in
-#: milliseconds, so the next one fails a gate rather than silently changing a
-#: census (#879).
-#:
-#: They are equal EXCEPT for `'not requested'`, which is deliberate and is why
-#: the gate names it rather than subtracting it quietly: it is not a
-#: `_SKIP_REASON` value at all but `floorplan.grade`'s `.get(name, 'not
-#: requested')` fallback, for a rule that was skipped with no reason recorded.
-#: (`_SKIP_REASON` also has 12 keys and 11 distinct values -- `decap_distance`
-#: and `decap_ungraded` share one -- so a count comparison would be wrong too.)
-NOT_ASKED = {
-    'the intent declares no envelope.rect',
-    'no block declares a zone',
-    'no block declares a side',
-    'no block is marked exclusive',
-    'the intent declares no keepouts',
-    'the intent declares no edge_connectors',
-    'the intent declares no decaps.max_distance_mm',
-    'the intent declares no decaps.max_pin_distance_mm',
-    'the intent declares no must_lock patterns',
-    'the intent declares no legality_budget',
-    'the intent declares no assembly.sides',
-    'not requested',
-}
+def classify(rule, reason):
+    """-> 'withheld' | 'not_asked' | 'arm'.
 
+    CALLS the engine rather than mirroring it. This used to hold its own copy
+    of every `_SKIP_REASON` value and match on the reason string, and both
+    halves of that were wrong (#879):
 
-def classify(reason):
-    """-> 'withheld' | 'not_asked' | 'arm'."""
-    if WITHHELD_MARK in reason:
-        return 'withheld'
-    if reason in NOT_ASKED:
+    * The copy went stale -- #837 added `assembly_side` to `RULES` and the set
+      was not updated, so a board with no pad-bearing part had an honest skip
+      counted as a real abstention.
+    * Matching on the VALUE is the failure `_is_not_asked`'s own docstring was
+      written against: "an `_ARM` reason that ever happened to equal some OTHER
+      rule's skip reason would read as 'nobody asked' -- a real abstention
+      silently downgraded to a pass, which is the dangerous direction."
+      Not theoretical here: `_SKIP_REASON` has 12 keys and 11 distinct values,
+      because `decap_distance` and `decap_ungraded` already share one. Keying
+      on the RULE, which this call site has in hand, makes the strings not have
+      to stay distinct.
+
+    Measured before the swap: over every `(rule, reason)` pair the engine can
+    produce, the old value-set match and `_is_not_asked` agree on all 12, and a
+    full re-record is byte-identical -- so this changes the census's ANSWER
+    nowhere and its exposure everywhere.
+    """
+    if _is_not_asked(rule, reason):
         return 'not_asked'
+    if _WITHHELD_MARK in reason:
+        return 'withheld'
     return 'arm'
 
 
@@ -202,7 +198,7 @@ def census(repo, quiet=False):
 
             buckets = {'withheld': [], 'not_asked': [], 'arm': []}
             for rule, reason in (doc.get('rules_skipped') or {}).items():
-                buckets[classify(reason)].append(rule)
+                buckets[classify(rule, reason)].append(rule)
 
             row['pass'] = s.get('pass')
             row['errors'] = s.get('errors')
@@ -335,7 +331,18 @@ def main(argv=None):
         except OSError:
             pass
 
-    doc = census(a.repo, quiet=a.quiet)
+    try:
+        doc = census(a.repo, quiet=a.quiet)
+    except (subprocess.CalledProcessError, OSError) as exc:
+        # The same refusal, one rung earlier. `--repo <a directory outside any
+        # git tree>` makes `git ls-files` exit 128, and `check=True` turned
+        # that into a traceback at exit 1 -- which is a broken-tool exit, not
+        # the deliberate "I will not write a census of nothing" this refuses
+        # with. Same failure, so same answer and same exit code.
+        print(f"REFUSED: `git ls-files` could not name a corpus under "
+              f"{a.repo!r} ({type(exc).__name__}: {exc}). No census was "
+              f"taken, so nothing was written.", file=sys.stderr)
+        return 2
 
     # REFUSE to write a census of nothing. `tracked_boards` asks git from
     # `repo`, so a plausible-but-wrong root -- `tests/` instead of the repo,

--- a/tests/713_abstention_census.py
+++ b/tests/713_abstention_census.py
@@ -25,7 +25,19 @@ and rules_skipped (not asked) is NOT one of them.
 
 The `CMD:` banner means stdout is not bare JSON; the summary is read off the
 `JSON_SUMMARY:` line and the reason strings out of the --json document.
+
+    python3 -X utf8 tests/713_abstention_census.py             # re-record
+    python3 -X utf8 tests/713_abstention_census.py --out PATH  # somewhere else
+
+WHY THIS HAS A `main()` AND AN `--out` (#879). It was a bare top-level script
+whose output path came from `__file__`, and that meant two things: IMPORTING it
+ran the whole 42 s census, and it always wrote over the committed baseline.
+Both blocked the drift gate that now guards it
+(`tests/test_713_abstention_drift.py`), which has to re-derive the census
+somewhere harmless and compare. The default path is unchanged, so a plain
+invocation still re-records exactly what it always did.
 """
+import argparse
 import json
 import os
 import subprocess
@@ -33,25 +45,22 @@ import sys
 import tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-# Derived, never hardcoded: this file is committed and an absolute path from
-# the machine that first ran it would make the census unrunnable anywhere else.
-REPO = sys.argv[1] if len(sys.argv) > 1 else os.path.dirname(HERE)
-CHECK = os.path.join(REPO, 'py_tools', 'check_floorplan.py')
-# TRACKED boards only, via git -- not os.listdir. Running the suite leaves 11
-# gitignored routing artifacts in kicad_files/ (fanout_output*,
-# interf_u_routed, sonde_u_routed*, ...), so a listdir census silently grades
-# 33 boards before a suite run and 22 after one. Measured: exactly that
-# happened between two runs of this census on the same tree.
-BOARDS = sorted(
-    os.path.basename(p) for p in subprocess.run(
-        ['git', 'ls-files', 'kicad_files/*.kicad_pcb'],
-        capture_output=True, text=True, cwd=REPO,
-        check=True).stdout.split()
-    if p.endswith('.kicad_pcb'))
+#: The committed baseline. Derived, never hardcoded: this file is committed and
+#: an absolute path from the machine that first ran it would make the census
+#: unrunnable anywhere else.
+DEFAULT_OUT = os.path.join(HERE, '713_abstention_census.json')
 
 WITHHELD_MARK = 'the emitter WITHHELD'
-# Every _SKIP_REASON value, verbatim from floorplan.py:2875-2887. A skip whose
-# reason is one of these (and carries no WITHHELD note) means nobody asked.
+
+#: Every `_SKIP_REASON` value, verbatim from floorplan.py. A skip whose reason
+#: is one of these (and carries no WITHHELD note) means nobody asked.
+#:
+#: HAND-MIRRORED, and it has already fallen out of step once: #837 added
+#: `assembly_side` to `RULES` and this set was not updated, so a board with no
+#: pad-bearing part had an honest skip classified as a real abstention.
+#: `test_713_abstention_drift.py` asserts the two sets are equal in BOTH
+#: directions in milliseconds, so the next one fails a gate rather than
+#: silently changing a census (#879).
 NOT_ASKED = {
     'the intent declares no envelope.rect',
     'no block declares a zone',
@@ -77,10 +86,27 @@ def classify(reason):
     return 'arm'
 
 
-def run(argv):
+def tracked_boards(repo):
+    """The TRACKED board names, via git -- not os.listdir.
+
+    Running the suite leaves 11 gitignored routing artifacts in kicad_files/
+    (fanout_output*, interf_u_routed, sonde_u_routed*, ...), so a listdir
+    census silently grades 33 boards before a suite run and 22 after one.
+    Measured: exactly that happened between two runs of this census on the
+    same tree.
+    """
+    return sorted(
+        os.path.basename(p) for p in subprocess.run(
+            ['git', 'ls-files', 'kicad_files/*.kicad_pcb'],
+            capture_output=True, text=True, cwd=repo,
+            check=True).stdout.split()
+        if p.endswith('.kicad_pcb'))
+
+
+def run(argv, repo):
     return subprocess.run([sys.executable, '-X', 'utf8'] + argv,
                           capture_output=True, text=True, encoding='utf-8',
-                          errors='replace', cwd=REPO, timeout=900)
+                          errors='replace', cwd=repo, timeout=900)
 
 
 def summary_of(text):
@@ -90,93 +116,141 @@ def summary_of(text):
     return None
 
 
-rows = []
-with tempfile.TemporaryDirectory() as tmp:
-    for name in BOARDS:
-        board = os.path.join(REPO, 'kicad_files', name)
-        intent = os.path.join(tmp, name.replace('.kicad_pcb', '.intent.json'))
-        doc_p = os.path.join(tmp, name.replace('.kicad_pcb', '.grade.json'))
-        row = {'board': name}
+def census(repo, quiet=False):
+    """Grade every tracked board and RETURN the census document.
 
-        e = run([CHECK, board, '--emit-intent', intent, '-q'])
-        row['emit_rc'] = e.returncode
-        if not os.path.isfile(intent):
-            row['emit_refused'] = (e.stdout + e.stderr).strip()[-300:]
+    Returning rather than writing is what lets the drift gate re-derive
+    without touching the committed file.
+    """
+    check = os.path.join(repo, 'py_tools', 'check_floorplan.py')
+    boards = tracked_boards(repo)
+
+    def say(*a, **kw):
+        if not quiet:
+            print(*a, **kw)
+
+    rows = []
+    with tempfile.TemporaryDirectory() as tmp:
+        for name in boards:
+            board = os.path.join(repo, 'kicad_files', name)
+            intent = os.path.join(tmp,
+                                  name.replace('.kicad_pcb', '.intent.json'))
+            doc_p = os.path.join(tmp, name.replace('.kicad_pcb', '.grade.json'))
+            row = {'board': name}
+
+            e = run([check, board, '--emit-intent', intent, '-q'], repo)
+            row['emit_rc'] = e.returncode
+            if not os.path.isfile(intent):
+                row['emit_refused'] = (e.stdout + e.stderr).strip()[-300:]
+                rows.append(row)
+                say(f"  {name:42s} emit rc={e.returncode} NO INTENT",
+                    flush=True)
+                continue
+
+            g = run([check, board, '--intent', intent, '--json', doc_p], repo)
+            row['grade_rc'] = g.returncode
+            s = summary_of(g.stdout)
+            if s is None:
+                row['grade_refused'] = (g.stdout + g.stderr).strip()[-300:]
+                rows.append(row)
+                say(f"  {name:42s} grade rc={g.returncode} NO SUMMARY",
+                    flush=True)
+                continue
+            with open(doc_p, encoding='utf-8') as f:
+                doc = json.load(f)
+
+            buckets = {'withheld': [], 'not_asked': [], 'arm': []}
+            for rule, reason in (doc.get('rules_skipped') or {}).items():
+                buckets[classify(reason)].append(rule)
+
+            row['pass'] = s.get('pass')
+            row['errors'] = s.get('errors')
+            row['rules_run'] = s.get('rules_run')
+            row['budget_abstained'] = s.get('budget_abstained')
+            row['budget_abstained_keys'] = s.get('budget_abstained_keys')
+            row['edge_seating_abstained'] = s.get('edge_seating_abstained')
+            row['skipped_not_asked'] = sorted(buckets['not_asked'])
+            row['skipped_withheld'] = sorted(buckets['withheld'])
+            row['skipped_arm'] = sorted(buckets['arm'])
+            row['human_pass_line'] = any(
+                'rule(s) ran, no violations' in ln
+                for ln in g.stdout.splitlines())
+            row['human_not_derivable'] = 'NOT DERIVABLE' in g.stdout
+
+            # ONLY the declared-but-ungraded channels. `not_asked` is excluded
+            # on purpose: it is the honest case and counting it makes every
+            # board with a minimal intent permanently incomplete.
+            ungraded = ((row['budget_abstained'] or 0)
+                        + (row['edge_seating_abstained'] or 0)
+                        + len(buckets['arm']))
+            row['ungraded_declared'] = ungraded
+            row['clean_but_ungraded'] = bool(row['pass']) and ungraded > 0
             rows.append(row)
-            print(f"  {name:42s} emit rc={e.returncode} NO INTENT", flush=True)
-            continue
+            say(f"  {name:42s} rc={g.returncode} pass={row['pass']!s:5s} "
+                f"err={row['errors']} run={row['rules_run']} "
+                f"abst={row['budget_abstained']} "
+                f"arm={len(buckets['arm'])} "
+                f"wh={len(buckets['withheld'])} "
+                f"na={len(buckets['not_asked'])} "
+                f"{'<<< CLEAN BUT UNGRADED' if row['clean_but_ungraded'] else ''}",
+                flush=True)
 
-        g = run([CHECK, board, '--intent', intent, '--json', doc_p])
-        row['grade_rc'] = g.returncode
-        s = summary_of(g.stdout)
-        if s is None:
-            row['grade_refused'] = (g.stdout + g.stderr).strip()[-300:]
-            rows.append(row)
-            print(f"  {name:42s} grade rc={g.returncode} NO SUMMARY", flush=True)
-            continue
-        with open(doc_p, encoding='utf-8') as f:
-            doc = json.load(f)
+    graded = [r for r in rows if 'pass' in r]
+    bad = [r for r in rows if r.get('clean_but_ungraded')]
+    return {
+        'what': 'boards where the grade reports pass:true while a channel the '
+                'intent ASKED FOR went ungraded (rules_skipped "not asked" '
+                'excluded -- see module docstring)',
+        'boards_total': len(rows),
+        'boards_graded': len(graded),
+        'boards_clean_but_ungraded': len(bad),
+        'names_clean_but_ungraded': [r['board'] for r in bad],
+        'channels_seen': {
+            'budget_abstained':
+                sum(1 for r in graded if r.get('budget_abstained')),
+            'rules_skipped_arm':
+                sum(1 for r in graded if r.get('skipped_arm')),
+            'rules_skipped_withheld':
+                sum(1 for r in graded if r.get('skipped_withheld')),
+            'edge_seating_abstained':
+                sum(1 for r in graded if r.get('edge_seating_abstained')),
+            'rules_skipped_not_asked_EXCLUDED':
+                sum(1 for r in graded if r.get('skipped_not_asked')),
+        },
+        'rows': rows,
+    }
 
-        buckets = {'withheld': [], 'not_asked': [], 'arm': []}
-        for rule, reason in (doc.get('rules_skipped') or {}).items():
-            buckets[classify(reason)].append(rule)
 
-        row['pass'] = s.get('pass')
-        row['errors'] = s.get('errors')
-        row['rules_run'] = s.get('rules_run')
-        row['budget_abstained'] = s.get('budget_abstained')
-        row['budget_abstained_keys'] = s.get('budget_abstained_keys')
-        row['edge_seating_abstained'] = s.get('edge_seating_abstained')
-        row['skipped_not_asked'] = sorted(buckets['not_asked'])
-        row['skipped_withheld'] = sorted(buckets['withheld'])
-        row['skipped_arm'] = sorted(buckets['arm'])
-        row['human_pass_line'] = any(
-            'rule(s) ran, no violations' in ln for ln in g.stdout.splitlines())
-        row['human_not_derivable'] = 'NOT DERIVABLE' in g.stdout
+def write(doc, path):
+    """The ONE place the serialization lives, so the gate cannot come to
+    disagree with the recorder about formatting."""
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(doc, f, indent=1, sort_keys=True)
 
-        # ONLY the declared-but-ungraded channels. `not_asked` is excluded on
-        # purpose: it is the honest case and counting it makes every board with
-        # a minimal intent permanently incomplete.
-        ungraded = ((row['budget_abstained'] or 0)
-                    + (row['edge_seating_abstained'] or 0)
-                    + len(buckets['arm']))
-        row['ungraded_declared'] = ungraded
-        row['clean_but_ungraded'] = bool(row['pass']) and ungraded > 0
-        rows.append(row)
-        print(f"  {name:42s} rc={g.returncode} pass={row['pass']!s:5s} "
-              f"err={row['errors']} run={row['rules_run']} "
-              f"abst={row['budget_abstained']} "
-              f"arm={len(buckets['arm'])} "
-              f"wh={len(buckets['withheld'])} "
-              f"na={len(buckets['not_asked'])} "
-              f"{'<<< CLEAN BUT UNGRADED' if row['clean_but_ungraded'] else ''}",
-              flush=True)
 
-graded = [r for r in rows if 'pass' in r]
-bad = [r for r in rows if r.get('clean_but_ungraded')]
-doc = {
-    'what': 'boards where the grade reports pass:true while a channel the '
-            'intent ASKED FOR went ungraded (rules_skipped "not asked" '
-            'excluded -- see module docstring)',
-    'boards_total': len(rows),
-    'boards_graded': len(graded),
-    'boards_clean_but_ungraded': len(bad),
-    'names_clean_but_ungraded': [r['board'] for r in bad],
-    'channels_seen': {
-        'budget_abstained': sum(1 for r in graded if r.get('budget_abstained')),
-        'rules_skipped_arm': sum(1 for r in graded if r.get('skipped_arm')),
-        'rules_skipped_withheld':
-            sum(1 for r in graded if r.get('skipped_withheld')),
-        'edge_seating_abstained':
-            sum(1 for r in graded if r.get('edge_seating_abstained')),
-        'rules_skipped_not_asked_EXCLUDED':
-            sum(1 for r in graded if r.get('skipped_not_asked')),
-    },
-    'rows': rows,
-}
-print('\nCENSUS: ' + json.dumps(
-    {k: v for k, v in doc.items() if k != 'rows'}, indent=1))
-out = os.path.join(HERE, '713_abstention_census.json')
-with open(out, 'w', encoding='utf-8') as f:
-    json.dump(doc, f, indent=1, sort_keys=True)
-print(f"wrote {out}")
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        description='Census the boards whose grade reports a clean verdict '
+                    'about something it never measured.')
+    p.add_argument('repo', nargs='?', default=os.path.dirname(HERE),
+                   help='repo root (default: the parent of tests/)')
+    p.add_argument('--out', default=DEFAULT_OUT,
+                   help='where to write the census (default: the committed '
+                        'baseline). The drift gate points this at a temp dir, '
+                        'so re-deriving cannot overwrite the very file it is '
+                        'comparing against')
+    p.add_argument('-q', '--quiet', action='store_true',
+                   help='suppress the per-board progress lines')
+    a = p.parse_args(argv)
+
+    doc = census(a.repo, quiet=a.quiet)
+    if not a.quiet:
+        print('\nCENSUS: ' + json.dumps(
+            {k: v for k, v in doc.items() if k != 'rows'}, indent=1))
+    write(doc, a.out)
+    print(f"wrote {a.out}")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/713_abstention_census.py
+++ b/tests/713_abstention_census.py
@@ -116,17 +116,36 @@ def run(argv, repo):
                           errors='replace', cwd=repo, timeout=900)
 
 
-def refusal_text(text, tmp):
-    """The tail of a refusal, with the per-run temp path taken out.
+def refusal_text(text, tmp, repo):
+    """The tail of a refusal, with every path that is not the same everywhere
+    taken out.
 
-    The raw tail embeds the `tempfile.mkdtemp` directory, which changes every
-    run -- so a board that starts refusing would make this census flap forever
-    on a random string, and the gate would report it as DRIFT every time. No
-    board refuses today (0 of 22), which is exactly why it is worth removing
-    now: the first one to refuse would otherwise turn the gate into noise at
-    the moment it finally had something to say.
+    Two of them, and both would make this file un-gateable:
+
+    * the `tempfile.mkdtemp` directory changes every RUN, so a refusing board
+      would make the census flap forever on a random string and the gate would
+      report DRIFT every time;
+    * the repo root differs per CHECKOUT -- and this repo is worked in several
+      worktrees at once -- so a recorded absolute path makes the baseline
+      machine-specific: the gate reports permanent DRIFT anywhere else, and
+      re-recording there just breaks it for the first tree. Ping-pong.
+
+    SCRUB BEFORE TRUNCATING. The other order only works when the whole path
+    happens to fall inside the last 300 characters, and in the one real refusal
+    measured (`--emit-intent` on an outline-less board) the boundary landed
+    five characters into the temp path -- forty more characters of message and
+    the substitution would have silently stopped happening.
+
+    No board refuses today (0 of 22), which is exactly why this is worth
+    getting right now: the first one to refuse would otherwise turn the gate
+    into noise at the moment it finally had something to say.
     """
-    return (text.strip()[-300:]).replace(tmp, '<tmp>')
+    for path, token in ((tmp, '<tmp>'), (os.path.abspath(repo), '<repo>')):
+        # Both spellings: a subprocess may echo back either separator, and on
+        # Windows the two are the same path but not the same string.
+        for spelling in (path, path.replace(os.sep, '/')):
+            text = text.replace(spelling, token)
+    return text.strip()[-300:]
 
 
 def summary_of(text):
@@ -161,7 +180,8 @@ def census(repo, quiet=False):
             e = run([check, board, '--emit-intent', intent, '-q'], repo)
             row['emit_rc'] = e.returncode
             if not os.path.isfile(intent):
-                row['emit_refused'] = refusal_text(e.stdout + e.stderr, tmp)
+                row['emit_refused'] = refusal_text(e.stdout + e.stderr,
+                                                   tmp, repo)
                 rows.append(row)
                 say(f"  {name:42s} emit rc={e.returncode} NO INTENT",
                     flush=True)
@@ -171,7 +191,8 @@ def census(repo, quiet=False):
             row['grade_rc'] = g.returncode
             s = summary_of(g.stdout)
             if s is None:
-                row['grade_refused'] = refusal_text(g.stdout + g.stderr, tmp)
+                row['grade_refused'] = refusal_text(g.stdout + g.stderr,
+                                                    tmp, repo)
                 rows.append(row)
                 say(f"  {name:42s} grade rc={g.returncode} NO SUMMARY",
                     flush=True)
@@ -252,11 +273,24 @@ def write(doc, path):
     committed baseline, so a plain `'w'` truncates it before serialising and a
     Ctrl-C in that window leaves it destroyed. Cheap insurance on the one file
     this whole gate exists to protect.
+
+    The temp file is cleaned up on failure. `tests/*.tmp` is not gitignored, so
+    a Ctrl-C -- the very case above -- would otherwise leave a partial
+    `713_abstention_census.json.tmp` for the next `git add -A` to ship.
     """
     tmp = path + '.tmp'
-    with open(tmp, 'w', encoding='utf-8') as f:
-        json.dump(doc, f, indent=1, sort_keys=True)
-    os.replace(tmp, path)
+    try:
+        with open(tmp, 'w', encoding='utf-8') as f:
+            json.dump(doc, f, indent=1, sort_keys=True)
+        os.replace(tmp, path)
+    except BaseException:
+        # BaseException, not Exception: KeyboardInterrupt is the motivating
+        # case and does not inherit from Exception.
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def main(argv=None):
@@ -277,11 +311,29 @@ def main(argv=None):
     # Fail on an unwritable --out BEFORE spending 42 s, not after. A
     # `FileNotFoundError` traceback from `write()` at the end of a full census
     # is the same information delivered at the worst possible moment.
+    # `isdir` alone is not enough: it answers "is there a directory here", not
+    # "can I write there". An illegal filename (`tests/a?b.json`), a read-only
+    # directory, a full disk all pass it and then raise from `write()` 42 s
+    # later. So PROBE the exact path `write()` will use, and delete the probe.
     out_dir = os.path.dirname(os.path.abspath(a.out))
     if not os.path.isdir(out_dir):
         p.error(f"--out directory does not exist: {out_dir}")
     if os.path.isdir(a.out):
         p.error(f"--out is a directory, not a file: {a.out}")
+    probe = a.out + '.tmp'
+    probe_existed = os.path.exists(probe)
+    try:
+        with open(probe, 'a', encoding='utf-8'):
+            pass
+    except OSError as exc:
+        p.error(f"--out is not writable: {a.out} ({exc})")
+    if not probe_existed:
+        # Only remove what this probe created. A `.tmp` already sitting there
+        # is somebody else's business -- possibly a concurrent recorder's.
+        try:
+            os.remove(probe)
+        except OSError:
+            pass
 
     doc = census(a.repo, quiet=a.quiet)
 

--- a/tests/test_713_abstention_drift.py
+++ b/tests/test_713_abstention_drift.py
@@ -329,6 +329,28 @@ def arm_engine(census_mod):
           f"{len(pairs)} (rule, reason) pair(s) the engine can produce")
 
 
+def summary(code=None):
+    """The one exit. EVERY return in `main` goes through it.
+
+    They did not, and the drift-gate mutation battery caught it: with the
+    ENGINE arm failing AND the recorder then unable to run, the arm's finding
+    was collected into FAILURES and never printed -- `main` returned 1 from the
+    recorder branch first. Non-zero, so the row still went red, but naming a
+    different cause than the one actually found. A gate that discards its own
+    findings on the way out is this PR's subject one level up.
+
+    `code` forces an exit code (77 for a SKIP) when nothing has failed;
+    a real failure always wins over a skip, and always gets printed.
+    """
+    if code is not None and not FAILURES:
+        return code
+    print(f"\n{'FAIL' if FAILURES else 'PASS'}: #879 census drift, "
+          f"{len(FAILURES)} failure(s)")
+    for f in FAILURES:
+        print(f"  - {f}")
+    return 1 if FAILURES else 0
+
+
 def main():
     print("#879 abstention-census drift")
 
@@ -349,23 +371,23 @@ def main():
         # actually raises; everything else must reach the traceback.
         print(f"SKIP: git cannot name the tracked corpus here "
               f"({type(exc).__name__}), so there is no set to census: {exc}")
-        return 77
+        return summary(77)
     if not boards:
         print("SKIP: git named no tracked boards, so this would grade nothing")
-        return 77
+        return summary(77)
 
     if not os.path.isfile(BASELINE):
         # NOT a pass. Deleting the baseline must not delete the protection
         # behind exit 0.
         print(f"FAIL: no baseline at {BASELINE}. Re-record it deliberately:\n"
               f"  {REMEDY}")
-        return 1
+        return summary(1)
     try:
         with open(BASELINE, encoding='utf-8') as fh:
             expected = json.load(fh)
     except Exception as exc:                                   # noqa: BLE001
         print(f"FAIL: baseline unreadable: {exc}\n  {REMEDY}")
-        return 1
+        return summary(1)
 
     # Re-derive into a temp dir. The recorder's default `--out` IS the
     # committed file, so a gate that forgot this flag would overwrite the very
@@ -387,12 +409,12 @@ def main():
                   f"there is no census to compare. This is the only one of "
                   f"the three clocks that gives a reason, which is why it is "
                   f"set below run_all's {RUN_ALL_TIMEOUT} s budget.")
-            return 1
+            return summary(1)
         if r.returncode != 0 or not os.path.isfile(out):
             tail = (r.stdout + r.stderr).strip()[-800:]
             print(f"FAIL: the recorder did not produce a census "
                   f"(exit {r.returncode}):\n{tail}")
-            return 1
+            return summary(1)
         with open(out, encoding='utf-8') as fh:
             current = json.load(fh)
 
@@ -420,11 +442,7 @@ def main():
               f"row(s) match this run of "
               f"{os.path.basename(RECORDER)}")
 
-    print(f"\n{'FAIL' if FAILURES else 'PASS'}: #879 census drift, "
-          f"{len(FAILURES)} failure(s)")
-    for f in FAILURES:
-        print(f"  - {f}")
-    return 1 if FAILURES else 0
+    return summary()
 
 
 if __name__ == '__main__':

--- a/tests/test_713_abstention_drift.py
+++ b/tests/test_713_abstention_drift.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""#879: the committed abstention census must still be what the tree produces.
+
+`tests/713_abstention_census.json` records, per tracked board, whether the
+emit-intent -> grade round trip reports a CLEAN verdict while a channel the
+intent ASKED FOR went ungraded. Nothing re-derived it. Its recorder is not
+named `test_*.py`, so `run_all.py`'s glob never collected it, and a tree-wide
+grep finds no other caller -- so the file was free to drift arbitrarily far
+from the tree while still reading as authoritative.
+
+It did. Measured over the four days between its only two recordings:
+
+    rules_run                                   moved on 22 boards
+    pass / grade_rc / human_pass_line /
+    clean_but_ungraded                          moved on  5 boards
+    boards_clean_but_ungraded                   5 -> 0
+
+The second recording was made as part of #837, and the `5 -> 0` was published
+in a commit message AND a code comment as that change's effect. It was not:
+a reviewer re-ran the census at the base commit with none of the new code
+present and found those five boards already failing. The drift was
+`budget_abstained` making the grade incomplete, days earlier and unrelated.
+
+A stale baseline is worse than an absent one. Absent, you measure. Stale, you
+diff -- and the diff goes out signed with your name.
+
+    python3 -X utf8 tests/test_713_abstention_drift.py
+
+Two arms, and the cheap one is not a formality:
+
+  DRIFT   re-derives the whole census (~45 s) and compares it to the committed
+          file, per board and per key.
+  MIRROR  asserts `NOT_ASKED` still equals `floorplan._SKIP_REASON`'s values,
+          in milliseconds. That set is hand-maintained and has already fallen
+          out of step once (#837 added `assembly_side` and did not update it),
+          which silently reclassifies an honest skip as a real abstention. The
+          DRIFT arm sees only the symptom, and only once somebody re-records;
+          this one catches the cause.
+
+WHY NOT `RUN_ALL_FAST_OK`. This shells out 44 times. `run_all`'s marker is
+documented for the case where "the shelling-out really is cheap" -- one
+`git ls-files` -- and 45 s of `check_floorplan.py` is not that. So it stays in
+the integration bucket and `--fast` skips it, deliberately.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+TESTS = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(TESTS)
+sys.path[:0] = [os.path.join(ROOT, 'py_router'), os.path.join(ROOT, 'py_placer')]
+
+#: 42.6 s measured on the author's machine, dominated by `parse_kicad_pcb` on
+#: the four large boards. Declared with headroom so a slower box reports FAIL
+#: rather than TIME -- and note the recorder's own per-subprocess timeout is
+#: 900 s, so a genuinely hung `check_floorplan` blows that first.
+RUN_ALL_TIMEOUT = 900
+
+BASELINE = os.path.join(TESTS, '713_abstention_census.json')
+RECORDER = os.path.join(TESTS, '713_abstention_census.py')
+
+#: How to re-record, printed with every failure. A gate that says "this moved"
+#: without saying what to do about it gets worked around rather than answered.
+REMEDY = ('python3 -X utf8 tests/713_abstention_census.py   '
+          '# then READ the diff before committing it')
+
+FAILURES = []
+
+
+def fail(msg):
+    FAILURES.append(msg)
+
+
+def _load_recorder():
+    """Import the recorder WITHOUT running the census.
+
+    Possible only since #879 phase 1 gave it a `main()`; before that, importing
+    this module ran a 42 s corpus grade as a side effect. If that regresses,
+    this import is where it shows up -- as a 42 s pause in a test that claims
+    to be milliseconds.
+    """
+    spec = importlib.util.spec_from_file_location('abstention_census',
+                                                  RECORDER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --- the comparator ---------------------------------------------------------
+#
+# Verdict vocabulary and message shapes are `tests/test_placement_ab.py`'s
+# `compare_baseline` (its docstring explains each), reused rather than
+# reinvented. One is deliberately NOT carried over: INVERTED compares the
+# direction of an off/on pair, and this document has no arms -- there is
+# nothing to reverse. Saying so here is cheaper than leaving the next reader to
+# wonder which verdict went missing and why.
+
+def compare(current, expected):
+    """Problems, as strings. Every class is fatal; they are kept apart because
+    they mean different things."""
+    problems = []
+    if not isinstance(expected, dict):
+        # REPORTED, not raised: crashing after a 45 s re-derive is not a
+        # verdict, and the message a reader needs is which shape it found.
+        return [f"MALFORMED baseline: expected an object, got "
+                f"{type(expected).__name__}"]
+
+    for key in sorted(set(current) | set(expected)):
+        if key == 'rows':
+            continue
+        if key not in expected:
+            problems.append(f"NEW KEY {key}: measured {current[key]!r}, "
+                            f"the baseline has never seen it")
+        elif key not in current:
+            problems.append(f"MISSING KEY {key}: the baseline records "
+                            f"{expected[key]!r}, this run produced nothing")
+        elif current[key] != expected[key]:
+            problems.append(f"DRIFT {key}: baseline {expected[key]!r}, "
+                            f"measured {current[key]!r}")
+
+    cur_rows = {r.get('board'): r for r in (current.get('rows') or [])}
+    exp_rows = expected.get('rows')
+    if not isinstance(exp_rows, list):
+        problems.append("MALFORMED baseline.rows: expected a list, got "
+                        f"{type(exp_rows).__name__}")
+        return problems
+    exp_rows = {r.get('board'): r for r in exp_rows if isinstance(r, dict)}
+
+    for board in sorted(set(cur_rows) | set(exp_rows)):
+        cur, exp = cur_rows.get(board), exp_rows.get(board)
+        if exp is None:
+            problems.append(f"NEW ROW {board}: not in the baseline")
+            continue
+        if cur is None:
+            problems.append(f"MISSING {board}: in the baseline, not measured "
+                            f"in this run")
+            continue
+        # Per KEY, never a whole-row equality. An aggregate verdict cannot say
+        # which of its inputs moved -- #694's lesson, and the reason the
+        # misattribution this gate exists for was possible at all.
+        for key in sorted(set(cur) | set(exp)):
+            if key not in exp:
+                problems.append(f"NEW KEY {board}.{key}: measured "
+                                f"{cur[key]!r}")
+            elif key not in cur:
+                problems.append(f"MISSING KEY {board}.{key}: the baseline "
+                                f"records {exp[key]!r}")
+            elif cur[key] != exp[key]:
+                problems.append(f"DRIFT {board}.{key}: baseline {exp[key]!r}, "
+                                f"measured {cur[key]!r}")
+    return problems
+
+
+def arm_mirror(census_mod):
+    """`NOT_ASKED` is a hand-copy of `floorplan._SKIP_REASON`'s values.
+
+    Both directions. A reason the census does not know falls through
+    `classify()` to `'arm'` -- a real abstention -- so a stale mirror does not
+    error, it quietly changes the answer. And an entry here that `_SKIP_REASON`
+    no longer produces is a claim about a rule that no longer exists.
+    """
+    from placement.floorplan import _SKIP_REASON
+    declared = set(_SKIP_REASON.values())
+    mirrored = set(census_mod.NOT_ASKED)
+    # `not requested` is raised outside the RULES loop, so it is legitimately
+    # in the mirror and not in _SKIP_REASON. Named, not silently subtracted.
+    extra_by_design = {'not requested'}
+
+    missing = sorted(declared - mirrored)
+    if missing:
+        fail(f"NOT_ASKED is missing {len(missing)} _SKIP_REASON value(s), so "
+             f"an honest skip is classified as a real abstention: "
+             f"{missing}")
+    stale = sorted(mirrored - declared - extra_by_design)
+    if stale:
+        fail(f"NOT_ASKED carries {len(stale)} reason(s) _SKIP_REASON no longer "
+             f"produces: {stale}")
+    if not missing and not stale:
+        print(f"  ok   MIRROR: NOT_ASKED == _SKIP_REASON values "
+              f"({len(declared)} reasons, both directions)")
+
+
+def main():
+    print("#879 abstention-census drift")
+
+    census_mod = _load_recorder()
+    arm_mirror(census_mod)
+
+    # The corpus comes from `git ls-files`. Where git cannot answer, SKIP
+    # loudly rather than grading a set we cannot identify -- the rule
+    # `run_utils.corpus_boards` states and `test_714_identity_write_unchanged`
+    # follows.
+    try:
+        boards = census_mod.tracked_boards(ROOT)
+    except Exception as exc:                                   # noqa: BLE001
+        print(f"SKIP: git cannot name the tracked corpus here "
+              f"({type(exc).__name__}), so there is no set to census: {exc}")
+        return 77
+    if not boards:
+        print("SKIP: git named no tracked boards, so this would grade nothing")
+        return 77
+
+    if not os.path.isfile(BASELINE):
+        # NOT a pass. Deleting the baseline must not delete the protection
+        # behind exit 0.
+        print(f"FAIL: no baseline at {BASELINE}. Re-record it deliberately:\n"
+              f"  {REMEDY}")
+        return 1
+    try:
+        with open(BASELINE, encoding='utf-8') as fh:
+            expected = json.load(fh)
+    except Exception as exc:                                   # noqa: BLE001
+        print(f"FAIL: baseline unreadable: {exc}\n  {REMEDY}")
+        return 1
+
+    # Re-derive into a temp dir. The recorder's default `--out` IS the
+    # committed file, so a gate that forgot this flag would overwrite the very
+    # document it is comparing against and then report a match.
+    with tempfile.TemporaryDirectory() as td:
+        out = os.path.join(td, 'fresh.json')
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8', RECORDER, ROOT, '--out', out, '-q'],
+            capture_output=True, text=True, encoding='utf-8',
+            errors='replace', cwd=ROOT, timeout=RUN_ALL_TIMEOUT)
+        if r.returncode != 0 or not os.path.isfile(out):
+            tail = (r.stdout + r.stderr).strip()[-800:]
+            print(f"FAIL: the recorder did not produce a census "
+                  f"(exit {r.returncode}):\n{tail}")
+            return 1
+        with open(out, encoding='utf-8') as fh:
+            current = json.load(fh)
+
+    problems = compare(current, expected)
+    if problems:
+        fail(f"{len(problems)} baseline problem(s)")
+        print(f"\nbaseline: {len(problems)} problem(s) vs "
+              f"{os.path.basename(BASELINE)}")
+        for p in problems[:40]:
+            print(f"  {p}")
+        if len(problems) > 40:
+            print(f"  ... and {len(problems) - 40} more")
+        print("\n  READ THE DIFF BEFORE RE-RECORDING. A number that moved for "
+              "someone else's reason becomes yours the moment you re-record "
+              "it and cite it -- which is the mistake this gate exists to "
+              "prevent (#879).\n"
+              f"  {REMEDY}")
+    else:
+        print(f"  ok   DRIFT: {len(current.get('rows') or ())} board(s) match "
+              f"{os.path.basename(BASELINE)}")
+
+    print(f"\n{'FAIL' if FAILURES else 'PASS'}: #879 census drift, "
+          f"{len(FAILURES)} failure(s)")
+    for f in FAILURES:
+        print(f"  - {f}")
+    return 1 if FAILURES else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_713_abstention_drift.py
+++ b/tests/test_713_abstention_drift.py
@@ -28,14 +28,15 @@ diff -- and the diff goes out signed with your name.
 
 Two arms, and the cheap one is not a formality:
 
-  DRIFT   re-derives the whole census (~45 s) and compares it to the committed
+  DRIFT   re-derives the whole census (~40 s) and compares it to the committed
           file, per board and per key.
-  MIRROR  asserts `NOT_ASKED` still equals `floorplan._SKIP_REASON`'s values,
-          in milliseconds. That set is hand-maintained and has already fallen
-          out of step once (#837 added `assembly_side` and did not update it),
-          which silently reclassifies an honest skip as a real abstention. The
-          DRIFT arm sees only the symptom, and only once somebody re-records;
-          this one catches the cause.
+  ENGINE  asserts the census still ASKS `floorplan._is_not_asked` which skips
+          are the honest kind, rather than keeping its own copy of the reason
+          strings, in milliseconds. It kept one once, and it went stale (#837
+          added `assembly_side` and the copy was not updated), which silently
+          reclassifies an honest skip as a real abstention. The DRIFT arm sees
+          only the symptom, and only once somebody re-records; this one catches
+          the cause.
 
 WHY NOT `RUN_ALL_FAST_OK`. This shells out 44 times. `run_all`'s marker is
 documented for the case where "the shelling-out really is cheap" -- one
@@ -53,16 +54,30 @@ import tempfile
 
 TESTS = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(TESTS)
-sys.path[:0] = [os.path.join(ROOT, 'py_router'), os.path.join(ROOT, 'py_placer')]
+sys.path[:0] = [os.path.join(ROOT, 'py_router'),
+                os.path.join(ROOT, 'py_placer')]
 
-#: 42.6 s measured on the author's machine, dominated by `parse_kicad_pcb` on
-#: the four large boards. Declared with headroom so a slower box reports FAIL
-#: rather than TIME. The recorder's own per-subprocess timeout is also 900 s,
-#: and this one ALWAYS expires first: the outer clock starts when the recorder
-#: launches, the inner one when the hung board's `check_floorplan` does. So a
-#: hang surfaces here, which is why the timeout is caught and named rather than
-#: left to raise.
+#: 40 s measured on an idle machine, dominated by `parse_kicad_pcb` on the four
+#: large boards. Declared with headroom so a slower box reports FAIL rather
+#: than TIME.
 RUN_ALL_TIMEOUT = 900
+
+#: THREE clocks can expire on a hang, and only this one gives a reason, so it
+#: is set below the other two rather than equal to them:
+#:
+#:   run_all's budget          `max(RUN_ALL_TIMEOUT, 600)` = 900, started at
+#:                             process spawn -> prints `TIME (... NOT a failed
+#:                             assertion)`, which discloses nothing about why
+#:   this gate's subprocess     started ~1 s later, after import and the ENGINE
+#:                             arm -> `FAIL: the recorder did not finish ...`
+#:   the recorder's own        900 s per `check_floorplan` child, started later
+#:                             still
+#:
+#: Set equal, run_all always wins by that ~1 s head start and the named path is
+#: unreachable under the runner -- measured: forced equal, standalone printed
+#: the reason and `run_all` printed only `TIME`. The margin makes the reason
+#: reachable where a reader will actually meet it.
+RECORDER_TIMEOUT = RUN_ALL_TIMEOUT - 120
 
 BASELINE = os.path.join(TESTS, '713_abstention_census.json')
 RECORDER = os.path.join(TESTS, '713_abstention_census.py')
@@ -96,12 +111,21 @@ def _load_recorder():
 
 # --- the comparator ---------------------------------------------------------
 #
-# Verdict vocabulary and message shapes are `tests/test_placement_ab.py`'s
-# `compare_baseline` (its docstring explains each), reused rather than
-# reinvented. One is deliberately NOT carried over: INVERTED compares the
-# direction of an off/on pair, and this document has no arms -- there is
-# nothing to reverse. Saying so here is cheaper than leaving the next reader to
-# wonder which verdict went missing and why.
+# DRIFT, MISSING, MALFORMED and the message shapes are
+# `tests/test_placement_ab.py`'s `compare_baseline` (its docstring explains
+# each), reused rather than reinvented. The rest of that vocabulary does not
+# transfer, and the reader is owed which is which rather than left to wonder:
+#
+#   INVERTED  NOT carried over. It compares the direction of an off/on pair,
+#             and this document has no arms -- there is nothing to reverse.
+#   ORPHAN    NOT carried over. There, it means a baseline row that `ROWS` no
+#             longer declares; here the row set is the corpus itself, so that
+#             case is MISSING (in the baseline, not measured).
+#   NEW ROW / NEW KEY / MISSING KEY / DUPLICATE
+#             NEW here. This document is a per-board table with a fixed key
+#             set, which `placement_ab_baseline.json` is not, so appearing,
+#             gaining a field and being recorded twice are all reachable and
+#             all mean different things.
 
 def diff_value(label, exp_v, cur_v, problems):
     """One value -- or one level deeper when both sides are objects.
@@ -122,7 +146,17 @@ def diff_value(label, exp_v, cur_v, problems):
             else:
                 diff_value(f'{label}.{k}', exp_v[k], cur_v[k], problems)
         return
-    if exp_v != cur_v:
+    # TYPE too, not just value. `1 == True` and `22 == 22.0` in Python, so a
+    # baseline whose `pass` is `1` where the run produces `true`, or whose
+    # counts have become floats, compares equal and the gate says nothing. It
+    # is a shape change in a recorded measurement, and this document's ints and
+    # bools carry different meanings -- assert the shape, not just the value.
+    if type(exp_v) is not type(cur_v):
+        problems.append(f"DRIFT {label}: baseline {exp_v!r} "
+                        f"({type(exp_v).__name__}), measured {cur_v!r} "
+                        f"({type(cur_v).__name__}) -- same value, different "
+                        f"type")
+    elif exp_v != cur_v:
         problems.append(f"DRIFT {label}: baseline {exp_v!r}, "
                         f"measured {cur_v!r}")
 
@@ -199,6 +233,16 @@ def compare(current, expected):
     exp_rows, exp_problems = index_rows(exp_raw, 'baseline')
     problems += exp_problems
 
+    # `boards_total` is compared baseline-vs-measured above, but never against
+    # the rows it counts -- so a document whose header disagrees with its own
+    # body on BOTH sides is internally inconsistent and silent. Cheap to hold.
+    for doc, where, rows in ((expected, 'baseline', exp_raw),
+                             (current, 'measured', current.get('rows') or [])):
+        total = doc.get('boards_total')
+        if isinstance(total, int) and total != len(rows):
+            problems.append(f"MALFORMED {where}: boards_total says {total}, "
+                            f"rows holds {len(rows)}")
+
     for board in sorted(set(cur_rows) | set(exp_rows)):
         cur, exp = cur_rows.get(board), exp_rows.get(board)
         if exp is None:
@@ -223,50 +267,73 @@ def compare(current, expected):
     return problems
 
 
-def arm_mirror(census_mod):
-    """`NOT_ASKED` is a hand-copy of `floorplan._SKIP_REASON`'s values.
+def arm_engine(census_mod):
+    """`classify` must ASK the engine, not re-implement it.
 
-    Both directions. A reason the census does not know falls through
-    `classify()` to `'arm'` -- a real abstention -- so a stale mirror does not
-    error, it quietly changes the answer. And an entry here that `_SKIP_REASON`
-    no longer produces is a claim about a rule that no longer exists.
+    This arm replaces a set-equality check against `floorplan._SKIP_REASON`'s
+    VALUES, and the reason it replaces it is the point. The census used to keep
+    its own copy of those strings; the arm compared the two sets in both
+    directions and would have caught the copy going stale. But the engine
+    exports `_is_not_asked(rule, reason)` as, in its own words, "ONE home for
+    the distinction", keyed on the RULE precisely because a value match "meant
+    an `_ARM` reason that ever happened to equal some OTHER rule's skip reason
+    would read as 'nobody asked' -- a real abstention silently downgraded to a
+    pass". Two sets can be perfectly equal and that collision still happen, so
+    the mirror arm was green in exactly the case it most needed to be red.
+
+    Calling the engine deletes the mirror, and this arm holds it deleted: a
+    census that grows its own copy again reintroduces the drift AND the
+    collision. Milliseconds, no subprocess.
     """
+    from placement.floorplan import _is_not_asked, _WITHHELD_MARK
+    if census_mod.classify.__code__.co_argcount != 2:
+        fail("classify() no longer takes (rule, reason). Keyed on the reason "
+             "alone it cannot tell two rules that share a skip-reason string "
+             "apart -- and _SKIP_REASON has 12 keys to 11 distinct values")
+        return
+    for name in ('NOT_ASKED', 'WITHHELD_MARK', '_SKIP_REASON'):
+        if hasattr(census_mod, name):
+            fail(f"the census has grown its own `{name}` again. That copy is "
+                 f"what #879 is about: it went stale once already, and a "
+                 f"value-keyed match is the downgrade `_is_not_asked` exists "
+                 f"to prevent. Call the engine")
+            return
+    # And the call must actually REACH it: agree with the engine on every pair
+    # the engine can produce, and on the `not requested` fallback grade()
+    # raises outside the RULES loop for a rule with no recorded reason.
+    #
+    # That fallback is the one place the swap changed an ANSWER. The old
+    # hand-copy listed `not requested` as "nobody asked"; `_is_not_asked` says
+    # no, because it cannot match a rule that recorded no reason -- so it now
+    # counts as an abstention. The engine is right: an unexplained skip is
+    # exactly the case that must not read as a pass, and this is the direction
+    # its docstring calls safe. Unreachable today (`RULES` and `_SKIP_REASON`
+    # have the same 12 keys, so the fallback never fires), which is why the
+    # re-record is byte-identical -- but pinned here so the change is a
+    # decision on record rather than a silent consequence.
     from placement.floorplan import _SKIP_REASON
-    declared = set(_SKIP_REASON.values())
-    mirrored = set(census_mod.NOT_ASKED)
-    # `not requested` is raised outside the RULES loop, so it is legitimately
-    # in the mirror and not in _SKIP_REASON. Named, not silently subtracted.
-    extra_by_design = {'not requested'}
-
-    missing = sorted(declared - mirrored)
-    if missing:
-        fail(f"NOT_ASKED is missing {len(missing)} _SKIP_REASON value(s), so "
-             f"an honest skip is classified as a real abstention: "
-             f"{missing}")
-    stale = sorted(mirrored - declared - extra_by_design)
-    if stale:
-        fail(f"NOT_ASKED carries {len(stale)} reason(s) _SKIP_REASON no longer "
-             f"produces: {stale}")
-    # An exemption is a claim, so hold it in both directions too. Subtracting a
-    # set without asserting it is PRESENT means `not requested` can be deleted
-    # from the mirror and both arms above stay silent -- the exemption quietly
-    # covering its own absence.
-    absent = sorted(extra_by_design - mirrored)
-    if absent:
-        fail(f"NOT_ASKED no longer carries {absent}, which floorplan raises "
-             f"OUTSIDE the RULES loop (the `.get(name, ...)` fallback) and "
-             f"_SKIP_REASON therefore never declares. Dropped, that reason "
-             f"classifies as a real abstention.")
-    if not missing and not stale and not absent:
-        print(f"  ok   MIRROR: NOT_ASKED == _SKIP_REASON values "
-              f"({len(declared)} reasons, both directions)")
+    pairs = list(_SKIP_REASON.items()) + [('a_rule_with_no_reason',
+                                           'not requested')]
+    wrong = [(rule, reason, census_mod.classify(rule, reason))
+             for rule, reason in pairs
+             if (census_mod.classify(rule, reason) == 'not_asked')
+             is not bool(_is_not_asked(rule, reason))]
+    if wrong:
+        fail(f"classify disagrees with floorplan._is_not_asked on "
+             f"{len(wrong)} pair(s): {wrong[:5]}")
+        return
+    if census_mod._WITHHELD_MARK is not _WITHHELD_MARK:
+        fail("the census's WITHHELD mark is not the engine's object")
+        return
+    print(f"  ok   ENGINE: classify() calls _is_not_asked, agreeing on all "
+          f"{len(pairs)} (rule, reason) pair(s) the engine can produce")
 
 
 def main():
     print("#879 abstention-census drift")
 
     census_mod = _load_recorder()
-    arm_mirror(census_mod)
+    arm_engine(census_mod)
 
     # The corpus comes from `git ls-files`. Where git cannot answer, SKIP
     # loudly rather than grading a set we cannot identify -- the rule
@@ -274,7 +341,12 @@ def main():
     # follows.
     try:
         boards = census_mod.tracked_boards(ROOT)
-    except Exception as exc:                                   # noqa: BLE001
+    except (subprocess.CalledProcessError, OSError) as exc:
+        # NARROW on purpose. A bare `except Exception` here attributes any
+        # recorder-side bug -- an AttributeError, a bad import -- to "git is
+        # missing", and turns a broken gate into a clean SKIP that run_all
+        # scores as exit 0. These two are what an absent or unhappy git
+        # actually raises; everything else must reach the traceback.
         print(f"SKIP: git cannot name the tracked corpus here "
               f"({type(exc).__name__}), so there is no set to census: {exc}")
         return 77
@@ -305,15 +377,16 @@ def main():
                 [sys.executable, '-X', 'utf8', RECORDER, ROOT,
                  '--out', out, '-q'],
                 capture_output=True, text=True, encoding='utf-8',
-                errors='replace', cwd=ROOT, timeout=RUN_ALL_TIMEOUT)
+                errors='replace', cwd=ROOT, timeout=RECORDER_TIMEOUT)
         except subprocess.TimeoutExpired:
             # A traceback here reads as a broken test, not as a verdict --
             # CLAUDE.md's rule that a non-zero exit is not evidence, assert the
             # REASON. Say which clock ran out and how long it was given.
             print(f"FAIL: the recorder did not finish within "
-                  f"RUN_ALL_TIMEOUT={RUN_ALL_TIMEOUT} s (measured 42.6 s), so "
-                  f"there is no census to compare. A hung `check_floorplan` "
-                  f"surfaces here, not on the recorder's own equal timer.")
+                  f"RECORDER_TIMEOUT={RECORDER_TIMEOUT} s (measured 40 s), so "
+                  f"there is no census to compare. This is the only one of "
+                  f"the three clocks that gives a reason, which is why it is "
+                  f"set below run_all's {RUN_ALL_TIMEOUT} s budget.")
             return 1
         if r.returncode != 0 or not os.path.isfile(out):
             tail = (r.stdout + r.stderr).strip()[-800:]

--- a/tests/test_713_abstention_drift.py
+++ b/tests/test_713_abstention_drift.py
@@ -57,8 +57,11 @@ sys.path[:0] = [os.path.join(ROOT, 'py_router'), os.path.join(ROOT, 'py_placer')
 
 #: 42.6 s measured on the author's machine, dominated by `parse_kicad_pcb` on
 #: the four large boards. Declared with headroom so a slower box reports FAIL
-#: rather than TIME -- and note the recorder's own per-subprocess timeout is
-#: 900 s, so a genuinely hung `check_floorplan` blows that first.
+#: rather than TIME. The recorder's own per-subprocess timeout is also 900 s,
+#: and this one ALWAYS expires first: the outer clock starts when the recorder
+#: launches, the inner one when the hung board's `check_floorplan` does. So a
+#: hang surfaces here, which is why the timeout is caught and named rather than
+#: left to raise.
 RUN_ALL_TIMEOUT = 900
 
 BASELINE = os.path.join(TESTS, '713_abstention_census.json')
@@ -100,6 +103,70 @@ def _load_recorder():
 # nothing to reverse. Saying so here is cheaper than leaving the next reader to
 # wonder which verdict went missing and why.
 
+def diff_value(label, exp_v, cur_v, problems):
+    """One value -- or one level deeper when both sides are objects.
+
+    `channels_seen` is a nested dict, and reporting it whole hands the reader
+    two five-key objects to diff by eye. That is the aggregate-verdict mistake
+    #694 is about, in the one place in this document where it could still
+    happen: `DRIFT channels_seen.budget_abstained` names the input that moved,
+    where the whole-dict form only says the dict is different.
+    """
+    if isinstance(exp_v, dict) and isinstance(cur_v, dict):
+        for k in sorted(set(exp_v) | set(cur_v)):
+            if k not in exp_v:
+                problems.append(f"NEW KEY {label}.{k}: measured {cur_v[k]!r}")
+            elif k not in cur_v:
+                problems.append(f"MISSING KEY {label}.{k}: the baseline "
+                                f"records {exp_v[k]!r}")
+            else:
+                diff_value(f'{label}.{k}', exp_v[k], cur_v[k], problems)
+        return
+    if exp_v != cur_v:
+        problems.append(f"DRIFT {label}: baseline {exp_v!r}, "
+                        f"measured {cur_v!r}")
+
+
+def index_rows(rows, where):
+    """`board` -> row, and the problems found while indexing.
+
+    The obvious `{r['board']: r for r in rows}` is LAST-WINS, and it silently
+    drops any row without a usable `board`. Both matter here:
+
+    * A duplicated board makes one of the two copies invisible to every
+      comparison downstream -- so a baseline row claiming `pass: false` about a
+      board that passes can sit in the committed file while the gate reports
+      zero problems. That is not exotic for a 22-row JSON array: it is what a
+      merge conflict resolved by keeping both hunks produces, and a
+      hand-edited baseline is this gate's entire threat model.
+    * A row with no `board` key indexes under `None`, and `sorted()` over a set
+      holding `None` and strings raises `TypeError` -- a traceback after a 40 s
+      re-derive, which is not a verdict and is indistinguishable from a broken
+      test.
+
+    Both are REPORTED, by name and row index.
+    """
+    indexed, problems, seen = {}, [], {}
+    for i, row in enumerate(rows):
+        if not isinstance(row, dict):
+            problems.append(f"MALFORMED {where}.rows[{i}]: expected an "
+                            f"object, got {type(row).__name__}")
+            continue
+        board = row.get('board')
+        if not isinstance(board, str):
+            problems.append(f"MALFORMED {where}.rows[{i}]: 'board' is "
+                            f"{board!r}, not a string")
+            continue
+        if board in seen:
+            problems.append(f"DUPLICATE {where}.rows[{i}]: {board} is already "
+                            f"row {seen[board]}; only one of the two would be "
+                            f"compared, so the other never had to be right")
+            continue
+        seen[board] = i
+        indexed[board] = row
+    return indexed, problems
+
+
 def compare(current, expected):
     """Problems, as strings. Every class is fatal; they are kept apart because
     they mean different things."""
@@ -119,17 +186,18 @@ def compare(current, expected):
         elif key not in current:
             problems.append(f"MISSING KEY {key}: the baseline records "
                             f"{expected[key]!r}, this run produced nothing")
-        elif current[key] != expected[key]:
-            problems.append(f"DRIFT {key}: baseline {expected[key]!r}, "
-                            f"measured {current[key]!r}")
+        else:
+            diff_value(key, expected[key], current[key], problems)
 
-    cur_rows = {r.get('board'): r for r in (current.get('rows') or [])}
-    exp_rows = expected.get('rows')
-    if not isinstance(exp_rows, list):
+    cur_rows, cur_problems = index_rows(current.get('rows') or [], 'measured')
+    problems += cur_problems
+    exp_raw = expected.get('rows')
+    if not isinstance(exp_raw, list):
         problems.append("MALFORMED baseline.rows: expected a list, got "
-                        f"{type(exp_rows).__name__}")
+                        f"{type(exp_raw).__name__}")
         return problems
-    exp_rows = {r.get('board'): r for r in exp_rows if isinstance(r, dict)}
+    exp_rows, exp_problems = index_rows(exp_raw, 'baseline')
+    problems += exp_problems
 
     for board in sorted(set(cur_rows) | set(exp_rows)):
         cur, exp = cur_rows.get(board), exp_rows.get(board)
@@ -150,9 +218,8 @@ def compare(current, expected):
             elif key not in cur:
                 problems.append(f"MISSING KEY {board}.{key}: the baseline "
                                 f"records {exp[key]!r}")
-            elif cur[key] != exp[key]:
-                problems.append(f"DRIFT {board}.{key}: baseline {exp[key]!r}, "
-                                f"measured {cur[key]!r}")
+            else:
+                diff_value(f'{board}.{key}', exp[key], cur[key], problems)
     return problems
 
 
@@ -180,7 +247,17 @@ def arm_mirror(census_mod):
     if stale:
         fail(f"NOT_ASKED carries {len(stale)} reason(s) _SKIP_REASON no longer "
              f"produces: {stale}")
-    if not missing and not stale:
+    # An exemption is a claim, so hold it in both directions too. Subtracting a
+    # set without asserting it is PRESENT means `not requested` can be deleted
+    # from the mirror and both arms above stay silent -- the exemption quietly
+    # covering its own absence.
+    absent = sorted(extra_by_design - mirrored)
+    if absent:
+        fail(f"NOT_ASKED no longer carries {absent}, which floorplan raises "
+             f"OUTSIDE the RULES loop (the `.get(name, ...)` fallback) and "
+             f"_SKIP_REASON therefore never declares. Dropped, that reason "
+             f"classifies as a real abstention.")
+    if not missing and not stale and not absent:
         print(f"  ok   MIRROR: NOT_ASKED == _SKIP_REASON values "
               f"({len(declared)} reasons, both directions)")
 
@@ -223,10 +300,21 @@ def main():
     # document it is comparing against and then report a match.
     with tempfile.TemporaryDirectory() as td:
         out = os.path.join(td, 'fresh.json')
-        r = subprocess.run(
-            [sys.executable, '-X', 'utf8', RECORDER, ROOT, '--out', out, '-q'],
-            capture_output=True, text=True, encoding='utf-8',
-            errors='replace', cwd=ROOT, timeout=RUN_ALL_TIMEOUT)
+        try:
+            r = subprocess.run(
+                [sys.executable, '-X', 'utf8', RECORDER, ROOT,
+                 '--out', out, '-q'],
+                capture_output=True, text=True, encoding='utf-8',
+                errors='replace', cwd=ROOT, timeout=RUN_ALL_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            # A traceback here reads as a broken test, not as a verdict --
+            # CLAUDE.md's rule that a non-zero exit is not evidence, assert the
+            # REASON. Say which clock ran out and how long it was given.
+            print(f"FAIL: the recorder did not finish within "
+                  f"RUN_ALL_TIMEOUT={RUN_ALL_TIMEOUT} s (measured 42.6 s), so "
+                  f"there is no census to compare. A hung `check_floorplan` "
+                  f"surfaces here, not on the recorder's own equal timer.")
+            return 1
         if r.returncode != 0 or not os.path.isfile(out):
             tail = (r.stdout + r.stderr).strip()[-800:]
             print(f"FAIL: the recorder did not produce a census "
@@ -243,15 +331,21 @@ def main():
         for p in problems[:40]:
             print(f"  {p}")
         if len(problems) > 40:
-            print(f"  ... and {len(problems) - 40} more")
+            print(f"  ... and {len(problems) - 40} more (sorted, so what is "
+                  f"cut is the tail of the alphabet -- re-record and read the "
+                  f"diff for the whole set)")
         print("\n  READ THE DIFF BEFORE RE-RECORDING. A number that moved for "
               "someone else's reason becomes yours the moment you re-record "
               "it and cite it -- which is the mistake this gate exists to "
               "prevent (#879).\n"
               f"  {REMEDY}")
     else:
-        print(f"  ok   DRIFT: {len(current.get('rows') or ())} board(s) match "
-              f"{os.path.basename(BASELINE)}")
+        # Count the BASELINE's rows, not the fresh run's. The success line is
+        # a claim about the committed file, and counting the thing that was
+        # just measured would report 22 about a 24-row baseline.
+        print(f"  ok   DRIFT: {len(expected.get('rows') or ())} baseline "
+              f"row(s) match this run of "
+              f"{os.path.basename(RECORDER)}")
 
     print(f"\n{'FAIL' if FAILURES else 'PASS'}: #879 census drift, "
           f"{len(FAILURES)} failure(s)")

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -558,9 +558,19 @@ def test_every_test_is_registered_in_its_files_own_list():
     print('  PASS: every registry-style test file lists all its tests')
 
 
-#: Every committed baseline under `tests/`, mapped to the test that READS it
-#: and fails when it is wrong -- or, in `_BASELINE_UNGATED`, to the reason it
-#: has none (#879).
+#: Every committed `.json`/`.jsonl` baseline under `tests/`, mapped to the test
+#: that READS it and fails when it is wrong -- or, in `_BASELINE_UNGATED`, to
+#: the reason it has none (#879).
+#:
+#: THE EXTENSIONS ARE THE SCOPE, and saying "every committed baseline" would
+#: overstate it. The first cut said `.json` and three committed `.jsonl`
+#: measurements were invisible; the honest reading of that is not "now it is
+#: complete" but "the scope is a list, and a list has an edge". A live one:
+#: `tests/stress/RUNBOOK.md` hand-transcribes `831_fill_timing_census.json`'s
+#: numbers into a markdown table, which is a recorded measurement under
+#: `tests/` that this never sees. Widening to `.md` would mean parsing prose
+#: for tables, so it stays out -- named here rather than left to be discovered
+#: the way 713 was.
 #:
 #: "Reads it and fails when it is wrong" is deliberately weaker than
 #: "re-derives every cell": four of these honestly do less, and say so.
@@ -653,8 +663,13 @@ _UNGATED_BASELINE_COUNT = 7
 #: And the total the walk must CONSIDER. Without it the check goes vacuous in
 #: silence: widen an exclusion to `tests/` and every baseline disappears, while
 #: the map still holds its entries and the summary still prints PASS. Measured
-#: -- `PASS: 0 committed baseline(s) declared -- 13 re-derived by a named gate`
-#: at exit 0, a line that contradicts itself and that nothing was comparing.
+#: at `8816eab5`, which had no such literal: widening one exclusion to `tests/`
+#: printed a summary claiming ZERO baselines were considered and eleven were
+#: gated, and exited 0. Three numbers in one line, one of them contradicting
+#: the others, and nothing compared them. (Quoted as a shape rather than
+#: verbatim, because the print string has since been reworded and the counts
+#: have moved -- a "measured" line spliced from two versions is exactly what
+#: #879 is about.)
 _DECLARED_BASELINE_COUNT = 20
 
 #: Committed JSON/JSONL under `tests/` that is an INPUT, not a recorded
@@ -678,12 +693,59 @@ _NOT_A_BASELINE = (
 )
 
 
+def _names_in_live_code(src, needle):
+    """Does `needle` appear in a string this file actually EVALUATES?
+
+    `-> (answer, why_not)`, with `answer is None` when the file does not parse.
+
+    `_code_only` strips comments and the docstring in `body[0]`, which is the
+    right question for the path scanners above but not strong enough here: a
+    file whose ONLY mention is `__doc__ = "...I guard tests/x.json..."`, or a
+    second bare string statement after the real docstring, or an f-string used
+    as a statement, survived it -- and one such file, opening nothing and
+    asserting nothing, certified a baseline. So exclude every string used as a
+    STATEMENT (a bare string is never functional code, wherever it sits) and
+    every assignment to `__doc__`, and refuse a file that will not parse.
+
+    What this proves is that the registration is not PROSE. It does not prove
+    the gate is effective -- `note = 'x.json'` binds a name and nothing more,
+    and no static rule separates that from `ROWS = os.path.join(D, 'x.json')`.
+    That residual is why the map's own docstring claims "reads it and fails
+    when it is wrong" rather than anything stronger, and why the mutation
+    battery, not this check, is the evidence a gate can go red.
+    """
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return None, 'it does not parse'
+    inert = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Expr) and isinstance(node.value,
+                                                     (ast.Constant,
+                                                      ast.JoinedStr)):
+            inert.add(id(node.value))
+        targets = []
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+            targets = [node.target]
+        if any(getattr(t, 'id', getattr(t, 'attr', None)) == '__doc__'
+               for t in targets) and node.value is not None:
+            inert.add(id(node.value))
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                and id(node) not in inert and needle in node.value):
+            return True, ''
+    return False, 'it names the file only in a docstring, a bare string or a '\
+                  '`__doc__` assignment, if at all'
+
+
 #: Directories the walk always skips, whatever git says about them.
 _ALWAYS_SKIP = ('__pycache__', '.pytest_cache')
 
 
 def _ignored_dirnames(dirpath):
-    """Plain directory names a `.gitignore` in `dirpath` excludes.
+    """Directory names a `.gitignore` IN `dirpath` excludes from `dirpath`.
 
     Only unambiguous entries -- a bare name, or `name/`. No globs, no `!`
     negation, no embedded path. Anything this cannot parse is left IN the walk,
@@ -697,6 +759,16 @@ def _ignored_dirnames(dirpath):
     followed, this check went red about files git deliberately ignores. That is
     the `_WK_DEPENDENT` defect class inverted, and "delete the scratch file" is
     the wrong advice when the file is a gate's workdir.
+
+    STRICTLY LOCAL, and that is the correction to the first cut. It also read
+    the repo-root `.gitignore` and applied those 20 bare names -- `lib`,
+    `parts`, `var`, `build`, `dist`, `wk`, ... -- at EVERY level under tests/.
+    Measured: `git add -f tests/lib/probe_recorded_baseline.json` gave a
+    TRACKED file that `git check-ignore` says is not ignored, and this check
+    neither reported nor counted it, so `_DECLARED_BASELINE_COUNT` stayed
+    green too. Git's ignore rules never apply to tracked files; a name-matcher
+    has no way to know that, so it does not get to guess. A `.gitignore` next
+    to the directory it names is the only claim specific enough to act on.
     """
     out = set()
     path = os.path.join(dirpath, '.gitignore')
@@ -761,21 +833,20 @@ def test_every_committed_baseline_is_declared():
         # gate being rewritten to guard something else entirely.
         with open(gate_full, encoding='utf-8', errors='replace') as fh:
             src = fh.read()
-        # The gate must name the file in CODE. `_code_only` is the same
-        # comment-and-docstring stripper the spawn scanners above use --
-        # called, not mirrored. Measured, all three of these registered a gate
-        # that certifies nothing and a raw substring test accepted every one:
-        # `test_789_slate_harness.py` names `placement_rule1_withdrawal.json`
-        # in its module docstring, `reseat.py` and
-        # `docs/placement-optimization.md` name `836_flip_vs_reseat_baseline
-        # .json` in a docstring and in prose. Comments are the other half of
-        # the same trap -- a comment quoting code has satisfied a source-grep
-        # test in this repo before.
-        if os.path.basename(path) not in _code_only(src):
+        # The gate must name the file in CODE it evaluates. Measured, all
+        # three of these registered a gate that certifies nothing and a raw
+        # substring test accepted every one: `test_789_slate_harness.py` names
+        # `placement_rule1_withdrawal.json` in its module docstring, and
+        # `reseat.py` and `docs/placement-optimization.md` name
+        # `836_flip_vs_reseat_baseline.json` in a docstring and in prose.
+        # Comments are the other half of the same trap -- a comment quoting
+        # code has satisfied a source-grep test in this repo before.
+        live, why_not = _names_in_live_code(src, os.path.basename(path))
+        if not live:
             problems.append(
-                f'{path}: {gate} names it only in a docstring or comment, if '
-                f'at all -- prose is not a gate. The registration must be '
-                f'supported by code that opens the file')
+                f'{path}: {gate} cannot support the registration -- '
+                f'{why_not}. Prose is not a gate; name the file in code '
+                f'that reads it')
 
     for path, reason in sorted(_BASELINE_UNGATED.items()):
         if not os.path.isfile(os.path.join(ROOT, path)):
@@ -799,9 +870,8 @@ def test_every_committed_baseline_is_declared():
     # A registry that cannot see the most exposed file in the tree is the #879
     # bug wearing a green tick.
     seen = set()
-    root_ignored = _ignored_dirnames(ROOT)
     for dirpath, dirnames, filenames in os.walk(TESTS_DIR):
-        skip = set(_ALWAYS_SKIP) | root_ignored | _ignored_dirnames(dirpath)
+        skip = set(_ALWAYS_SKIP) | _ignored_dirnames(dirpath)
         dirnames[:] = [d for d in sorted(dirnames) if d not in skip]
         for fname in sorted(filenames):
             if not fname.lower().endswith(('.json', '.jsonl')):
@@ -834,11 +904,19 @@ def test_every_committed_baseline_is_declared():
             f'holds {len(_BASELINE_UNGATED)}. Re-state the literal '
             f'deliberately -- an ungated baseline is a decision, not a line')
     if len(seen) != _DECLARED_BASELINE_COUNT:
+        # Name the DIRECTION. The two cases have opposite remedies, and a
+        # message that assumes the shrinking one sends a reader hunting for an
+        # exclusion that does not exist.
+        if len(seen) < _DECLARED_BASELINE_COUNT:
+            why = ('a SHRINKING scope is how this check goes vacuous while '
+                   'still printing PASS -- find the exclusion or the pruned '
+                   'directory that swallowed one')
+        else:
+            why = ('the scope GREW -- a baseline arrived, so re-state the '
+                   'literal once you have registered it')
         problems.append(
             f'_DECLARED_BASELINE_COUNT says {_DECLARED_BASELINE_COUNT}, the '
-            f'walk considered {len(seen)}. A shrinking scope is how this '
-            f'check goes vacuous while still printing PASS -- re-state it '
-            f'deliberately, or find the exclusion that swallowed one')
+            f'walk considered {len(seen)}. {why}')
 
     assert not problems, ('committed-baseline registry:\n  '
                           + '\n  '.join(problems))

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -558,8 +558,20 @@ def test_every_test_is_registered_in_its_files_own_list():
     print('  PASS: every registry-style test file lists all its tests')
 
 
-#: Every committed baseline under `tests/`, mapped to the test that RE-DERIVES
-#: it -- or, in `_BASELINE_UNGATED`, to the reason it has none (#879).
+#: Every committed baseline under `tests/`, mapped to the test that READS it
+#: and fails when it is wrong -- or, in `_BASELINE_UNGATED`, to the reason it
+#: has none (#879).
+#:
+#: "Reads it and fails when it is wrong" is deliberately weaker than
+#: "re-derives every cell": four of these honestly do less, and say so.
+#:
+#: `test_553_recall_regen` re-derives 2 of 36 cells;
+#: `test_554_relocation_regen` re-derives the summary only;
+#: `test_803_calibration_claims` consumes its two files as the INPUT it holds
+#: `docs/placement-calibration.md` to; and
+#: `test_789_rule1_withdrawal` re-evaluates a rule over stored metrics. A map
+#: that claimed full re-derivation for all of them would be the kind of
+#: overstatement this file exists to catch.
 #:
 #: A baseline nothing re-derives is free to drift arbitrarily far from the tree
 #: while still reading as authoritative, and whoever eventually re-records it
@@ -582,6 +594,10 @@ _BASELINE_GATES = {
         'tests/test_554_reach_regen.py',
     'tests/713_abstention_census.json':
         'tests/test_713_abstention_drift.py',
+    'tests/792_seeding_rows.jsonl':
+        'tests/test_792_seeding_claims.py',
+    'tests/799_feasibility_rows.jsonl':
+        'tests/test_799_feasibility_claims.py',
     'tests/799_feasibility_summary.json':
         'tests/test_799_feasibility_claims.py',
     'tests/831_fill_timing_census.json':
@@ -610,28 +626,91 @@ _BASELINE_UNGATED = {
     'tests/measure_847_calibration.json':
         'nothing references it; only measure_847_calibration.py is cited, in '
         'docs/utilities.md and check_channels.py',
+    'tests/553_diagnosis_recall_rows.jsonl':
+        'ZERO references repo-wide -- 52 KB and 36 recorded rows that nothing '
+        'in the tree reads. test_553_recall_regen.py writes its OWN rows into '
+        'a temp workdir and never opens this one. The most exposed file in '
+        'the tree by this issue\'s own definition, and named here rather than '
+        'left to be discovered the way 713 was',
     'tests/stress/corpus_noop_baseline.json':
         'read by tests/stress/corpus_noop_sweep.py, which is not a test_*.py '
         'and lives outside run_all.py the non-recursive glob',
+    'tests/stress/modal_sweep/board_value.json':
+        'a recorded measurement (`boards_scored: 148`) that is ALSO consumed '
+        'as sweep config, written by modal_sweep/curate_boards.py after a big '
+        'sweep. Nothing re-derives it',
+    'tests/stress/modal_sweep/retry_shape_2127.json':
+        'a per-board rescue-step census, cited as the frozen board list in '
+        'modal_sweep/PREREG_590_sets21_27.md. Nothing re-derives it',
 }
 
 #: A PINNED literal, never `len(_BASELINE_UNGATED)`. Deriving it from the map
 #: it guards would make this agree with whatever the map currently says, and
-#: the point is that a fifth ungated baseline be a decision somebody takes
+#: the point is that another ungated baseline be a decision somebody takes
 #: rather than a line somebody adds.
-_UNGATED_BASELINE_COUNT = 4
+_UNGATED_BASELINE_COUNT = 7
 
-#: Committed JSON under `tests/` that is an INPUT, not a recorded measurement.
-#: Prefix-matched, each with its reason.
+#: And the total the walk must CONSIDER. Without it the check goes vacuous in
+#: silence: widen an exclusion to `tests/` and every baseline disappears, while
+#: the map still holds its entries and the summary still prints PASS. Measured
+#: -- `PASS: 0 committed baseline(s) declared -- 13 re-derived by a named gate`
+#: at exit 0, a line that contradicts itself and that nothing was comparing.
+_DECLARED_BASELINE_COUNT = 20
+
+#: Committed JSON/JSONL under `tests/` that is an INPUT, not a recorded
+#: measurement. Full-path regexes, each with its reason.
+#:
+#: Regexes rather than prefixes because a bare prefix widens silently:
+#: `tests/stress/manifest_set` also exempted a hypothetical
+#: `manifest_set_results_2026.json`, which would be a measurement. The pattern
+#: says what the shape actually is.
 _NOT_A_BASELINE = (
-    ('tests/stress/manifest_set',
-     'stress-corpus manifests: they name the boards to fetch and record '
-     'nothing'),
-    ('tests/stress/modal_sweep/',
-     'sweep arm configurations, an input to a study'),
-    ('tests/fixtures/',
+    (r'tests/stress/manifest_set\d+(monster)?\.json$',
+     'stress-corpus manifests -- set1..set28 plus the three `monster` sets: '
+     'they name the boards to fetch and record nothing'),
+    (r'tests/stress/modal_sweep/arms\.[A-Za-z0-9_]+\.json$',
+     'sweep ARM configurations, an input to a study. Deliberately not the '
+     'whole modal_sweep/ directory: board_value.json and '
+     'retry_shape_2127.json in it are recorded measurements, and a directory '
+     'prefix quietly exempted both'),
+    (r'tests/fixtures/.*\.jsonl?$',
      'fixture inputs a test feeds in, not measurements it took'),
 )
+
+
+#: Directories the walk always skips, whatever git says about them.
+_ALWAYS_SKIP = ('__pycache__', '.pytest_cache')
+
+
+def _ignored_dirnames(dirpath):
+    """Plain directory names a `.gitignore` in `dirpath` excludes.
+
+    Only unambiguous entries -- a bare name, or `name/`. No globs, no `!`
+    negation, no embedded path. Anything this cannot parse is left IN the walk,
+    so an unhandled rule makes the check louder, never quieter.
+
+    This exists because `os.walk` sees gitignored OUTPUT directories, which
+    makes the result depend on which gates the machine has run.
+    `tests/gui_parity/.gitignore` holds `work/`, and both
+    `replay_plan_vs_run.py` and `test_gui_engine_parity.py` write `.json` into
+    it -- so on a tree where CLAUDE.md's own parity instructions have been
+    followed, this check went red about files git deliberately ignores. That is
+    the `_WK_DEPENDENT` defect class inverted, and "delete the scratch file" is
+    the wrong advice when the file is a gate's workdir.
+    """
+    out = set()
+    path = os.path.join(dirpath, '.gitignore')
+    if not os.path.isfile(path):
+        return out
+    with open(path, encoding='utf-8', errors='replace') as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith('#') or line.startswith('!'):
+                continue
+            name = line.rstrip('/')
+            if name and not set(name) & set('/*?[]'):
+                out.add(name)
+    return out
 
 
 def test_every_committed_baseline_is_declared():
@@ -657,6 +736,16 @@ def test_every_committed_baseline_is_declared():
         if not os.path.isfile(gate_full):
             problems.append(f'{path}: its gate {gate} does not exist')
             continue
+        # A gate must be a TEST, under tests/, named so `run_all`'s glob can
+        # find it. Without this, any file in the repo that happens to contain
+        # the basename qualifies -- and a docs page did.
+        if not (gate.startswith('tests/')
+                and os.path.basename(gate).startswith('test_')
+                and gate.endswith('.py')):
+            problems.append(
+                f'{path}: its gate {gate} is not a tests/**/test_*.py, so '
+                f'nothing runs it as a gate')
+            continue
         # THIS file can never be the gate. It names every baseline -- that is
         # what a registry is -- so the "does the gate mention it" check below
         # is satisfied trivially by pointing an entry here, and the entry then
@@ -672,10 +761,21 @@ def test_every_committed_baseline_is_declared():
         # gate being rewritten to guard something else entirely.
         with open(gate_full, encoding='utf-8', errors='replace') as fh:
             src = fh.read()
-        if os.path.basename(path) not in src:
+        # The gate must name the file in CODE. `_code_only` is the same
+        # comment-and-docstring stripper the spawn scanners above use --
+        # called, not mirrored. Measured, all three of these registered a gate
+        # that certifies nothing and a raw substring test accepted every one:
+        # `test_789_slate_harness.py` names `placement_rule1_withdrawal.json`
+        # in its module docstring, `reseat.py` and
+        # `docs/placement-optimization.md` name `836_flip_vs_reseat_baseline
+        # .json` in a docstring and in prose. Comments are the other half of
+        # the same trap -- a comment quoting code has satisfied a source-grep
+        # test in this repo before.
+        if os.path.basename(path) not in _code_only(src):
             problems.append(
-                f'{path}: {gate} never mentions it, so the registration is a '
-                f'claim nothing supports')
+                f'{path}: {gate} names it only in a docstring or comment, if '
+                f'at all -- prose is not a gate. The registration must be '
+                f'supported by code that opens the file')
 
     for path, reason in sorted(_BASELINE_UNGATED.items()):
         if not os.path.isfile(os.path.join(ROOT, path)):
@@ -683,23 +783,34 @@ def test_every_committed_baseline_is_declared():
         if not (reason or '').strip():
             problems.append(f'{path}: listed as ungated with no reason given')
 
+    for pattern, why in _NOT_A_BASELINE:
+        if not (why or '').strip():
+            problems.append(f'{pattern}: excluded with no reason given. An '
+                            f'exclusion is a claim like any other')
+
     declared = set(_BASELINE_GATES) | set(_BASELINE_UNGATED)
     both = set(_BASELINE_GATES) & set(_BASELINE_UNGATED)
     if both:
         problems.append(f'listed as both gated and ungated: {sorted(both)}')
 
-    found = 0
+    # .jsonl too, and case-insensitively. The first cut matched `.json` only,
+    # and three committed .jsonl measurements were invisible to it -- one of
+    # them, `553_diagnosis_recall_rows.jsonl`, with zero references repo-wide.
+    # A registry that cannot see the most exposed file in the tree is the #879
+    # bug wearing a green tick.
+    seen = set()
+    root_ignored = _ignored_dirnames(ROOT)
     for dirpath, dirnames, filenames in os.walk(TESTS_DIR):
-        dirnames[:] = [d for d in sorted(dirnames)
-                       if d not in ('__pycache__', '.pytest_cache')]
+        skip = set(_ALWAYS_SKIP) | root_ignored | _ignored_dirnames(dirpath)
+        dirnames[:] = [d for d in sorted(dirnames) if d not in skip]
         for fname in sorted(filenames):
-            if not fname.endswith('.json'):
+            if not fname.lower().endswith(('.json', '.jsonl')):
                 continue
             rel = os.path.relpath(os.path.join(dirpath, fname),
                                   ROOT).replace(os.sep, '/')
-            if any(rel.startswith(pre) for pre, _why in _NOT_A_BASELINE):
+            if any(re.fullmatch(pat, rel) for pat, _why in _NOT_A_BASELINE):
                 continue
-            found += 1
+            seen.add(rel)
             if rel not in declared:
                 problems.append(
                     f'{rel}: a committed baseline nothing declares. Register '
@@ -707,16 +818,32 @@ def test_every_committed_baseline_is_declared():
                     f'_BASELINE_UNGATED with the reason it has none. (A '
                     f'scratch file? Delete it.)')
 
+    # The other direction, and the reason the count below can be trusted: a
+    # declared entry the walk never REACHES is a dead registration. `isfile`
+    # does not catch it -- widen an exclusion to cover a listed baseline and
+    # the entry stays green while guarding a file nothing looks at any more.
+    for rel in sorted(declared - seen):
+        problems.append(
+            f'{rel}: declared, but the walk never reaches it. Either it is '
+            f'outside tests/, or a _NOT_A_BASELINE pattern now swallows it -- '
+            f'so its registration guards nothing')
+
     if len(_BASELINE_UNGATED) != _UNGATED_BASELINE_COUNT:
         problems.append(
             f'_UNGATED_BASELINE_COUNT says {_UNGATED_BASELINE_COUNT}, the map '
             f'holds {len(_BASELINE_UNGATED)}. Re-state the literal '
             f'deliberately -- an ungated baseline is a decision, not a line')
+    if len(seen) != _DECLARED_BASELINE_COUNT:
+        problems.append(
+            f'_DECLARED_BASELINE_COUNT says {_DECLARED_BASELINE_COUNT}, the '
+            f'walk considered {len(seen)}. A shrinking scope is how this '
+            f'check goes vacuous while still printing PASS -- re-state it '
+            f'deliberately, or find the exclusion that swallowed one')
 
     assert not problems, ('committed-baseline registry:\n  '
                           + '\n  '.join(problems))
-    print(f'  PASS: {found} committed baseline(s) declared -- '
-          f'{len(_BASELINE_GATES)} re-derived by a named gate, '
+    print(f'  PASS: {len(seen)} committed baseline(s) declared -- '
+          f'{len(_BASELINE_GATES)} read by a named gate, '
           f'{len(_BASELINE_UNGATED)} ungated with a stated reason')
 
 

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -558,6 +558,168 @@ def test_every_test_is_registered_in_its_files_own_list():
     print('  PASS: every registry-style test file lists all its tests')
 
 
+#: Every committed baseline under `tests/`, mapped to the test that RE-DERIVES
+#: it -- or, in `_BASELINE_UNGATED`, to the reason it has none (#879).
+#:
+#: A baseline nothing re-derives is free to drift arbitrarily far from the tree
+#: while still reading as authoritative, and whoever eventually re-records it
+#: inherits every delta since the last recording as apparently their own. Not
+#: hypothetical: `713_abstention_census.json` drifted for four days, and the
+#: re-record was then published in a commit message AND a code comment as one
+#: change's effect. It was somebody else's.
+#:
+#: Declared rather than discovered, and held in BOTH directions like
+#: `_WK_DEPENDENT` above: a baseline missing from the map fails, and an entry
+#: naming a gate that does not exist -- or a gate that never mentions the file
+#: it claims to guard -- fails too. A registration nobody checks is how the
+#: #696 containment guard passed 28/28 while the thing it named had moved.
+_BASELINE_GATES = {
+    'tests/553_diagnosis_recall_baseline.json':
+        'tests/test_553_recall_regen.py',
+    'tests/554_block_relocation_baseline.json':
+        'tests/test_554_relocation_regen.py',
+    'tests/554_relocation_reach_baseline.json':
+        'tests/test_554_reach_regen.py',
+    'tests/713_abstention_census.json':
+        'tests/test_713_abstention_drift.py',
+    'tests/799_feasibility_summary.json':
+        'tests/test_799_feasibility_claims.py',
+    'tests/831_fill_timing_census.json':
+        'tests/test_831_fill_preflight_census.py',
+    'tests/placement_ab_baseline.json': 'tests/test_placement_ab.py',
+    'tests/placement_calibration_recovered.json':
+        'tests/test_803_calibration_claims.py',
+    'tests/placement_calibration_rows.json':
+        'tests/test_803_calibration_claims.py',
+    'tests/placement_rule1_withdrawal.json':
+        'tests/test_789_rule1_withdrawal.py',
+    'tests/data/714_identity_sha256.json':
+        'tests/test_714_identity_write_unchanged.py',
+}
+
+#: Committed baselines with NO gate, each with its reason. Being on this list
+#: is a DISCLOSURE, not an exemption -- see `_UNGATED_BASELINE_COUNT`.
+_BASELINE_UNGATED = {
+    'tests/797_seed_exclusive_baseline.json':
+        'no test names it; its own `reproduce` key carries a two-command '
+        'recipe, which is a recipe rather than a gate',
+    'tests/836_flip_vs_reseat_baseline.json':
+        'test_836_flip_census.py is a real gate on the two MECHANISMS the '
+        'answer rests on, but it re-derives them from the engine and never '
+        'opens this file, so the recorded verdict itself is unguarded',
+    'tests/measure_847_calibration.json':
+        'nothing references it; only measure_847_calibration.py is cited, in '
+        'docs/utilities.md and check_channels.py',
+    'tests/stress/corpus_noop_baseline.json':
+        'read by tests/stress/corpus_noop_sweep.py, which is not a test_*.py '
+        'and lives outside run_all.py the non-recursive glob',
+}
+
+#: A PINNED literal, never `len(_BASELINE_UNGATED)`. Deriving it from the map
+#: it guards would make this agree with whatever the map currently says, and
+#: the point is that a fifth ungated baseline be a decision somebody takes
+#: rather than a line somebody adds.
+_UNGATED_BASELINE_COUNT = 4
+
+#: Committed JSON under `tests/` that is an INPUT, not a recorded measurement.
+#: Prefix-matched, each with its reason.
+_NOT_A_BASELINE = (
+    ('tests/stress/manifest_set',
+     'stress-corpus manifests: they name the boards to fetch and record '
+     'nothing'),
+    ('tests/stress/modal_sweep/',
+     'sweep arm configurations, an input to a study'),
+    ('tests/fixtures/',
+     'fixture inputs a test feeds in, not measurements it took'),
+)
+
+
+def test_every_committed_baseline_is_declared():
+    """A committed baseline is either re-derived by a test, or says why not.
+
+    Three failures, each meaning something different:
+
+      unlisted -- a new baseline arrived and nobody decided how it stays
+                  honest. (Or a scratch .json is sitting in tests/, which is
+                  also worth being told about.)
+      stale    -- the map names a gate that does not exist, or one that never
+                  mentions the file it claims to guard. Both are worse than no
+                  map: they certify nothing while looking like they do.
+      count    -- the number of UNGATED baselines moved and nobody re-stated
+                  it.
+    """
+    problems = []
+    for path, gate in sorted(_BASELINE_GATES.items()):
+        if not os.path.isfile(os.path.join(ROOT, path)):
+            problems.append(f'{path}: registered, but the file is gone')
+            continue
+        gate_full = os.path.join(ROOT, gate)
+        if not os.path.isfile(gate_full):
+            problems.append(f'{path}: its gate {gate} does not exist')
+            continue
+        # THIS file can never be the gate. It names every baseline -- that is
+        # what a registry is -- so the "does the gate mention it" check below
+        # is satisfied trivially by pointing an entry here, and the entry then
+        # certifies nothing. Found by mutating an entry to do exactly that and
+        # watching the row survive.
+        if os.path.abspath(gate_full) == os.path.abspath(__file__):
+            problems.append(
+                f'{path}: registered against this registry, which declares '
+                f'every baseline and re-derives none. Name the test that '
+                f're-computes it, or move it to _BASELINE_UNGATED')
+            continue
+        # The gate must NAME the file. A pairing nobody checks survives the
+        # gate being rewritten to guard something else entirely.
+        with open(gate_full, encoding='utf-8', errors='replace') as fh:
+            src = fh.read()
+        if os.path.basename(path) not in src:
+            problems.append(
+                f'{path}: {gate} never mentions it, so the registration is a '
+                f'claim nothing supports')
+
+    for path, reason in sorted(_BASELINE_UNGATED.items()):
+        if not os.path.isfile(os.path.join(ROOT, path)):
+            problems.append(f'{path}: listed as ungated, but the file is gone')
+        if not (reason or '').strip():
+            problems.append(f'{path}: listed as ungated with no reason given')
+
+    declared = set(_BASELINE_GATES) | set(_BASELINE_UNGATED)
+    both = set(_BASELINE_GATES) & set(_BASELINE_UNGATED)
+    if both:
+        problems.append(f'listed as both gated and ungated: {sorted(both)}')
+
+    found = 0
+    for dirpath, dirnames, filenames in os.walk(TESTS_DIR):
+        dirnames[:] = [d for d in sorted(dirnames)
+                       if d not in ('__pycache__', '.pytest_cache')]
+        for fname in sorted(filenames):
+            if not fname.endswith('.json'):
+                continue
+            rel = os.path.relpath(os.path.join(dirpath, fname),
+                                  ROOT).replace(os.sep, '/')
+            if any(rel.startswith(pre) for pre, _why in _NOT_A_BASELINE):
+                continue
+            found += 1
+            if rel not in declared:
+                problems.append(
+                    f'{rel}: a committed baseline nothing declares. Register '
+                    f'it against the test that re-derives it, or in '
+                    f'_BASELINE_UNGATED with the reason it has none. (A '
+                    f'scratch file? Delete it.)')
+
+    if len(_BASELINE_UNGATED) != _UNGATED_BASELINE_COUNT:
+        problems.append(
+            f'_UNGATED_BASELINE_COUNT says {_UNGATED_BASELINE_COUNT}, the map '
+            f'holds {len(_BASELINE_UNGATED)}. Re-state the literal '
+            f'deliberately -- an ungated baseline is a decision, not a line')
+
+    assert not problems, ('committed-baseline registry:\n  '
+                          + '\n  '.join(problems))
+    print(f'  PASS: {found} committed baseline(s) declared -- '
+          f'{len(_BASELINE_GATES)} re-derived by a named gate, '
+          f'{len(_BASELINE_UNGATED)} ungated with a stated reason')
+
+
 TESTS = [
     test_wk_dependent_tests_are_declared,
     test_no_test_spawns_a_script_that_moved,
@@ -565,6 +727,9 @@ TESTS = [
     test_no_module_scope_posix_only_import,
     test_no_test_is_defined_after_its_own_runner,
     test_every_test_is_registered_in_its_files_own_list,
+
+
+    test_every_committed_baseline_is_declared,
 ]
 
 

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -932,8 +932,6 @@ TESTS = [
     test_no_module_scope_posix_only_import,
     test_no_test_is_defined_after_its_own_runner,
     test_every_test_is_registered_in_its_files_own_list,
-
-
     test_every_committed_baseline_is_declared,
 ]
 


### PR DESCRIPTION
Closes #879

`tests/713_abstention_census.json` is a committed baseline that nothing
re-derived. Its recorder is not named `test_*.py`, so `run_all.py`'s
`tests/test_*.py` glob never collected it, and a tree-wide grep finds two
references, one of them a comment citing a past run.

So it drifted for four days and I walked into the consequence: re-recording it
as part of #837 I saw `boards_clean_but_ungraded 5 -> 0` and published that as
my change's effect, in a commit message *and* a code comment. A reviewer re-ran
the census at the base commit, with none of my code present, and found those
boards already failing -- `budget_abstained` drift from four days earlier.
Corrected in `bfd8796b`; this is the gate that would have caught it.

## What lands

**1. The recorder becomes callable -- `tests/713_abstention_census.py`**

It was a bare top-level script: no `main()`, no `__name__` guard, output path
hardcoded from `__file__`. Importing it ran a 42 s census and it always
overwrote the committed file. Now `census(repo)` returns the document, `main()`
takes `--out`, and `write()` goes through a temp file plus `os.replace`. Import
is 0.33 s. A plain run is still byte-identical to the committed JSON
(`git diff` empty). A census of zero boards REFUSES to write and exits 2 --
a hole where a git failure would otherwise have silently produced an empty
baseline that then passed its own gate forever.

**2. The drift gate -- `tests/test_713_abstention_drift.py` (new)**

Re-derives the whole census to a temp `--out` and compares **parsed JSON, never
bytes** -- the working tree is CRLF and the git blob is LF (14192 vs 13575), a
trap this repo already fell into once (`b802c0a4`). Per-key and per-board, in
`test_placement_ab.py`'s verdict vocabulary: `DRIFT`, `NEW ROW`, `MISSING`,
`NEW KEY`, `MISSING KEY`, `MALFORMED`. `INVERTED` is deliberately absent and
the file says why: it compares an off/on pair and this document has no arms.
A missing or unreadable baseline FAILs rather than passing. Without git, exit
77 with a `SKIP:` line.

~39 s, `RUN_ALL_TIMEOUT = 900`, classified `integration` -- deliberately no
`RUN_ALL_FAST_OK`, because 44 subprocesses is not the "shelling out really is
cheap" the marker's own docstring asks for.

**3. The census stops mirroring the engine and calls it**

The census kept its own copy of every `floorplan._SKIP_REASON` value and
classified skips by matching the reason STRING. That copy had already gone
stale once (#837 added `assembly_side` and it was not updated), which silently
reclassifies an honest skip as a real abstention.

My first fix was an arm asserting the two sets are equal in both directions.
The final verifier refuted it: the engine already exports
`_is_not_asked(rule, reason)` as "ONE home for the distinction", keyed on the
RULE precisely because a value match "meant an `_ARM` reason that ever happened
to equal some OTHER rule's skip reason would read as 'nobody asked' -- a real
abstention silently downgraded to a pass, which is the dangerous direction."

That is live here: `_SKIP_REASON` has 12 keys and **11 distinct values**,
because `decap_distance` and `decap_ungraded` already share one. Two sets can
be perfectly equal while the mapping is not injective -- so the mirror arm
would have been green straight through the failure it was written for.

`classify` now calls the engine and the copy is gone. The arm becomes ENGINE:
it holds the copy deleted and checks agreement over every `(rule, reason)` pair
the engine can produce, in milliseconds. Measured before the swap -- the two
agree on all 12 pairs, and a full re-record is byte-identical. One answer does
change and is pinned rather than left implicit: the `not requested` fallback,
for a rule that recorded no reason at all, now counts as an abstention rather
than as "nobody asked". That is the engine's safe direction, and it is
unreachable today since `RULES` and `_SKIP_REASON` carry the same 12 keys.

**4. The registry -- `tests/test_718_static_test_hygiene.py`**

Every committed baseline under `tests/` now names the gate that reads it and
fails when it is wrong, or states why nobody does: **20 baselines, 13 gated,
7 ungated with a reason**. Held in both directions -- a listed baseline must
exist, a named gate must exist, must be a `tests/**/test_*.py`, and must name
the file *in code*; a baseline nobody lists is named; and a declared entry the
walk no longer REACHES is reported, so an exclusion cannot quietly turn a
registration into a dead one.

Two counts are pinned literals rather than `len()` of the maps they guard: the
ungated count, so another ungated baseline is a decision somebody takes rather
than a line somebody adds, and the total the walk must consider, because a
widened exclusion is how this check goes vacuous while still printing PASS.

The ungated entries are a disclosure, not an exemption, and two are worth
reading. `553_diagnosis_recall_rows.jsonl`: 52 KB and 36 recorded rows with
**zero references anywhere in the tree** — its neighbouring gate writes its own
rows into a temp workdir and never opens this one. And
`836_flip_vs_reseat_baseline.json` (mine, from the same session):
`test_836_flip_census.py` is a real gate on the two mechanisms the answer rests
on, but it re-derives them from the engine and never opens the JSON, so the
recorded verdict itself is unguarded.

A registry entry may not name `test_718` itself. It declares every baseline, so
pointing an entry at it satisfies the "the gate mentions the file" check
trivially -- my own mutation found that hole and the guard closes it.

Two limits worth stating rather than leaving to be found. The scope is
`.json`/`.jsonl`, and the file says so: `tests/stress/RUNBOOK.md`
hand-transcribes `831_fill_timing_census.json`'s numbers into a markdown table
that this will never see, and widening to `.md` would mean parsing prose. And "gated" is a claim about the
map, not about your machine -- until #883 landed, `test_831_fill_preflight
_census.py` was a registered gate that died on `import resource` before
running, so a Windows box had 12 live gates where the map said 13.

## Verification

Every claim here was mutated, not asserted:

Both batteries open with an UNMUTATED control -- a gate that errors out for
its own reasons scores every row after it as killed and exits 0, which has
happened to me before.

- drift gate: **20 kills, 1 negative control, 0 survivors.** Each verdict by
  its own name; a duplicated board row; a non-object row; a row with no
  `board`; a nested `channels_seen` key; a bool that became an int;
  `boards_total` disagreeing with the rows it counts; baseline deleted,
  corrupt, not-an-object; the census re-growing its own `NOT_ASKED`, dropping
  the rule argument, or hand-rolling the answer instead of asking the engine.
  The negative control is a CRLF baseline, which must stay silent. A row that
  makes the gate CRASH scores as CRASHED, not as killed: a traceback is not a
  verdict. Its first run with the new rows found a real defect, described at
  the end of this section.
- registry: **19 kills, 2 negative controls, 0 survivors.** An unlisted stray
  as `.json`, `.jsonl` and `.JSON`; a missing gate file; a gate that never
  names the file, or names it only in a docstring or a `__doc__` assignment;
  a gate that does not parse; a docs page as the gate; the registry naming
  itself; both pinned counts; an empty ungated reason and an empty exclusion
  reason; an exclusion that swallows every baseline, and one that shadows a
  single listed entry; a deleted baseline; a manifest-SHAPED measurement that
  must not be exempt; a tracked baseline under a root-gitignored directory
  name. The two controls that must stay silent are a new
  `manifest_setNN.json` and a parity gate's gitignored workdir.
- recorder: plain run byte-identical; `--out` redirects; import 0.33 s (was 42)
- `test_718` still classified `unit`; the drift gate `integration`

Full suite at the branch head, rebased onto current `main`: **552 passed,
0 failed, 4836 s**, with both new gates passing.

Two files timed out under the suite's budgets (`test_431_board_gates.py`,
`test_interf_u.py`) and pass alone in 573 s and 341 s. Both are untouched by
this branch, and `run_all` says it itself: a timeout is not evidence of a
broken test.

Each of the four phases was refuted by an adversarial subagent in its own
worktree before the next began, and every one of them found real defects in my
own code.

Phase 1's found four: no zero-board refusal, no `--out` pre-validation,
temp-path leakage in the refusal message, a non-atomic write.

Phase 2/3's found two BLOCKING, and they are the reason this PR is worth
reading. Both row indexes were last-wins dict comprehensions with a silent
`isinstance` filter, so **a baseline carrying a duplicate board row -- the
wrong copy first, `pass: false, errors: 9999` -- reported PASS with zero
problems**, and so did one with an appended garbage string or `null`. The
success line then printed the FRESH row count, announcing "22 board(s) match"
about a 24-row baseline; nothing disclosed it. And a row with no `board` key
put `None` into a set of strings, so `sorted()` raised `TypeError` after the
full 40 s re-derive -- a traceback where a verdict belongs.

A gate that cannot see the one edit shape its threat model is built around is
the #879 bug wearing a green tick. `index_rows()` replaces both comprehensions
and names `MALFORMED` / `DUPLICATE` by row index; six smaller findings from
the same pass are fixed alongside it. (The baseline index was the one carrying
the silent `isinstance` filter; the measured index was plain last-wins.)

Phase 4's found the registry could not see `.jsonl` at all -- three committed
measurements invisible to a map whose entire claim is that none are, including
the one with zero references. It also found the check could go **fully vacuous
and still print PASS** (`PASS: 0 committed baseline(s) declared -- 11
re-derived by a named gate`, exit 0, three numbers nothing compared), that a
"gate" could be any file in the repo that mentioned the basename **in prose**,
and that `os.walk` saw gitignored output directories -- so following CLAUDE.md's
own parity-gate instructions turned the check red about files git ignores.

A fifth verifier took the whole branch and the draft of this description. It
found no BLOCKING, confirmed every number here against its own runs, and
produced the finding in section 3 -- that my mirror arm was solving a problem
the engine had already solved better, and would have been green through the
case it was written for. It also found that the fix for gitignored workdirs had
over-reached (a TRACKED baseline under a root-ignored NAME went invisible, with
the new count guard green too), that `__doc__ = "...x.json..."` still counted
as code, that the only clock able to explain a hang was unreachable under
`run_all`, and that `1 == True` made a bool-turned-int compare equal. All fixed
above, each with a row in a battery.

And the last defect was found not by a reviewer but by the battery itself, on
its first run with those new rows. The row that removes `classify`'s `rule`
argument exited 1 -- and still counted as a SURVIVOR, because it went red for
the wrong reason. The ENGINE arm had found the defect and appended it to
`FAILURES`; `main` then returned 1 from the recorder branch without printing
the summary, as six early returns did. A suite sees a failure either way. A
human sees a `TypeError` from the recorder and never learns the gate had
already named the cause one arm earlier. Every exit now goes through one
`summary()`, and a real failure outranks a SKIP there, so a broken gate cannot
leave by the 77 door.

That is this PR's own subject one level up: evidence collected, then discarded
on the way out, with a non-zero exit standing in for a reason.
