### PR TITLE
#877: mutation anchors that match nothing -- a shared pre-flight, a standing gate, and the 29 re-anchored rows

### DIFF
--- a/tests/mutate_553.py
+++ b/tests/mutate_553.py
@@ -248,6 +248,12 @@ ROWS = [
      (T553,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_554.py
+++ b/tests/mutate_554.py
@@ -336,6 +336,12 @@ ROWS = [
      (T554,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_554.py
+++ b/tests/mutate_554.py
@@ -307,9 +307,18 @@ ROWS = [
     # The relocation's own disclosure replaced by the SELECTOR's. It still reads
     # like a disclosure and still says NOT MEASURED -- about a different
     # experiment. This is the shape a laundered claim actually takes.
+    # RE-ANCHORED (#877). `d3a3f47d` ("#554: the routed A/B ran, and it is
+    # UNDERPOWERED with the incumbent ahead") REWORDED the claim -- the A/B it
+    # said did not exist has since been run -- so the quote matched nothing.
+    # The mutation is unchanged: make the claim name a DIFFERENT experiment
+    # than the one it reports, which is what the gate has to catch.
     ('efficacy-names-the-wrong-experiment', 'r',
-     "NO_EFFICACY_CLAIM = (\n    'NOT MEASURED: no paired routed A/B of relocate-on vs relocate-off exists, '\n",
-     "NO_EFFICACY_CLAIM = (\n    'NOT MEASURED: no paired routed A/B of pins vs diagnosis exists. '\n",
+     "NO_EFFICACY_CLAIM = (\n"
+     "    'UNDERPOWERED, AND THE INCUMBENT WON. The paired routed A/B of relocate-on '\n"
+     "    'vs relocate-off HAS now been run (tests/stress/block_relocation_study.py): '\n",
+     "NO_EFFICACY_CLAIM = (\n"
+     "    'UNDERPOWERED, AND THE INCUMBENT WON. The paired routed A/B of pins '\n"
+     "    'vs diagnosis HAS now been run (tests/stress/block_relocation_study.py): '\n",
      (T554, T554S), 'KILLED'),
 
     # ---- an expected survivor, recorded rather than deleted -----------------

--- a/tests/mutate_619.py
+++ b/tests/mutate_619.py
@@ -161,6 +161,12 @@ ROWS = [
                     'layer rule, so the two values are equal on every fixture)'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def run(tests):
     env = dict(os.environ, PYTHONDONTWRITEBYTECODE='1')

--- a/tests/mutate_620.py
+++ b/tests/mutate_620.py
@@ -407,6 +407,12 @@ ROWS = [
      (T756, T370), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _head():
     p = subprocess.run(['git', 'rev-parse', 'HEAD'], capture_output=True,

--- a/tests/mutate_698.py
+++ b/tests/mutate_698.py
@@ -354,6 +354,12 @@ ROWS = [
      (T698,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),

--- a/tests/mutate_702.py
+++ b/tests/mutate_702.py
@@ -132,13 +132,21 @@ ROWS = [
     # ---- per-ENTRY indexing -------------------------------------------------
     # The whole point of _IntentTerm: aggregate a rule's entries to one scalar
     # per ref and a part hops between two keep-outs at 1.0 -> 1.0.
+    # RE-ANCHORED (#877), and so are the five rows below it. `c7bef8d9` ("#698
+    # prep: the declared-claim measurement leaves the state that enforces it")
+    # moved this gate out of the state class into the module-level
+    # `intent_spec` / `build_zone_spec` / `intent_term_values`, so every anchor
+    # here lost its `self.` and four to eight columns of indent. The CODE is
+    # unchanged and every mutation below is the one it always was; only the
+    # quotation moved. Eight of this battery's 22 rows had been asserting
+    # nothing since that commit, which is what #877 measured.
     ('keepout-terms-collapse-to-one-per-ref', 'q',
-     "        return zones + tuple(\n"
-     "            _IntentTerm('keepout', str(k.get('name') or '<unnamed>'),\n"
-     "                        None, 0.0, False, k)\n"
-     "            for k in kos)\n",
-     "        return zones + (_IntentTerm('keepout', 'all', None, 0.0,\n"
-     "                                    False, kos[0]),)\n",
+     "    return zones + tuple(\n"
+     "        _IntentTerm('keepout', str(k.get('name') or '<unnamed>'),\n"
+     "                    None, 0.0, False, k)\n"
+     "        for k in kos)\n",
+     "    return zones + (_IntentTerm('keepout', 'all', None, 0.0,\n"
+     "                                False, kos[0]),)\n",
      (T702,), 'KILLED'),
 
     # The keep-out slice must stay LIVE, or #701's census lift is defeated:
@@ -147,35 +155,42 @@ ROWS = [
     # the census went lifted=49 -> lifted=0 on arm Q's fixture, and the
     # verdict degraded from
     # `keepout_blocks` to `no_movable_neighbour`.
+    # The REPLACEMENT is re-spelled too, and deliberately: the old one reached
+    # for `self.keepouts`, the whole board's list, which the free function does
+    # not have. Flattening `keepouts_for.values()` is the same mutation -- hand
+    # the ref every keep-out instead of its own live slice, so removing one
+    # entry from `keepouts_for[ref]` changes nothing and the census lift goes
+    # invisible. Widening it to anything else would be a different experiment.
     ('the-keepout-slice-stops-honouring-the-lift', 'q',
-     "        kos = self.keepouts_for.get(ref, ())\n",
-     "        kos = (self.keepouts if self.keepouts_for.get(ref) else ())\n",
+     "    kos = keepouts_for.get(ref, ())\n",
+     "    kos = (tuple(k for _v in keepouts_for.values() for k in _v)\n"
+     "           if keepouts_for.get(ref) else ())\n",
      (T702,), 'KILLED'),
 
     # ---- what the terms MEASURE --------------------------------------------
     ('the-keepout-test-forgets-the-through-hole-rect', 'q',
-     "                out.append(_fp.keepout_hit(t.entry, rects))\n",
-     "                out.append(_fp.keepout_hit(t.entry, (rects[0],)))\n",
+     "            out.append(_fp.keepout_hit(t.entry, rects))\n",
+     "            out.append(_fp.keepout_hit(t.entry, (rects[0],)))\n",
      (T702, T701P), 'KILLED'),
 
     ('the-anchor-branch-is-never-taken', 'q',
-     "                        _anchor = not any(\n"
-     "                            _fp.zone_fits_courtyard(\n"
-     "                                _z['rect'], _p.rect(0.0, 0.0, _r), _tol)\n"
-     "                            for _r in (_p.rot % 360, (_p.rot + 90) % 360))\n",
-     "                        _anchor = False\n",
+     "                _anchor = not any(\n"
+     "                    _fp.zone_fits_courtyard(\n"
+     "                        _z['rect'], _p.rect(0.0, 0.0, _r), _tol)\n"
+     "                    for _r in (_p.rot % 360, (_p.rot + 90) % 360))\n",
+     "                _anchor = False\n",
      (T702,), 'KILLED'),
 
     ('the-zone-tolerance-is-ignored', 'q',
-     "                    _tol = float(_z['tolerance_mm'])\n",
-     "                    _tol = 0.0\n",
+     "            _tol = float(_z['tolerance_mm'])\n",
+     "            _tol = 0.0\n",
      (T702,), 'KILLED'),
 
     ('the-exclusive-zone-term-is-dropped', 'q',
-     "                        _terms.append(_IntentTerm(\n"
-     "                            'zone_exclusive', _z['name'], tuple(_z['rect']),\n"
-     "                            legality.EPS, False, None))\n",
-     "                        pass\n",
+     "                _terms.append(_IntentTerm(\n"
+     "                    'zone_exclusive', _z['name'], tuple(_z['rect']),\n"
+     "                    legality.EPS, False, None))\n",
+     "                pass\n",
      (T702,), 'KILLED'),
 
     # ---- the shared measurement, which the GRADE also calls -----------------
@@ -238,9 +253,19 @@ ROWS = [
      (T702,), 'SURVIVED'),
 
     # ---- inertness ----------------------------------------------------------
+    # RE-ANCHORED (#877). This is the one row whose old anchor names code
+    # `c7bef8d9` DELETED rather than moved: the state no longer guards the
+    # build on "something was declared", it builds unconditionally and lets
+    # `_intent_active` be False. The claim is unchanged -- CONSTRUCTING the
+    # gate when nothing is declared is harmless -- so it is re-pointed at the
+    # early-out that now expresses it, in `build_zone_spec`. Removing that
+    # early-out builds the (empty) spec anyway, which is exactly what the old
+    # `if True:` did, and it must still SURVIVE.
     ('the-gate-is-built-even-with-no-intent', 'q',
-     "        if self.intent_zones or self.keepouts_for:\n",
-     "        if True:\n",
+     "    if not zones:\n"
+     "        return spec\n",
+     "    if False:\n"
+     "        return spec\n",
      (T702,), 'SURVIVED'),
 
     # ---- expected survivors, recorded rather than deleted -------------------
@@ -249,9 +274,9 @@ ROWS = [
     # `intent_ok` returns True on `if not spec`. Recorded so it becomes a
     # detector the day the guard starts meaning something else.
     ('the-active-flag-ignores-whether-anything-bound', 'q',
-     "            self._intent_active = bool(self._intent_spec\n"
-     "                                       or self.keepouts_for)\n",
-     "            self._intent_active = True\n",
+     "        self._intent_active = bool(self._intent_spec"
+     " or self.keepouts_for)\n",
+     "        self._intent_active = True\n",
      (T702,), 'SURVIVED'),
 
     # MEASURED KILLED, and I had expected SURVIVED. Arm A asserts

--- a/tests/mutate_702.py
+++ b/tests/mutate_702.py
@@ -333,6 +333,12 @@ ROWS = [
      (T702,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),

--- a/tests/mutate_702.py
+++ b/tests/mutate_702.py
@@ -43,10 +43,15 @@ start reports nothing at all.
 THE MEASURED TABLE IS IN THE HEADER OF `test_702_quench_intent_gate.py`, FROM
 THE RUN -- never predicted here and never edited afterwards to match.
 
-RE-RUN at 939fec4f, after #877 re-anchored eight of these rows: **22 rows, 18
-killed, 4 survived, 0 broken, 1 disagreeing.** Before it, the same 22 rows were
+RE-RUN at e59e8cf9, after #877 re-anchored eight of these rows: **22 rows, 19
+killed, 3 survived, 0 broken, 1 disagreeing.** Before it, the same 22 rows were
 14 usable and 8 BROKEN -- 8 of this battery's rows had asserted nothing since
 `c7bef8d9`, which is the worst case #877 measured.
+
+(An intermediate run at 939fec4f read 18 killed / 4 survived / 3 disagreeing.
+That is not this table: two rows were still wrong at that commit -- the keepout
+row's first re-anchor was inert, and the active-flag row had not been re-graded
+-- and both are described below. The number above is the shipped table's.)
 
 Two things that run found, both recorded rather than tidied away:
 
@@ -59,10 +64,12 @@ Two things that run found, both recorded rather than tidied away:
     is the one disagreement left, and it is NOT from #877's work: the row, its
     target (`floorplan.py`) and its witness are byte-identical to
     upstream/main, so its verdict is deterministic and predates this branch.
-    It was invisible because the battery already exited non-zero on the eight
-    BROKEN rows, so nobody read past them. Left standing as a real finding
-    about this gate's coverage, to be fixed on its own terms rather than
-    folded into an anchor pass.
+    It is a COVERAGE REGRESSION, not a wrong expectation -- the table in
+    `test_702_quench_intent_gate.py` records this row as KILLED when it was
+    last measured, so the gate went quiet in between. It was invisible because
+    the battery already exited non-zero on the eight BROKEN rows, so nobody
+    read past them. Left standing as a real finding, to be fixed on its own
+    terms rather than folded into an anchor pass.
 """
 from __future__ import annotations
 

--- a/tests/mutate_702.py
+++ b/tests/mutate_702.py
@@ -42,6 +42,27 @@ start reports nothing at all.
 
 THE MEASURED TABLE IS IN THE HEADER OF `test_702_quench_intent_gate.py`, FROM
 THE RUN -- never predicted here and never edited afterwards to match.
+
+RE-RUN at 939fec4f, after #877 re-anchored eight of these rows: **22 rows, 18
+killed, 4 survived, 0 broken, 1 disagreeing.** Before it, the same 22 rows were
+14 usable and 8 BROKEN -- 8 of this battery's rows had asserted nothing since
+`c7bef8d9`, which is the worst case #877 measured.
+
+Two things that run found, both recorded rather than tidied away:
+
+  * `the-active-flag-ignores-whether-anything-bound` was recorded SURVIVED and
+    now KILLS. The gate got stronger while the row could not fire: `test_702`
+    has since grown two arms that assert `_intent_active` itself rather than
+    its consequences. Re-graded KILLED, with the arms named at the row.
+
+  * `the-crossed-claim-check-never-fires` SURVIVES and is expected KILLED. It
+    is the one disagreement left, and it is NOT from #877's work: the row, its
+    target (`floorplan.py`) and its witness are byte-identical to
+    upstream/main, so its verdict is deterministic and predates this branch.
+    It was invisible because the battery already exited non-zero on the eight
+    BROKEN rows, so nobody read past them. Left standing as a real finding
+    about this gate's coverage, to be fixed on its own terms rather than
+    folded into an anchor pass.
 """
 from __future__ import annotations
 
@@ -155,16 +176,26 @@ ROWS = [
     # the census went lifted=49 -> lifted=0 on arm Q's fixture, and the
     # verdict degraded from
     # `keepout_blocks` to `no_movable_neighbour`.
-    # The REPLACEMENT is re-spelled too, and deliberately: the old one reached
-    # for `self.keepouts`, the whole board's list, which the free function does
-    # not have. Flattening `keepouts_for.values()` is the same mutation -- hand
-    # the ref every keep-out instead of its own live slice, so removing one
-    # entry from `keepouts_for[ref]` changes nothing and the census lift goes
-    # invisible. Widening it to anything else would be a different experiment.
+    # RE-ANCHORED TO THE CALL SITE (#877), and the first re-anchor here was
+    # WRONG -- recorded because the run caught it and the row is the reason the
+    # run exists. `c7bef8d9` left the free `intent_spec` no `self.keepouts` to
+    # reach for, so the first attempt flattened `keepouts_for.values()`
+    # instead. MEASURED: SURVIVED, expected KILLED. On this fixture one ref
+    # holds every keep-out, so the flattened union EQUALS that ref's own slice
+    # and the mutation is a no-op -- a re-anchor that had quietly stopped
+    # expressing the claim, which is exactly the failure #877 is about.
+    #
+    # `self.keepouts` is still there (quench.py:892); it is the CALLER that has
+    # it now. Mutating the call site reproduces the original edit exactly --
+    # hand the ref every keep-out on the board whenever it has any, so removing
+    # one entry from `keepouts_for[ref]` changes nothing and #701's census lift
+    # goes invisible.
     ('the-keepout-slice-stops-honouring-the-lift', 'q',
-     "    kos = keepouts_for.get(ref, ())\n",
-     "    kos = (tuple(k for _v in keepouts_for.values() for k in _v)\n"
-     "           if keepouts_for.get(ref) else ())\n",
+     "        return intent_spec(self._intent_spec, self.keepouts_for, ref)\n",
+     "        return intent_spec(\n"
+     "            self._intent_spec,\n"
+     "            {ref: self.keepouts} if self.keepouts_for.get(ref) else {},\n"
+     "            ref)\n",
      (T702,), 'KILLED'),
 
     # ---- what the terms MEASURE --------------------------------------------
@@ -268,16 +299,28 @@ ROWS = [
      "        return spec\n",
      (T702,), 'SURVIVED'),
 
-    # ---- expected survivors, recorded rather than deleted -------------------
-    # `_intent_active` is what candidate_valid guards on; flipping it ON with
-    # an empty spec changes nothing, because every lookup misses and
-    # `intent_ok` returns True on `if not spec`. Recorded so it becomes a
-    # detector the day the guard starts meaning something else.
+    # RE-ANCHORED AND RE-GRADED (#877). The anchor was a two-line wrap that
+    # `c7bef8d9` reflowed onto one line.
+    #
+    # It was recorded SURVIVED, with the reasoning that flipping the flag ON
+    # with an empty spec changes nothing: every lookup misses and `intent_ok`
+    # returns True on `if not spec`. MEASURED NOW: KILLED. The gate got
+    # stronger while the row could not fire -- `test_702` has since grown two
+    # arms that assert the FLAG rather than its consequences, and both fail:
+    #
+    #     FAIL a state with no intent binds nothing --
+    #          _intent_active False, _intent_spec empty
+    #     FAIL a no-intent quench never calls the gate --
+    #          the intent gate was reached with no intent
+    #
+    # Graded KILLED, from the run. The old expectation is kept in this comment
+    # rather than overwritten, because "the day the guard starts meaning
+    # something else" is the day this row was written for, and it arrived.
     ('the-active-flag-ignores-whether-anything-bound', 'q',
      "        self._intent_active = bool(self._intent_spec"
      " or self.keepouts_for)\n",
      "        self._intent_active = True\n",
-     (T702,), 'SURVIVED'),
+     (T702,), 'KILLED'),
 
     # MEASURED KILLED, and I had expected SURVIVED. Arm A asserts
     # `by_site['candidate_valid'] > 0`, so the tally is load-bearing after all:

--- a/tests/mutate_703.py
+++ b/tests/mutate_703.py
@@ -78,10 +78,18 @@ _TIE_SCAN = (
     "            j += 1\n"
     "        avg = (i + j) / 2.0 + 1\n")
 
+# DISAMBIGUATED (#877). `89bd8a29` ("#789: the arithmetic -- Kendall tau-b in
+# rank_stats, and its self-test") added `board_tau` as a near-copy of
+# `board_rho`, so this block occurs TWICE. `replace(..., 1)` would still have
+# hit the `board_rho` copy -- it is first in the file -- but only by luck of
+# ordering, and the battery's own exactly-once check reported BROKEN. The
+# trailing line is board_rho's alone (`board_tau` tests both columns in one
+# `or`), so the quote names the site the row is about.
 _DROP_NULL = (
     "        if p is None or d is None:\n"
     "            dropped += 1\n"
-    "            continue\n")
+    "            continue\n"
+    "        if isinstance(p, float) and p != p:\n")
 
 _MAPPING_GUARD = (
     "    if not isinstance(rhos_by_board, Mapping):\n"
@@ -181,9 +189,18 @@ ROWS = [
      (T703,), 'KILLED'),
 
     # ---- the formatter that cannot emit a bare rho -------------------------
+    # DISAMBIGUATED (#877), with `fmt-rho-hides-a-missing-span` below. `fmt_tau`
+    # is a near-copy of `fmt_rho` and carries the same two `span` lines, so both
+    # rows quoted a string that occurs TWICE. The `rho=n/a` prefix belongs to
+    # `fmt_rho` alone and names the function each row is about; the mutations
+    # are unchanged.
     ('fmt-rho-drops-the-LOO-span', 'rs',
+     "        return f'rho=n/a [{reason or \"not measurable\"}' + (\n"
+     "            f', K={k}]' if k is not None else ']')\n"
      "    span = (f'LOO {fmt(lo, 0)}..{fmt(hi, 0)}' if lo == lo and hi == hi\n"
      "            else 'LOO not computed')\n",
+     "        return f'rho=n/a [{reason or \"not measurable\"}' + (\n"
+     "            f', K={k}]' if k is not None else ']')\n"
      "    span = ''\n",
      (T703,), 'KILLED'),
 
@@ -201,7 +218,8 @@ ROWS = [
     ('board-rho-coerces-a-null-to-zero', 'rs',
      _DROP_NULL,
      "        if p is None or d is None:\n"
-     "            p, d = (p or 0), (d or 0)\n",
+     "            p, d = (p or 0), (d or 0)\n"
+     "        if isinstance(p, float) and p != p:\n",
      (T703,), 'KILLED'),
 
     # ---- the anti-pooling guard, EXECUTED --------------------------------
@@ -236,7 +254,13 @@ ROWS = [
 
     # ---- renderings that misreport their own scope -------------------------
     ('fmt-rho-hides-a-missing-span', 'rs',
+     "        return f'rho=n/a [{reason or \"not measurable\"}' + (\n"
+     "            f', K={k}]' if k is not None else ']')\n"
+     "    span = (f'LOO {fmt(lo, 0)}..{fmt(hi, 0)}' if lo == lo and hi == hi\n"
      "            else 'LOO not computed')\n",
+     "        return f'rho=n/a [{reason or \"not measurable\"}' + (\n"
+     "            f', K={k}]' if k is not None else ']')\n"
+     "    span = (f'LOO {fmt(lo, 0)}..{fmt(hi, 0)}' if lo == lo and hi == hi\n"
      "            else '')\n",
      (T703,), 'KILLED'),
 

--- a/tests/mutate_703.py
+++ b/tests/mutate_703.py
@@ -328,6 +328,12 @@ ROWS = [
      (T703,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _uncache(path):
     """Delete the target's cached bytecode. MEASURED HAZARD, not hygiene.

--- a/tests/mutate_705_792_794.py
+++ b/tests/mutate_705_792_794.py
@@ -294,6 +294,12 @@ ROWS = [
      (T792P,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),

--- a/tests/mutate_708.py
+++ b/tests/mutate_708.py
@@ -250,6 +250,12 @@ ROWS = [
      (T_SNAP, T_RESEAT), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _uncache(path):
     """Delete the target's cached bytecode. MEASURED HAZARD, not hygiene --

--- a/tests/mutate_711.py
+++ b/tests/mutate_711.py
@@ -225,6 +225,12 @@ ROWS = [
      (T706,), KILLED),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _clear_pycache():
     """Delete every `__pycache__` under the repo.

--- a/tests/mutate_713_census.py
+++ b/tests/mutate_713_census.py
@@ -154,11 +154,11 @@ for label, rel, old, new, why in ROWS:
         # RAW BYTES for the restore, decoded text for the match (#877).
         # Writing without `newline=''` translates every '\n' to os.linesep, so
         # on Windows one run rewrote the whole target in CRLF and left it
-        # permanently "modified" -- which then tripped a dirty-tree refusal on
-        # the next run. `.gitattributes` pins `*.py text eol=lf`, so that was a
-        # real corruption, not a preference. `mutate_711.py:296-321` has the
-        # same pair and records the other half: matching a multi-line anchor
-        # against a RAW decode silently found nothing in three rows.
+        # modified in `git status`. `.gitattributes` pins `*.py text eol=lf`,
+        # so that is a real corruption, not a preference -- and this battery
+        # has NO dirty-tree refusal to notice it. `mutate_711.py` has the same
+        # raw/decoded pair and records the other half: matching a multi-line
+        # anchor against a RAW decode silently found nothing in three rows.
         raw = open(path, 'rb').read()
         with open(path, encoding='utf-8') as f:
             original = f.read()

--- a/tests/mutate_713_census.py
+++ b/tests/mutate_713_census.py
@@ -15,6 +15,20 @@ import shutil
 import subprocess
 import sys
 
+# This battery's runner is at MODULE SCOPE, so `import mutate_713_census`
+# RUNS THE GATE AND REWRITES ENGINE FILES. #877 was filed after a census did
+# exactly that to six batteries, rewrote 13 files under py_router/ and
+# py_placer/, and then reported numbers measured against its own damage.
+# Refusing the import outright, rather than hiding the runner behind
+# `if __name__`, keeps the reason visible and names the API that answers the
+# question the importer actually had.
+if __name__ != '__main__':                                 # pragma: no cover
+    raise ImportError(
+        'tests/mutate_713_census.py is a SCRIPT, not a module: importing it '
+        'runs the battery and rewrites engine files in place. To read its '
+        'rows, use tests/mutation_anchors.resolve_static(path), which parses '
+        'the file instead of executing it.')
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 GATE = os.path.join(ROOT, 'tests', 'test_713_wallclock_census.py')
 
@@ -84,6 +98,12 @@ ROWS = [
      'rather than discovered later'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 #: Rows that MUST survive, with the reason. A recorded expected survivor is a
 #: stated limit of the gate; an unrecorded one is a hole nobody looked at.
@@ -131,6 +151,15 @@ for label, rel, old, new, why in ROWS:
             broken += 1
             continue
     else:
+        # RAW BYTES for the restore, decoded text for the match (#877).
+        # Writing without `newline=''` translates every '\n' to os.linesep, so
+        # on Windows one run rewrote the whole target in CRLF and left it
+        # permanently "modified" -- which then tripped a dirty-tree refusal on
+        # the next run. `.gitattributes` pins `*.py text eol=lf`, so that was a
+        # real corruption, not a preference. `mutate_711.py:296-321` has the
+        # same pair and records the other half: matching a multi-line anchor
+        # against a RAW decode silently found nothing in three rows.
+        raw = open(path, 'rb').read()
         with open(path, encoding='utf-8') as f:
             original = f.read()
         if original.count(old) != 1:
@@ -139,7 +168,7 @@ for label, rel, old, new, why in ROWS:
             broken += 1
             continue
     try:
-        with open(path, 'w', encoding='utf-8') as f:
+        with open(path, 'w', encoding='utf-8', newline='') as f:
             f.write(new if created else original.replace(old, new))
         _clear_pyc()
         rc, out = run_gate()
@@ -147,8 +176,7 @@ for label, rel, old, new, why in ROWS:
         if created:
             os.unlink(path)
         else:
-            with open(path, 'w', encoding='utf-8') as f:
-                f.write(original)
+            open(path, 'wb').write(raw)      # byte-exact, from what was read
         _clear_pyc()
     expected = label in EXPECTED_SURVIVORS
     if rc != 0:

--- a/tests/mutate_713_phase1.py
+++ b/tests/mutate_713_phase1.py
@@ -192,10 +192,11 @@ for label, rel, old, new, why in ROWS:
     path = os.path.join(ROOT, rel)
     # RAW BYTES for the restore, decoded text for the match (#877). Writing
     # without `newline=''` translates every '\n' to os.linesep, so on Windows
-    # one run rewrote the whole target in CRLF and left it permanently
-    # "modified". `.gitattributes` pins `*.py text eol=lf`, so that was a real
-    # corruption. `mutate_711.py:296-321` records the other half: matching a
-    # multi-line anchor against a RAW decode silently found nothing.
+    # one run rewrote the whole target in CRLF and left it modified in `git
+    # status`. `.gitattributes` pins `*.py text eol=lf`, so that is a real
+    # corruption -- and this battery has NO dirty-tree refusal to notice it.
+    # `mutate_711.py` records the other half: matching a multi-line anchor
+    # against a RAW decode silently found nothing.
     raw = open(path, 'rb').read()
     with open(path, encoding='utf-8') as f:
         original = f.read()

--- a/tests/mutate_713_phase1.py
+++ b/tests/mutate_713_phase1.py
@@ -20,6 +20,20 @@ import shutil
 import subprocess
 import sys
 
+# This battery's runner is at MODULE SCOPE, so `import mutate_713_phase1`
+# RUNS THE GATE AND REWRITES ENGINE FILES. #877 was filed after a census did
+# exactly that to six batteries, rewrote 13 files under py_router/ and
+# py_placer/, and then reported numbers measured against its own damage.
+# Refusing the import outright, rather than hiding the runner behind
+# `if __name__`, keeps the reason visible and names the API that answers the
+# question the importer actually had.
+if __name__ != '__main__':                                 # pragma: no cover
+    raise ImportError(
+        'tests/mutate_713_phase1.py is a SCRIPT, not a module: importing it '
+        'runs the battery and rewrites engine files in place. To read its '
+        'rows, use tests/mutation_anchors.resolve_static(path), which parses '
+        'the file instead of executing it.')
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 GATE = os.path.join(ROOT, 'tests', 'test_713_refill_status.py')
 
@@ -140,6 +154,12 @@ ROWS = [
      'an absent verdict must not be reported as a fact about the board'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _clear_pyc():
     for base, dirs, _ in os.walk(ROOT):
@@ -170,6 +190,13 @@ print(f"baseline: gate passes clean ({out.strip().splitlines()[-1]})\n")
 killed = survived = broken = 0
 for label, rel, old, new, why in ROWS:
     path = os.path.join(ROOT, rel)
+    # RAW BYTES for the restore, decoded text for the match (#877). Writing
+    # without `newline=''` translates every '\n' to os.linesep, so on Windows
+    # one run rewrote the whole target in CRLF and left it permanently
+    # "modified". `.gitattributes` pins `*.py text eol=lf`, so that was a real
+    # corruption. `mutate_711.py:296-321` records the other half: matching a
+    # multi-line anchor against a RAW decode silently found nothing.
+    raw = open(path, 'rb').read()
     with open(path, encoding='utf-8') as f:
         original = f.read()
     if original.count(old) != 1:
@@ -178,13 +205,12 @@ for label, rel, old, new, why in ROWS:
         broken += 1
         continue
     try:
-        with open(path, 'w', encoding='utf-8') as f:
+        with open(path, 'w', encoding='utf-8', newline='') as f:
             f.write(original.replace(old, new))
         _clear_pyc()
         rc, out = run_gate()
     finally:
-        with open(path, 'w', encoding='utf-8') as f:
-            f.write(original)
+        open(path, 'wb').write(raw)          # byte-exact, from what was read
         _clear_pyc()
     if rc != 0:
         killed += 1

--- a/tests/mutate_714.py
+++ b/tests/mutate_714.py
@@ -282,6 +282,12 @@ ROWS = [
      (PERT,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths), cwd=_ROOT)

--- a/tests/mutate_726.py
+++ b/tests/mutate_726.py
@@ -209,7 +209,12 @@ ROWS = [
 # rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
 # witnesses have been paid for; this is the one second (#877).
 from mutation_anchors import preflight   # noqa: E402
-preflight(__file__)
+# `repo_wide=True` because THIS battery's own check was the strictest in the
+# tree: `verify_anchors` below also refuses an anchor that occurs in another
+# tracked file, the prose trap its docstring describes. `preflight` handles
+# `--verify-anchors` itself, so without this the shared check would have
+# SHADOWED the stricter one and quietly dropped that column.
+preflight(__file__, repo_wide=True)
 
 
 def _uncache(path):

--- a/tests/mutate_726.py
+++ b/tests/mutate_726.py
@@ -205,6 +205,12 @@ ROWS = [
      (T_SYNC,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _uncache(path):
     """Delete the target's cached bytecode. MEASURED HAZARD, not hygiene.

--- a/tests/mutate_730.py
+++ b/tests/mutate_730.py
@@ -69,13 +69,17 @@ _VIA_GATE = """        if override_holes and override_hole_gap(
 _CONN_GATE = """        if override_holes and override_hole_gap(
                 net_id, sx, sy, ex, ey) < hw - 1e-4:
             return False"""
-# RE-ANCHORED (#877), with the three site-E rows that share this quote.
-# `b02761b7` ("legality: the board's own copper-to-hole floor, and the review
-# its tripwire asked for (#761)") replaced `defaults.NPTH_TO_TRACK_CLEARANCE`
-# with the board-resolved local `_npth_floor` and reflowed the two lines into
-# one. The REPLACEMENTS below are re-spelled to `_npth_floor` as well, so each
-# row still changes exactly ONE thing: reverting to the raw default would drop
-# the board floor too, which is a second mutation and a different experiment.
+# RE-ANCHORED (#877). `b02761b7` ("legality: the board's own copper-to-hole
+# floor, and the review its tripwire asked for (#761)") replaced
+# `defaults.NPTH_TO_TRACK_CLEARANCE` with the board-resolved local
+# `_npth_floor` and reflowed the two lines into one, staling this quote and the
+# three site-E rows that inline their own copy of it.
+#
+# Where the mutation lands AT that line, the replacement says `_npth_floor`
+# too, so the row still changes exactly one thing -- naming the raw default
+# there would drop the board floor as well, which is a second mutation. The
+# one exception is `site-E-reverted-to-the-hoist`, whose edit lands at the TOP
+# of `__init__` where `_npth_floor` is not yet bound; see the note on that row.
 _E_BLOCK = """                    _lc = ((getattr(p, 'local_clearance', 0.0) or 0.0)
                            if copper_holes else 0.0)
                     npth_grow = max(0.0, max(_npth_floor, _lc) - clearance)"""
@@ -224,7 +228,16 @@ ROWS = [
        "'s pad requirements\n",
        '        self.max_floor = 0.0    # upper bound on this part'
        "'s pad requirements\n"
-       '        npth_grow = max(0.0, _npth_floor - clearance)\n'),
+       # NOT `_npth_floor`: this line is hoisted to the TOP of `__init__`
+       # (legality.py:2090) and `_npth_floor` is a local of that same function
+       # bound sixteen lines later, at :2105. Naming it here makes every
+       # `PartPads` construction raise UnboundLocalError, so the row reports
+       # its expected KILLED for an exception rather than for the floor -- a
+       # green tally measuring nothing, which is #877's own defect. The flat
+       # default is also what the pre-#730 hoist actually said, so this is the
+       # faithful revert as well as the working one.
+       '        npth_grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE'
+       ' - clearance)\n'),
       (_E_BLOCK, '                    pass')],
      None, (T730,), 'KILLED'),
     ('site-E-loses-the-fab-floor', 'leg',

--- a/tests/mutate_730.py
+++ b/tests/mutate_730.py
@@ -253,6 +253,12 @@ ROWS = [
      (T730,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_730.py
+++ b/tests/mutate_730.py
@@ -69,10 +69,16 @@ _VIA_GATE = """        if override_holes and override_hole_gap(
 _CONN_GATE = """        if override_holes and override_hole_gap(
                 net_id, sx, sy, ex, ey) < hw - 1e-4:
             return False"""
+# RE-ANCHORED (#877), with the three site-E rows that share this quote.
+# `b02761b7` ("legality: the board's own copper-to-hole floor, and the review
+# its tripwire asked for (#761)") replaced `defaults.NPTH_TO_TRACK_CLEARANCE`
+# with the board-resolved local `_npth_floor` and reflowed the two lines into
+# one. The REPLACEMENTS below are re-spelled to `_npth_floor` as well, so each
+# row still changes exactly ONE thing: reverting to the raw default would drop
+# the board floor too, which is a second mutation and a different experiment.
 _E_BLOCK = """                    _lc = ((getattr(p, 'local_clearance', 0.0) or 0.0)
                            if copper_holes else 0.0)
-                    npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,
-                                             _lc) - clearance)"""
+                    npth_grow = max(0.0, max(_npth_floor, _lc) - clearance)"""
 
 # (name, target, old, new, tests, expect)
 ROWS = [
@@ -218,18 +224,17 @@ ROWS = [
        "'s pad requirements\n",
        '        self.max_floor = 0.0    # upper bound on this part'
        "'s pad requirements\n"
-       '        npth_grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE'
-       ' - clearance)\n'),
+       '        npth_grow = max(0.0, _npth_floor - clearance)\n'),
       (_E_BLOCK, '                    pass')],
      None, (T730,), 'KILLED'),
     ('site-E-loses-the-fab-floor', 'leg',
-     '                    npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,\n'
-     '                                             _lc) - clearance)',
+     '                    npth_grow = max(0.0, max(_npth_floor, _lc)'
+     ' - clearance)',
      '                    npth_grow = max(0.0, _lc - clearance)',
      (T730,), 'KILLED'),
     ('site-E-threshold-at-clearance', 'leg',
-     '                    npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,\n'
-     '                                             _lc) - clearance)',
+     '                    npth_grow = max(0.0, max(_npth_floor, _lc)'
+     ' - clearance)',
      '                    npth_grow = max(0.0, max(clearance, _lc) - clearance)',
      (T730,), 'KILLED'),
     ('site-E-silk-gate-dropped', 'leg',
@@ -240,9 +245,9 @@ ROWS = [
     # an exact re-spelling of `max`. Recorded so nobody reads its survival as
     # a coverage hole.
     ('site-E-max-respelled-as-a-conditional', 'leg',
-     '                    npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,\n'
-     '                                             _lc) - clearance)',
-     '                    _f = defaults.NPTH_TO_TRACK_CLEARANCE\n'
+     '                    npth_grow = max(0.0, max(_npth_floor, _lc)'
+     ' - clearance)',
+     '                    _f = _npth_floor\n'
      '                    npth_grow = max(0.0, (_lc if _lc > _f else _f)\n'
      '                                    - clearance)',
      (T730,), 'SURVIVED'),

--- a/tests/mutate_735.py
+++ b/tests/mutate_735.py
@@ -217,6 +217,12 @@ ROWS = [
      (T735, TDRUC), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_746.py
+++ b/tests/mutate_746.py
@@ -139,6 +139,12 @@ GUI_ROWS = [
      "    via_resolved = result['via_resolved']"),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 BATTERIES = {
     'engine': (ENGINE, ENGINE_TEST, ENGINE_ROWS),
     'gui': (GUI, GUI_TEST, GUI_ROWS),

--- a/tests/mutate_747.py
+++ b/tests/mutate_747.py
@@ -329,6 +329,12 @@ ROWS = [
      (T747, T736, T746, T775), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_747.py
+++ b/tests/mutate_747.py
@@ -144,10 +144,15 @@ ROWS = [
      '                        radius=None,',
      (T747, T725), 'KILLED'),
 
+    # RE-ANCHORED (#877). `f1bfee4d` ("#779: the seed half of the via
+    # disclosure grades seed BARRELS") reformatted the `_register_via(...)`
+    # call: the statement no longer closes on this line, so the trailing `))`
+    # became `)` and the anchor matched nothing. Dropping the keep-out
+    # carry-over is still the mutation.
     ('drop-keepout-carry-over', 'fc',
      """                        radius=None if rec is None else rec[1],
-                        keepout=t[3]))""",
-     """                        radius=0.0 if rec is None else rec[1]))""",
+                        keepout=t[3])""",
+     """                        radius=0.0 if rec is None else rec[1])""",
      (T747,), 'KILLED'),
 
     # ---- the registrar: the match --------------------------------------

--- a/tests/mutate_750.py
+++ b/tests/mutate_750.py
@@ -180,6 +180,12 @@ ROWS = [
      'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_756.py
+++ b/tests/mutate_756.py
@@ -303,6 +303,12 @@ ROWS = [
      (T756, T370), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_760.py
+++ b/tests/mutate_760.py
@@ -22,6 +22,20 @@ Run it after touching either site:
 import os
 import subprocess
 import sys
+
+# This battery's runner is at MODULE SCOPE, so `import mutate_760` REWRITES
+# ENGINE FILES. #877 was filed after a census did exactly that to six batteries
+# and rewrote 13 files under py_router/ and py_placer/ -- then reported numbers
+# measured against its own damage. Refusing the import outright, rather than
+# hiding the runner behind `if __name__`, keeps the reason visible and points
+# at the API that answers the question the importer actually had.
+if __name__ != '__main__':                                 # pragma: no cover
+    raise ImportError(
+        'tests/mutate_760.py is a SCRIPT, not a module: importing it runs the '
+        'battery and rewrites engine files in place. To read its rows, use '
+        'tests/mutation_anchors.resolve_static(path), which parses the file '
+        'instead of executing it.')
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SER = os.path.join(ROOT, 'py_router/single_ended_routing.py')
 PCM = os.path.join(ROOT, 'py_router/pcb_modification.py')
@@ -61,11 +75,35 @@ ROWS = [
    "                hd >= npth_clr + w / 2.0 - 1e-4 and\n"
    "                edge_clears(x1, y1, x2, y2, w))"),
 ]
+
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
 killed = surv = broken = 0
+
+# A dirty target would be RESTORED to its committed text, silently destroying
+# uncommitted work. Every other battery refuses; this one did not (#877).
+_dirty = subprocess.run(
+    ['git', 'status', '--porcelain', '--'] + sorted({r[1] for r in ROWS}),
+    cwd=ROOT, capture_output=True, text=True).stdout.strip()
+if _dirty:
+    print('REFUSED: the files this battery rewrites have uncommitted changes.\n'
+          'Restoring them writes the COMMITTED text back over your work.\n'
+          + _dirty)
+    sys.exit(2)
+
 for row in ROWS:
     name, path, old, new = row[:4]
     nth = row[4] if len(row) > 4 else None
-    orig = open(path).read()
+    # RAW BYTES for the restore, decoded text for the match (#877). This was
+    # the worst of the four: no encoding AND no newline on either side, so it
+    # round-tripped every target through the locale codec (cp1252 on Windows)
+    # and translated every '\n' to os.linesep. `.gitattributes` pins `*.py text
+    # eol=lf`, so a single run left every target permanently "modified".
+    raw = open(path, 'rb').read()
+    orig = raw.decode('utf-8').replace('\r\n', '\n')
     if nth is not None:            # replace the Nth occurrence only
         parts = orig.split(old)
         if len(parts) - 1 < nth + 1:
@@ -77,7 +115,7 @@ for row in ROWS:
             print(f'  BROKEN {name}: anchor count {orig.count(old)}')
             broken += 1; continue
         mut = orig.replace(old, new)
-    open(path, 'w').write(mut)
+    open(path, 'w', encoding='utf-8', newline='').write(mut)
     try:
         r = subprocess.run([sys.executable, TEST], capture_output=True, text=True,
                            cwd=ROOT, timeout=600)
@@ -90,6 +128,6 @@ for row in ROWS:
             print(f'  SURVIVED {name}')
             surv += 1
     finally:
-        open(path, 'w').write(orig)
+        open(path, 'wb').write(raw)          # byte-exact, from what was read
 print(f'\n{killed} killed, {surv} SURVIVED, {broken} broken')
 sys.exit(1 if surv or broken else 0)

--- a/tests/mutate_761.py
+++ b/tests/mutate_761.py
@@ -216,6 +216,12 @@ ROWS = [
      (T761,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_768.py
+++ b/tests/mutate_768.py
@@ -105,8 +105,18 @@ _DISCLOSE = """                    if _capped:
 
 _HOLE_KW = "                hole_clearance=_hc,\n"
 
-_GUI_CEILING = ("                netclass_ceiling="
-                "fanout_config.get('clearance_ceiling'),\n")
+# RE-ANCHORED (#877), with the five other GUI rows below. `1c044399` ("#530
+# decision 2: --clearance sets the Default class; --clearance-ceiling caps every
+# class") renamed the shared key `clearance_ceiling` -> `placement_clearance_
+# ceiling`, keeping the old spelling as a two-line `.get(new, .get(old))`
+# fallback, and replaced `self.clearance_check.GetValue()` with
+# `self._ceiling_on()`. Six of this battery's 31 rows quoted the one-line forms
+# and had matched nothing since. The mutations are unchanged.
+_GUI_CEILING = (
+    "                netclass_ceiling=fanout_config.get("
+    "'placement_clearance_ceiling',\n"
+    "                                                   fanout_config.get("
+    "'clearance_ceiling')),\n")
 
 # RE-ANCHORED (#780). The predicate grew a second shape -- a FANOUT step
 # that switches the inline cap pass on runs the same pass -- so the old
@@ -250,18 +260,18 @@ ROWS = [
     # back on the OMITTED one. Found by a parity review measuring the value,
     # after two string-count assertions passed it.
     ('gui-gate-is-fix-drc-settings', 'gui',
-     "netclass_ceiling=fanout_config.get('clearance_ceiling'),",
-     "netclass_ceiling=(fanout_config.get('clearance')\n"
+     _GUI_CEILING,
+     "                netclass_ceiling=(fanout_config.get('clearance')\n"
      "                                  if fanout_config.get("
-     "'fix_drc_settings', True) else None),",
+     "'fix_drc_settings', True) else None),\n",
      (T768, TDLG), 'KILLED'),
     # THE SECOND CUT'S DEFECT, found by an adversarial review: the RESOLVED base
     # is already min(Default class, override), so handing it over as a ceiling
     # caps a class BETWEEN the two down to the Default. Measured 22 cap
     # clearance violations against main's 2 at the default dialog config.
     ('gui-ceiling-is-the-resolved-base', 'gui',
-     "netclass_ceiling=fanout_config.get('clearance_ceiling'),",
-     "netclass_ceiling=fanout_config.get('clearance'),",
+     _GUI_CEILING,
+     "                netclass_ceiling=fanout_config.get('clearance'),\n",
      (TDLG,), 'KILLED'),
     # RE-ANCHORED AND RE-GRADED (#780). The inline cap config gained the
     # same pair of lines at a DEEPER indent, and 12 spaces + the text is a
@@ -275,14 +285,20 @@ ROWS = [
     # driving run_cap_optimization. Both are fixed in the same commit
     # range; T772 is added because it drives the step end to end.
     ('gui-standalone-cfg-drops-the-key', 'gui',
-     "            'clearance_ceiling': shared.get('clearance_ceiling'),\n"
+     "            'clearance_ceiling': shared.get("
+     "'placement_clearance_ceiling',\n"
+     "                                            shared.get("
+     "'clearance_ceiling')),\n"
      "            'fix_drc_settings': shared.get('fix_drc_settings', True),\n",
      "            'fix_drc_settings': shared.get('fix_drc_settings', True),\n",
      (T768, TDLG, T772), 'KILLED'),
     # #780's own half of the same defect, on the INLINE dict. Its only
     # behavioural killer is TDLG's section 2, which drives _run_bga_fanout.
     ('gui-inline-cfg-drops-the-key', 'gui',
-     "                'clearance_ceiling': shared.get('clearance_ceiling'),\n",
+     "                'clearance_ceiling': shared.get("
+     "'placement_clearance_ceiling',\n"
+     "                                                shared.get("
+     "'clearance_ceiling')),\n",
      '',
      (TDLG,), 'KILLED'),
     ('fanout-tab-exports-the-RESOLVED-clearance-as-the-ceiling', 'swig',
@@ -295,7 +311,7 @@ ROWS = [
     # That is the runner behaving exactly as designed.
     ('fanout-tab-stops-exporting-the-override', 'swig',
      "                # what the pass must price at.\n"
-     "                'clamp_netclasses': self.clearance_check.GetValue(),\n",
+     "                'clamp_netclasses': self._ceiling_on(),\n",
      '',
      (T768, TDLG), 'KILLED'),
     # #768's plan-executor half: an OMITTED --clearance must not inherit the

--- a/tests/mutate_768.py
+++ b/tests/mutate_768.py
@@ -333,6 +333,12 @@ ROWS = [
      (T768,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_775.py
+++ b/tests/mutate_775.py
@@ -190,6 +190,12 @@ ROWS = [
      (T775,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_779.py
+++ b/tests/mutate_779.py
@@ -158,6 +158,12 @@ ROWS = [
      (T779,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_789.py
+++ b/tests/mutate_789.py
@@ -130,6 +130,12 @@ ROWS = [
      (T_HARNESS,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def run(tests):
     for t in tests:

--- a/tests/mutate_797.py
+++ b/tests/mutate_797.py
@@ -338,6 +338,12 @@ ROWS = [
 
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _uncache(path):
     """Delete the target's cached bytecode. MEASURED HAZARD, not hygiene --

--- a/tests/mutate_799.py
+++ b/tests/mutate_799.py
@@ -194,9 +194,13 @@ ROWS = [
      "    violations = list(validate_intent(intent)) + list(block_problems)\n",
      (T793, T799), 'KILLED'),
 
+    # RE-ANCHORED (#877). `a22a968a` ("#705: grade the decoupling cap to the
+    # PIN") EXTENDED `_NON_RULE_SEVERITIES`, so this line no longer closes the
+    # frozenset with `})` and the quote matched nothing. Dropping
+    # `keepout_allow_unresolved` from the registry is still the mutation.
     ('the-rule-name-is-not-registered', 'fp',
-     "    'intent_zone_in_keepout', 'keepout_allow_unresolved'})\n",
-     "    'intent_zone_in_keepout'})\n",
+     "    'intent_zone_in_keepout', 'keepout_allow_unresolved',\n",
+     "    'intent_zone_in_keepout',\n",
      (T549S,), 'KILLED'),
 
     # ---- the board_score prerequisite --------------------------------------

--- a/tests/mutate_799.py
+++ b/tests/mutate_799.py
@@ -210,6 +210,12 @@ ROWS = [
      (TBS,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),

--- a/tests/mutate_826.py
+++ b/tests/mutate_826.py
@@ -170,6 +170,12 @@ ROWS = [
      (T_PF,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _uncache(path):
     """Delete the target's cached bytecode. MEASURED HAZARD, not hygiene."""

--- a/tests/mutate_829.py
+++ b/tests/mutate_829.py
@@ -233,6 +233,12 @@ ROWS = [
      (TREF, T550), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),

--- a/tests/mutate_829.py
+++ b/tests/mutate_829.py
@@ -194,12 +194,16 @@ ROWS = [
     # Drop the "did the pose actually change?" qualifier and the backstop
     # refuses a write in which nothing moved -- which is exactly
     # `perturb._all_at_current`, and its dose-0 CONTROL board.
+    # RE-ANCHORED (#877). `68d9af16` ("#714: placement.writer can mirror a
+    # footprint to the other face") EXTENDED this disjunction with `side_change`
+    # and a comment block, so the closing paren the anchor quoted moved and the
+    # row matched nothing. Rather than quote thirteen lines to reach the new
+    # paren -- which would go stale again on the next term -- the mutation now
+    # neutralises the FIRST disjunct, making the whole `or` chain true. Same
+    # claim, same verdict: the writer stops refusing a zero-move write.
     ('the-writer-refuses-a-zero-move-write', 'wr',
-     "                and (abs(new_x - float(at_match.group(1))) > _POSE_EPS\n"
-     "                     or abs(new_y - float(at_match.group(2))) > _POSE_EPS\n"
-     "                     or abs((new_rot - old_rot + 180) % 360 - 180) "
-     "> _POSE_EPS)\n",
-     "                and True\n",
+     "                and (abs(new_x - float(at_match.group(1))) > _POSE_EPS\n",
+     "                and (True\n",
      (T829,), 'KILLED'),
 
     # Compare the fingerprint against the OUTPUT file instead of the in-memory

--- a/tests/mutate_830.py
+++ b/tests/mutate_830.py
@@ -205,6 +205,12 @@ ROWS = [
      (T830,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),

--- a/tests/mutate_834_835.py
+++ b/tests/mutate_834_835.py
@@ -217,10 +217,18 @@ ROWS = [
      'SURVIVED'),
 
     # ---- the reconciliation ---------------------------------------------
+    # The mutation is on the ADMISSION TEST only. `b31adcea` turned the
+    # comprehension into a loop where `shared` feeds two consumers -- the
+    # filter AND the charged rect -- so mutating `shared` would also inflate
+    # every admitted neighbour's box, and a kill could no longer be attributed
+    # to the one-sided test the row is named for. Mutating the `if` keeps the
+    # rect identical on both arms, which is what the comprehension's
+    # `_geom[g.ref].rect` did.
     ('routability-keeps-its-one-sided-side-test', 'rou',
-     """        shared = own_sides & g.sides""",
-     """        shared = (g.sides if footprint_side(fp) in g.sides
-                  else frozenset())""",
+     """        if not shared:
+            continue""",
+     """        if footprint_side(fp) not in g.sides:
+            continue""",
      (T835,), 'KILLED'),
 
     ('routability-goes-back-to-double-charging', 'rou',

--- a/tests/mutate_834_835.py
+++ b/tests/mutate_834_835.py
@@ -321,6 +321,12 @@ ROWS = [
      'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     out = subprocess.run(['git', 'status', '--porcelain', '--'] + list(paths),

--- a/tests/mutate_834_835.py
+++ b/tests/mutate_834_835.py
@@ -149,13 +149,19 @@ ROWS = [
      'SURVIVED'),
 
     # ---- #835: the escape ledger ----------------------------------------
+    # RE-ANCHORED (#877), with the six rows below it. This battery is not in
+    # #877's table at all -- 7 of its 22 rows had gone stale and nobody had
+    # measured it. Three causes, all of them later work on the same code:
+    # `b31adcea` (#848, charge a neighbour the sides it SHARES) turned two
+    # comprehensions into loops and moved `oth` out of the branch that used it,
+    # `398d8052` (#862) added kwargs to the ledger call, and `fa594fd1` (#850)
+    # renamed `own` to `geom` in `assign_faces`. Every mutation below is the
+    # one it always was, re-quoted against the code as it now stands.
     ('the-side-filter-goes-away', 'esc',
      """        if own is not None:
-            oth = sides.get(other)
             if oth is not None and not (own & oth):
                 continue""",
      """        if False:
-            oth = sides.get(other)
             if oth is not None and not (own & oth):
                 continue""",
      (T835,), 'KILLED'),
@@ -201,9 +207,9 @@ ROWS = [
 
     ('the-sides-map-is-not-threaded-into-the-ledger', 'esc',
      """                       sides=sides, containers=containers,
-                       obstruction_rects=orects)""",
+                       obstruction_rects=orects,""",
      """                       sides=None, containers=containers,
-                       obstruction_rects=orects)""",
+                       obstruction_rects=orects,""",
      (T835,),
      # Inert by construction: `part_escape` builds its own map when given
      # None. Recorded so that if the fallback is ever removed -- making the
@@ -212,12 +218,9 @@ ROWS = [
 
     # ---- the reconciliation ---------------------------------------------
     ('routability-keeps-its-one-sided-side-test', 'rou',
-     """    neighbors = [(g.ref, _geom[g.ref].rect) for g in _graded
-                 if g.ref != ref and (own_sides & g.sides)
-                 and g.ref not in _containers and g.ref in _geom]""",
-     """    neighbors = [(g.ref, _geom[g.ref].rect) for g in _graded
-                 if g.ref != ref and (footprint_side(fp) in g.sides)
-                 and g.ref not in _containers and g.ref in _geom]""",
+     """        shared = own_sides & g.sides""",
+     """        shared = (g.sides if footprint_side(fp) in g.sides
+                  else frozenset())""",
      (T835,), 'KILLED'),
 
     ('routability-goes-back-to-double-charging', 'rou',
@@ -240,15 +243,16 @@ ROWS = [
     # going back to billing routing for assembly margin: the deficit GROWS,
     # so every "is there a deficit" arm is satisfied harder.
     ('routability-goes-back-to-the-courtyard', 'rou',
-     """    neighbors = [(g.ref, _geom[g.ref].rect) for g in _graded""",
-     """    neighbors = [(g.ref, g.rect) for g in _graded""",
+     """        neighbors.append((g.ref, rect_on_sides(_geom[g.ref], shared)))""",
+     """        neighbors.append((g.ref, g.rect))""",
      (T835,), 'KILLED'),
 
     # #841, the other direction. `escape` charged the bbox of pad CENTRES, so
     # this is the exact code that shipped before -- and the per-board table is
     # what has to catch it.
     ('escape-neighbour-goes-back-to-pad-centres', 'esc',
-     """        obstacles.append((other, g.rect if g is not None else _part_rect(ofp)))""",
+     """        obstacles.append((other, _rect_on_sides(g, shared)
+                          if g is not None else _part_rect(ofp)))""",
      """        obstacles.append((other, _part_rect(ofp)))""",
      (T835,), 'KILLED'),
 
@@ -258,7 +262,7 @@ ROWS = [
     # every deficit number goes green DOWNWARD, which is why the demand arm
     # exists to kill it.
     ('escape-face-assignment-forgets-the-pad-edge', 'esc',
-     """        box = None if own is None else _pad_box(own, pad)""",
+     """        box = None if geom is None else _pad_box(geom, pad)""",
      """        box = None""",
      (T835,), 'KILLED'),
 
@@ -308,8 +312,8 @@ ROWS = [
      (T841,), 'KILLED'),
 
     ('routability-stops-exempting-containers', 'rou',
-     """                 and g.ref not in _containers and g.ref in _geom]""",
-     """                 and g.ref not in () and g.ref in _geom]""",
+     """        if g.ref == ref or g.ref in _containers or g.ref not in _geom:""",
+     """        if g.ref == ref or g.ref in () or g.ref not in _geom:""",
      (T835,),
      # Expected SURVIVED on the reasoning that only `escape` is asserted on;
      # measured KILLED, because `test_face_lane_ledger_side_test_is_symmetric`

--- a/tests/mutate_837.py
+++ b/tests/mutate_837.py
@@ -390,9 +390,15 @@ def main(argv=None):
     rows = [r for r in ROWS if not a.row or r[0] in set(a.row)]
     # RAW BYTES for the restore, decoded text for the match (#877). Every write
     # below lacked `newline=''`, so on Windows a single run rewrote all five
-    # targets in CRLF and left them permanently "modified" -- which then
-    # tripped THIS battery's own dirty-tree refusal on the next run.
-    # `.gitattributes` pins `*.py text eol=lf`, so that was a real corruption.
+    # targets in CRLF. `.gitattributes` pins `*.py text eol=lf`, so that is a
+    # real corruption of the working tree, and `git status --porcelain` shows
+    # all five as modified afterwards.
+    #
+    # It does NOT trip this battery's own refusal, which is `git diff --quiet`
+    # (:267): that applies the `text eol=lf` clean filter and reports a pure
+    # CRLF rewrite as CLEAN. So the damage was silent to the one guard that
+    # might have caught it -- worse than the first draft of this comment
+    # claimed, not better.
     raws = {k: io.open(v, 'rb').read() for k, v in TARGETS.items()}
     originals = {k: v.decode('utf-8').replace('\r\n', '\n')
                  for k, v in raws.items()}
@@ -400,9 +406,18 @@ def main(argv=None):
     try:
         for name, target, old, new, tests, expect in rows:
             src = originals[target]
-            # The count, checked BEFORE the write. This battery had none: its
-            # only protection was the pre-flight, so a stale anchor here was
-            # the silent false KILLED #877 describes rather than a BROKEN.
+            # The count, checked BEFORE the write. This battery had none --
+            # every other one counts here -- so its ONLY protection was the
+            # pre-flight at the top of main(). Belt and braces, not a live
+            # bug: with the pre-flight in place this branch is unreachable.
+            #
+            # What a stale anchor here would produce is SURVIVED, not KILLED:
+            # `replace` of an absent needle is a no-op, the witnesses pass, and
+            # `_run` reports not-killed. Of the 26 rows, 24 expect KILLED and
+            # would print `BAD SURVIVED` and exit 1; only the 2 that expect
+            # SURVIVED would pass silently. #877's title says such a row
+            # "reports KILLED", and that direction is wrong -- `mutate_702`'s
+            # own docstring has it right.
             n = src.count(old)
             if n != 1:
                 print(f"  BROKEN    {name}  (anchor matched {n} times)")

--- a/tests/mutate_837.py
+++ b/tests/mutate_837.py
@@ -257,6 +257,12 @@ ROWS = [
      (CEN,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths), cwd=_ROOT)
@@ -382,17 +388,31 @@ def main(argv=None):
     print(f"baseline: {why}")
 
     rows = [r for r in ROWS if not a.row or r[0] in set(a.row)]
-    originals = {k: io.open(v, encoding='utf-8').read()
-                 for k, v in TARGETS.items()}
+    # RAW BYTES for the restore, decoded text for the match (#877). Every write
+    # below lacked `newline=''`, so on Windows a single run rewrote all five
+    # targets in CRLF and left them permanently "modified" -- which then
+    # tripped THIS battery's own dirty-tree refusal on the next run.
+    # `.gitattributes` pins `*.py text eol=lf`, so that was a real corruption.
+    raws = {k: io.open(v, 'rb').read() for k, v in TARGETS.items()}
+    originals = {k: v.decode('utf-8').replace('\r\n', '\n')
+                 for k, v in raws.items()}
     wrong = broken = 0
     try:
         for name, target, old, new, tests, expect in rows:
             src = originals[target]
+            # The count, checked BEFORE the write. This battery had none: its
+            # only protection was the pre-flight, so a stale anchor here was
+            # the silent false KILLED #877 describes rather than a BROKEN.
+            n = src.count(old)
+            if n != 1:
+                print(f"  BROKEN    {name}  (anchor matched {n} times)")
+                broken += 1
+                continue
             _drop_pyc()
-            io.open(TARGETS[target], 'w', encoding='utf-8').write(
+            io.open(TARGETS[target], 'w', encoding='utf-8', newline='').write(
                 src.replace(old, new, 1))
             killed, why = _run(tests)
-            io.open(TARGETS[target], 'w', encoding='utf-8').write(src)
+            io.open(TARGETS[target], 'wb').write(raws[target])
             _drop_pyc()
             got = 'KILLED' if killed else 'SURVIVED'
             mark = 'ok ' if got == expect else 'BAD'
@@ -401,7 +421,7 @@ def main(argv=None):
             print(f"  {mark} {got:9} {name}  ({why})")
     finally:
         for k, v in TARGETS.items():
-            io.open(v, 'w', encoding='utf-8').write(originals[k])
+            io.open(v, 'wb').write(raws[k])   # byte-exact, from what was read
         _drop_pyc()
 
     killed = sum(1 for r in rows if r[5] == 'KILLED')

--- a/tests/mutate_846.py
+++ b/tests/mutate_846.py
@@ -207,6 +207,12 @@ ROWS = [
      (T652,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _head():
     p = subprocess.run(['git', 'rev-parse', 'HEAD'], capture_output=True,

--- a/tests/mutate_847.py
+++ b/tests/mutate_847.py
@@ -266,6 +266,12 @@ ROWS = [
      (T847,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     out = subprocess.run(['git', 'status', '--porcelain', '--'] + list(paths),

--- a/tests/mutate_849.py
+++ b/tests/mutate_849.py
@@ -147,6 +147,12 @@ ROWS = [
      (T_849,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 #: `run_all.py`'s self-skip code. A test that exits 77 asserted NOTHING, so
 #: reading it as a kill is exactly the "most flattering possible bug" this

--- a/tests/mutate_850_848.py
+++ b/tests/mutate_850_848.py
@@ -331,6 +331,12 @@ ROWS = [
      (T848,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     out = subprocess.run(['git', 'status', '--porcelain', '--'] + list(paths),

--- a/tests/mutation_anchors.py
+++ b/tests/mutation_anchors.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""Do the mutation batteries' anchors still match the code they quote? (#877)
+
+A mutation row is applied with `src.replace(old, new, 1)`. When `old` no longer
+occurs in the target the row mutates NOTHING, and whatever the runner prints
+next is about a tree it never changed. Every battery here does catch that --
+each counts the anchor and reports BROKEN rather than a kill -- but it catches
+it *during* the run, after the witnesses have been paid for. #877's own words:
+
+    a stale anchor reports BROKEN 50 minutes into a run rather than in one
+    second before it -- mutate_847.py:67-73
+
+This module is the one second. It answers a single question -- *does this
+anchor match its target exactly once?* -- for two callers that must not drift
+apart:
+
+  * each `tests/mutate_*.py`, from `--verify-anchors`, over the rows it already
+    holds in memory (`verify`); and
+  * `tests/test_718_static_test_hygiene.py`, over every battery in the tree,
+    without importing any of them (`resolve_static` -> `verify`).
+
+**Static resolution is not an optimisation, it is the only safe way.**
+`mutate_713_census.py`, `mutate_713_phase1.py` and `mutate_760.py` run their
+runner at module scope, so IMPORTING one mutates the tree. #877 was filed after
+a census did exactly that and rewrote 13 engine files under `py_router/` and
+`py_placer/` -- and reported inflated numbers measured against its own damage.
+Nothing here imports a battery; everything is `ast`.
+
+Two distinctions this draws that a plain `count(old) != 1` does not:
+
+  * **STALE (0 matches) is not AMBIGUOUS (>1).** A stale anchor guards nothing.
+    A 2-match anchor still mutates -- whichever site comes first -- so it is a
+    row whose subject is decided by file order rather than by the row. Both
+    deserve fixing; they are not the same finding, and #877 reported three
+    ambiguous rows in `mutate_703.py` as stale.
+
+  * **Targets are read with UNIVERSAL NEWLINES.** `mutate_711.py:296-321`
+    records why: matching a multi-line anchor against a raw byte decode
+    "silently found NOTHING in three rows".
+
+    python3 tests/mutation_anchors.py               # census over every battery
+    python3 tests/mutation_anchors.py --verbose     # every anchor, one a line
+    python3 tests/mutation_anchors.py --battery mutate_702.py
+"""
+import argparse
+import ast
+import os
+import sys
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(TESTS_DIR)
+
+#: `_fold` could not decide. Distinct from None, which several row layouts use
+#: as a MEANINGFUL value (`old is None` means "create this file", not "unknown").
+UNKNOWN = object()
+
+STALE = 'STALE'
+AMBIGUOUS = 'AMBIGUOUS'
+MISSING_TARGET = 'MISSING_TARGET'
+
+
+class Anchor(object):
+    """One `old` string, and the file it is supposed to occur in exactly once.
+
+    `nth` is `mutate_760.py`'s optional occurrence selector, which replaces the
+    Nth match instead of the first, so its requirement is "at least nth+1
+    matches" rather than "exactly one".
+
+    `old is None` marks `mutate_713_census.py`'s create-this-file row, which
+    carries no anchor at all and must not be graded as one.
+    """
+
+    __slots__ = ('battery', 'row', 'target', 'old', 'nth', 'edit')
+
+    def __init__(self, battery, row, target, old, nth=None, edit=0):
+        self.battery = battery
+        self.row = row
+        self.target = target
+        self.old = old
+        self.nth = nth
+        self.edit = edit
+
+    @property
+    def label(self):
+        return self.row if self.edit == 0 else '%s[%d]' % (self.row, self.edit)
+
+    def __repr__(self):                                    # pragma: no cover
+        return '<Anchor %s %s -> %s>' % (
+            self.battery, self.label, os.path.basename(self.target))
+
+
+class Problem(object):
+    __slots__ = ('anchor', 'kind', 'count', 'detail')
+
+    def __init__(self, anchor, kind, count, detail=''):
+        self.anchor = anchor
+        self.kind = kind
+        self.count = count
+        self.detail = detail
+
+    def __str__(self):
+        return '%s: %s %s -- matched %d time(s) in %s%s' % (
+            self.anchor.battery, self.kind, self.anchor.label, self.count,
+            os.path.relpath(self.anchor.target, ROOT).replace(os.sep, '/'),
+            ('  ' + self.detail) if self.detail else '')
+
+
+# --------------------------------------------------------------------------
+# constant folding
+# --------------------------------------------------------------------------
+
+def _dotted(node):
+    """'os.path.join' for the Attribute/Name chain in a Call's func, else ''."""
+    parts = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if not isinstance(node, ast.Name):
+        return ''
+    parts.append(node.id)
+    return '.'.join(reversed(parts))
+
+
+def _fold(node, env):
+    """The value of `node`, or UNKNOWN.
+
+    Deliberately narrow: string literals, implicit and explicit concatenation,
+    module-level names, and the `os.path` calls every battery builds its target
+    constants with. An f-string is UNKNOWN rather than guessed -- an anchor
+    whose text this cannot reproduce EXACTLY must be refused, not approximated,
+    or the census grades a string the battery will never apply.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        return env.get(node.id, UNKNOWN)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _fold(node.left, env)
+        right = _fold(node.right, env)
+        if isinstance(left, str) and isinstance(right, str):
+            return left + right
+        return UNKNOWN
+    if isinstance(node, ast.Call):
+        fn = _dotted(node.func)
+        if fn not in ('os.path.join', 'os.path.dirname', 'os.path.abspath'):
+            return UNKNOWN
+        args = [_fold(a, env) for a in node.args]
+        if not args or not all(isinstance(a, str) for a in args):
+            return UNKNOWN
+        if fn == 'os.path.join':
+            return os.path.join(*args)
+        if fn == 'os.path.dirname':
+            return os.path.dirname(args[0])
+        return os.path.abspath(args[0])
+    if isinstance(node, (ast.Tuple, ast.List)):
+        return [_fold(e, env) for e in node.elts]
+    if isinstance(node, ast.Dict):
+        out = {}
+        for k, v in zip(node.keys, node.values):
+            key = _fold(k, env)
+            if isinstance(key, str):
+                out[key] = _fold(v, env)
+        return out
+    return UNKNOWN
+
+
+def _module_env(tree, path):
+    """Module-level names a battery's tables are built from.
+
+    Walks top-level assignments in order, so a constant may be defined in terms
+    of an earlier one -- which is how every battery spells its paths
+    (`_ROOT = os.path.dirname(_TESTS)`).
+    """
+    env = {'__file__': os.path.abspath(path)}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        value = _fold(node.value, env)
+        for tgt in node.targets:
+            if isinstance(tgt, ast.Name):
+                env[tgt.id] = value
+    return env
+
+
+# --------------------------------------------------------------------------
+# table discovery
+# --------------------------------------------------------------------------
+
+def _is_row_table(value):
+    """A list of tuples whose first element is a string: a mutation table.
+
+    Every battery's table is one, and nothing else at module scope in these
+    files is. Empty lists are rejected -- a table that resolved to nothing is
+    a parse failure wearing a clean result.
+    """
+    if not isinstance(value, list) or not value:
+        return False
+    for row in value:
+        if not isinstance(row, list) or len(row) < 3:
+            return False
+        if not isinstance(row[0], str):
+            return False
+    return True
+
+
+def _tables(tree, env):
+    """[(variable name, rows)] for every module-level mutation table."""
+    out = []
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for tgt in node.targets:
+            if not isinstance(tgt, ast.Name):
+                continue
+            value = env.get(tgt.id, UNKNOWN)
+            if _is_row_table(value):
+                out.append((tgt.id, value))
+    return out
+
+
+def _battery_dict_targets(tree, env):
+    """`mutate_746.py`'s `BATTERIES = {'engine': (ENGINE, TEST, ENGINE_ROWS)}`.
+
+    Maps a table's VARIABLE NAME to the source path in the same tuple. Read off
+    the AST rather than the folded value because the association is by name --
+    two tables of equal content would be indistinguishable once folded.
+    """
+    out = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value,
+                                                              ast.Dict):
+            continue
+        for val in node.value.values:
+            if not isinstance(val, (ast.Tuple, ast.List)):
+                continue
+            names = [e.id for e in val.elts if isinstance(e, ast.Name)]
+            paths = [env.get(n) for n in names]
+            table = None
+            src = None
+            for name, resolved in zip(names, paths):
+                if _is_row_table(resolved):
+                    table = name
+                elif isinstance(resolved, str) and src is None:
+                    src = resolved
+            if table and src:
+                out[table] = src
+    return out
+
+
+def _abs_target(value, env, must_exist=True):
+    """An absolute path from a row's target slot, else None.
+
+    Handles both spellings: an already-absolute constant (`mutate_760.py`) and
+    a repo-relative string (`mutate_713_*.py`).
+
+    `must_exist` is False for a CREATE row, whose whole point is a file that is
+    not there yet (`mutate_713_census.py`'s "a NEW file with a clock,
+    registered nowhere"). Requiring the file unconditionally made that battery
+    report UNRESOLVED -- a resolver refusing the one row that is behaving
+    exactly as designed.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    path = value if os.path.isabs(value) else os.path.join(ROOT, value)
+    if must_exist and not os.path.isfile(path):
+        return None
+    if not must_exist and not value.endswith('.py'):
+        return None
+    return path
+
+
+def _edits(old, new):
+    """[(old, ...)] for a row, expanding the list-valued multi-edit form.
+
+    14 batteries let `old` be a list of `(old, new)` pairs with `new` None
+    (`mutate_554.py:78-83`). Each pair is its own anchor: one of them going
+    stale breaks the row exactly as a scalar anchor would, and #877's census
+    counted the ROW rather than the pair.
+    """
+    if isinstance(old, list):
+        out = []
+        for pair in old:
+            if isinstance(pair, list) and pair and isinstance(pair[0], str):
+                out.append(pair[0])
+            else:
+                out.append(UNKNOWN)
+        return out
+    return [old]
+
+
+def resolve_static(path):
+    """(anchors, unresolved_reason) for one `tests/mutate_*.py`, without import.
+
+    `unresolved_reason` is a string when the file could not be read as a
+    battery at all; the caller must treat that as a failure, never as "no
+    anchors". A resolver that answers cleanly for a file it did not understand
+    is the same bug this module exists to catch.
+    """
+    battery = os.path.basename(path)
+    try:
+        with open(path, encoding='utf-8') as fh:
+            src = fh.read()
+    except OSError as exc:                                 # pragma: no cover
+        return [], 'cannot read: %s' % exc
+    try:
+        tree = ast.parse(src, battery)
+    except SyntaxError as exc:                             # pragma: no cover
+        return [], 'cannot parse: %s' % exc
+
+    env = _module_env(tree, path)
+    tables = _tables(tree, env)
+    if not tables:
+        return [], 'no mutation table found'
+
+    targets_map = env.get('TARGETS')
+    if not isinstance(targets_map, dict):
+        targets_map = {}
+    by_table = _battery_dict_targets(tree, env)
+
+    #: The single-target fallback: a battery with one engine file names it
+    #: ENGINE (`mutate_750.py:46`). Only consulted when the row itself carries
+    #: no target, so it cannot mask a per-row path.
+    lone = _abs_target(env.get('ENGINE'), env)
+
+    anchors = []
+    for table_name, rows in tables:
+        table_target = by_table.get(table_name) or lone
+        for row in rows:
+            name = row[0]
+            slot = row[1]
+
+            # Layout A: row[1] keys the TARGETS dict.
+            if isinstance(slot, str) and slot in targets_map:
+                target = _abs_target(targets_map[slot], env)
+                old, new = row[2], row[3] if len(row) > 3 else None
+                nth = None
+            else:
+                # A CREATE row (`old is None`) names a file that does not exist
+                # yet; every other row's target must be a real file, or a typo
+                # would silently resolve and grade as stale.
+                creates = len(row) > 2 and row[2] is None
+                explicit = _abs_target(slot, env, must_exist=not creates)
+                if explicit is not None:
+                    # Layouts D and E: row[1] IS the path.
+                    target = explicit
+                    old = row[2]
+                    new = row[3] if len(row) > 3 else None
+                    nth = row[4] if len(row) > 4 and isinstance(
+                        row[4], int) and not isinstance(row[4], bool) else None
+                else:
+                    # Layouts B and C: no per-row target; row[1] is the anchor.
+                    target = table_target
+                    old, new = slot, row[2]
+                    nth = None
+
+            if target is None:
+                return [], ('row %r in %s names no resolvable target'
+                            % (name, table_name))
+
+            for i, one in enumerate(_edits(old, new)):
+                if one is UNKNOWN:
+                    return [], ('row %r in %s has an anchor this cannot '
+                                'reproduce exactly' % (name, table_name))
+                if one is not None and not isinstance(one, str):
+                    return [], ('row %r in %s has a non-string anchor'
+                                % (name, table_name))
+                anchors.append(Anchor(battery, name, target, one, nth,
+                                      0 if not isinstance(old, list) else i))
+    return anchors, None
+
+
+# --------------------------------------------------------------------------
+# verification
+# --------------------------------------------------------------------------
+
+def _read_target(path, cache):
+    """The target's text with UNIVERSAL NEWLINES, which is what the batteries
+    match against (`mutate_711.py:296-305`). Reading it any other way makes
+    every multi-line anchor stale on a CRLF checkout."""
+    if path not in cache:
+        with open(path, encoding='utf-8', errors='replace') as fh:
+            cache[path] = fh.read()
+    return cache[path]
+
+
+def verify(anchors, repo_wide=False):
+    """Every problem among `anchors`, worst first within each battery.
+
+    Returns a list, never raises on a bad anchor: the caller decides whether a
+    problem is fatal, and a run that stops at the first one hides the rest.
+    """
+    problems = []
+    cache = {}
+    for a in anchors:
+        if a.old is None:
+            # `mutate_713_census.py`'s create-this-file row. It carries no
+            # anchor; grading it as one invents a finding.
+            continue
+        if not os.path.isfile(a.target):
+            problems.append(Problem(a, MISSING_TARGET, 0,
+                                    'target does not exist'))
+            continue
+        n = _read_target(a.target, cache).count(a.old)
+        if a.nth is not None:
+            if n < a.nth + 1:
+                problems.append(Problem(
+                    a, STALE, n,
+                    'needs occurrence %d, so at least %d match(es)'
+                    % (a.nth, a.nth + 1)))
+            continue
+        if n == 0:
+            problems.append(Problem(a, STALE, 0,
+                                    'the row mutates nothing'))
+        elif n > 1:
+            problems.append(Problem(
+                a, AMBIGUOUS, n,
+                'replace(..., 1) takes whichever comes first in the file'))
+    if repo_wide:
+        problems.extend(_prose_problems(anchors))
+    return problems
+
+
+def _prose_problems(anchors):
+    """Anchors that also occur in another tracked file.
+
+    `mutate_726.py:248-280`'s check, kept: a comment quoting code has satisfied
+    a grep-shaped test in this repo before, and a battery that mutates a
+    comment reports SURVIVED for a mutation that changed nothing executable.
+    """
+    import subprocess
+    out = subprocess.run(['git', 'ls-files', '*.py', '*.md'], cwd=ROOT,
+                         capture_output=True, text=True).stdout.split()
+    texts = {}
+    for rel in out:
+        path = os.path.join(ROOT, rel)
+        try:
+            with open(path, encoding='utf-8', errors='replace') as fh:
+                texts[os.path.abspath(path)] = fh.read()
+        except OSError:                                    # pragma: no cover
+            continue
+    problems = []
+    for a in anchors:
+        if a.old is None:
+            continue
+        battery_path = os.path.abspath(os.path.join(TESTS_DIR, a.battery))
+        others = [p for p, text in texts.items()
+                  if p not in (os.path.abspath(a.target), battery_path)
+                  and a.old in text]
+        if others:
+            problems.append(Problem(
+                a, 'PROSE', len(others),
+                'also in ' + ', '.join(
+                    os.path.relpath(p, ROOT).replace(os.sep, '/')
+                    for p in sorted(others)[:3])))
+    return problems
+
+
+def batteries():
+    """Every `tests/mutate_*.py`, sorted. The corpus both callers run over."""
+    names = sorted(n for n in os.listdir(TESTS_DIR)
+                   if n.startswith('mutate_') and n.endswith('.py'))
+    return [os.path.join(TESTS_DIR, n) for n in names]
+
+
+def census():
+    """[(battery, anchors, problems, unresolved_reason)] over the whole tree."""
+    out = []
+    for path in batteries():
+        anchors, reason = resolve_static(path)
+        problems = [] if reason else verify(anchors)
+        out.append((os.path.basename(path), anchors, problems, reason))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--battery', help='census one file, by basename')
+    ap.add_argument('--verbose', action='store_true',
+                    help='print every anchor, not only the problems')
+    ap.add_argument('--repo-wide', action='store_true',
+                    help="also report anchors that occur in another tracked "
+                         "file, which may be prose rather than code")
+    args = ap.parse_args()
+
+    rows = census()
+    if args.battery:
+        rows = [r for r in rows if r[0] == args.battery]
+        if not rows:
+            print('no battery named %r' % args.battery, file=sys.stderr)
+            return 2
+
+    total = stale = ambiguous = missing = unresolved = 0
+    print('%-26s %6s %6s %6s %6s' % ('battery', 'rows', 'STALE', 'AMBIG',
+                                     'UNRES'))
+    for name, anchors, problems, reason in rows:
+        if args.repo_wide and not reason:
+            problems = verify(anchors, repo_wide=True)
+        n_stale = sum(1 for p in problems if p.kind == STALE)
+        n_amb = sum(1 for p in problems if p.kind == AMBIGUOUS)
+        n_missing = sum(1 for p in problems if p.kind == MISSING_TARGET)
+        total += len(anchors)
+        stale += n_stale
+        ambiguous += n_amb
+        missing += n_missing
+        if reason:
+            unresolved += 1
+        print('%-26s %6s %6s %6s %6s' % (
+            name, len(anchors) if not reason else '-', n_stale, n_amb,
+            'YES' if reason else ''))
+        if reason:
+            print('    UNRESOLVED: %s' % reason)
+        for p in problems:
+            print('    %s' % p)
+        if args.verbose and not reason:
+            for a in anchors:
+                print('      %-52s %s' % (
+                    a.label,
+                    os.path.relpath(a.target, ROOT).replace(os.sep, '/')))
+
+    print('\n%d battery(s), %d anchor(s): %d stale, %d ambiguous, %d missing '
+          'target, %d unresolved' % (len(rows), total, stale, ambiguous,
+                                     missing, unresolved))
+    return 1 if (stale or missing or unresolved) else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutation_anchors.py
+++ b/tests/mutation_anchors.py
@@ -566,6 +566,47 @@ def _prose_problems(anchors):
     return problems
 
 
+def preflight(path, repo_wide=False):
+    """Refuse to mutate anything until every anchor in `path` matches once.
+
+    ONE line at the top of a battery, right after its table:
+
+        from mutation_anchors import preflight
+        preflight(__file__)
+
+    and it also IS the battery's `--verify-anchors`: the flag is handled here
+    and stripped from `sys.argv` before the battery's own argparse sees it, so
+    no battery needs a flag, a help string or a branch of its own. That matters
+    because the alternative was a 38th hand-rolled copy in each of 37 files,
+    each free to drift -- which is how only 5 of them had the check at all.
+
+    Exits 2 on a bad anchor, matching the batteries' existing refusal code, so
+    a stale anchor stops the run in ONE SECOND rather than reporting BROKEN
+    after the witnesses have been paid for. With `--verify-anchors` it reports
+    and exits either way, mutating nothing.
+    """
+    only = '--verify-anchors' in sys.argv
+    if only:
+        sys.argv = [a for a in sys.argv if a != '--verify-anchors']
+    name = os.path.basename(path)
+    anchors, reason = resolve_static(path)
+    if reason:
+        print('%s: ANCHORS UNRESOLVED -- %s' % (name, reason), file=sys.stderr)
+        raise SystemExit(2)
+    problems = verify(anchors, repo_wide=repo_wide)
+    for p in problems:
+        print('  %s' % p, file=sys.stderr)
+    if problems:
+        print('%s: %d of %d anchor(s) do not match exactly once. Re-anchor '
+              'them before running -- a stale row mutates nothing and every '
+              'gate it names passes for free (#877).'
+              % (name, len(problems), len(anchors)), file=sys.stderr)
+        raise SystemExit(2)
+    if only:
+        print('%s: all %d anchor(s) match exactly once' % (name, len(anchors)))
+        raise SystemExit(0)
+
+
 def batteries():
     """Every `tests/mutate_*.py`, sorted. The corpus both callers run over."""
     names = sorted(n for n in os.listdir(TESTS_DIR)

--- a/tests/mutation_anchors.py
+++ b/tests/mutation_anchors.py
@@ -60,6 +60,34 @@ Distinctions a plain `count(old) != 1` does not draw:
     python3 tests/mutation_anchors.py               # census over every battery
     python3 tests/mutation_anchors.py --verbose     # every anchor, one a line
     python3 tests/mutation_anchors.py --battery mutate_702.py
+
+MEASURED at 0aff32c0, before the re-anchoring pass: 37 batteries, 831 anchors,
+**29 stale, 3 ambiguous, 0 unresolved**, across 9 batteries. After it: 0, 0, 0.
+
+An anchor matching exactly once does NOT establish that the row still means
+what its name says -- this branch's own `mutate_702` keepout row proved that,
+matching cleanly while mutating nothing. So every battery whose rows changed
+was RUN, not merely re-censused:
+
+    battery            rows  killed  survived  broken  disagreeing
+    mutate_702           22      19         3       0            1
+    mutate_703           29      27         2       0            0
+    mutate_554           30      26         4       0            0
+    mutate_730           28      25         3       0            0
+    mutate_747           22      20         2       0            0
+    mutate_768           31      31         0       0            0
+    mutate_799           22      18         4       0            0
+    mutate_829           23      22         1       0            0
+    mutate_834_835       22      18         4       0            0
+    -----------------------------------------------------------------
+    total               229     206        23       0            1
+
+Every survivor is a declared, expected one. The single disagreement is
+`mutate_702`'s `the-crossed-claim-check-never-fires`, which is byte-identical
+to upstream/main and predates this work -- disclosed at that row rather than
+re-graded. Each run also left the tree byte-identical, checked with BOTH `git
+status --porcelain` and `git diff --stat`, because a pure CRLF flip shows in
+the first and not the second.
 """
 import argparse
 import ast

--- a/tests/mutation_anchors.py
+++ b/tests/mutation_anchors.py
@@ -4,39 +4,55 @@
 A mutation row is applied with `src.replace(old, new, 1)`. When `old` no longer
 occurs in the target the row mutates NOTHING, and whatever the runner prints
 next is about a tree it never changed. Every battery here does catch that --
-each counts the anchor and reports BROKEN rather than a kill -- but it catches
-it *during* the run, after the witnesses have been paid for. #877's own words:
+each counts the anchor and reports BROKEN, and every one exits non-zero -- but
+it catches it DURING the run, after the witnesses have been paid for. #877's
+own citation:
 
     a stale anchor reports BROKEN 50 minutes into a run rather than in one
     second before it -- mutate_847.py:67-73
 
 This module is the one second. It answers a single question -- *does this
-anchor match its target exactly once?* -- for two callers that must not drift
-apart:
+anchor match its target exactly once?* -- and it is meant to be the ONLY
+implementation of that question in the tree, for two callers:
 
   * each `tests/mutate_*.py`, from `--verify-anchors`, over the rows it already
     holds in memory (`verify`); and
-  * `tests/test_718_static_test_hygiene.py`, over every battery in the tree,
-    without importing any of them (`resolve_static` -> `verify`).
+  * `tests/test_718_static_test_hygiene.py`, over every battery, without
+    importing any of them (`resolve_static` -> `verify`).
+
+The second caller exists today; the batteries are converted in the same PR.
+Until that lands, the five hand-rolled `--verify-anchors` implementations
+(`mutate_714`, `726`, `837`, `847`, `850_848`) are still the shipped state, and
+`mutate_726.py:248-280`'s is STRICTER than this module's default -- its prose
+check is always on, where here it needs `--repo-wide`.
 
 **Static resolution is not an optimisation, it is the only safe way.**
 `mutate_713_census.py`, `mutate_713_phase1.py` and `mutate_760.py` run their
 runner at module scope, so IMPORTING one mutates the tree. #877 was filed after
-a census did exactly that and rewrote 13 engine files under `py_router/` and
-`py_placer/` -- and reported inflated numbers measured against its own damage.
-Nothing here imports a battery; everything is `ast`.
+a census did exactly that, rewrote 13 engine files under `py_router/` and
+`py_placer/`, and reported numbers inflated by its own damage. Nothing here
+imports a battery; everything is `ast`.
 
-Two distinctions this draws that a plain `count(old) != 1` does not:
+Distinctions a plain `count(old) != 1` does not draw:
 
   * **STALE (0 matches) is not AMBIGUOUS (>1).** A stale anchor guards nothing.
-    A 2-match anchor still mutates -- whichever site comes first -- so it is a
-    row whose subject is decided by file order rather than by the row. Both
-    deserve fixing; they are not the same finding, and #877 reported three
-    ambiguous rows in `mutate_703.py` as stale.
+    A 2-match anchor still mutates -- whichever site comes first -- so the row's
+    subject is decided by file order rather than by the row. Both fail; they are
+    not the same finding, and #877 reported `mutate_703.py`'s three ambiguous
+    rows as stale.
 
-  * **Targets are read with UNIVERSAL NEWLINES.** `mutate_711.py:296-321`
-    records why: matching a multi-line anchor against a raw byte decode
-    "silently found NOTHING in three rows".
+  * **NEWLINE_SENSITIVE**: the anchor's verdict changes with how the target is
+    read. This module reads universal-newline, and so does `mutate_711.py`
+    (`:296-305`), whose comment records that matching a raw byte decode
+    "silently found NOTHING in three rows". But 18 batteries read their target
+    with `newline=''`, so on a CRLF checkout the census and the battery would
+    disagree. Dormant on this tree -- `.gitattributes` pins `*.py text eol=lf`
+    -- and free to keep.
+
+  * A **create row** (`old is None`, `mutate_713_census.py`'s "a NEW file with
+    a clock, registered nowhere") carries no anchor, but it is not unchecked:
+    the battery reports BROKEN when the file it means to create already exists
+    (`mutate_713_census.py:129-132`), and that is what is graded here.
 
     python3 tests/mutation_anchors.py               # census over every battery
     python3 tests/mutation_anchors.py --verbose     # every anchor, one a line
@@ -45,6 +61,7 @@ Two distinctions this draws that a plain `count(old) != 1` does not:
 import argparse
 import ast
 import os
+import re
 import sys
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -57,32 +74,48 @@ UNKNOWN = object()
 STALE = 'STALE'
 AMBIGUOUS = 'AMBIGUOUS'
 MISSING_TARGET = 'MISSING_TARGET'
+NEWLINE_SENSITIVE = 'NEWLINE_SENSITIVE'
+CREATE_EXISTS = 'CREATE_EXISTS'
+PROSE = 'PROSE'
+
+#: Names a battery gives a mutation table. A module-level binding matching this
+#: MUST resolve to a table or the whole battery is reported UNRESOLVED -- see
+#: `_tables`, and the defect that motivated it.
+_TABLE_NAME_RE = re.compile(r'^(ROWS|[A-Z_]*_ROWS)$')
 
 
 class Anchor(object):
-    """One `old` string, and the file it is supposed to occur in exactly once.
+    """One `old` string, and the file it must occur in exactly once.
 
-    `nth` is `mutate_760.py`'s optional occurrence selector, which replaces the
-    Nth match instead of the first, so its requirement is "at least nth+1
-    matches" rather than "exactly one".
+    `nth` is the optional occurrence selector `mutate_760.py:65-79` implements
+    (`row[4]`), which replaces the Nth match instead of the first -- so its
+    requirement is "at least nth+1 matches", not "exactly one". No row uses it
+    today; the form is supported because the battery accepts it.
 
-    `old is None` marks `mutate_713_census.py`'s create-this-file row, which
-    carries no anchor at all and must not be graded as one.
+    `old is None` marks a create-this-file row, which has no anchor.
     """
 
-    __slots__ = ('battery', 'row', 'target', 'old', 'nth', 'edit')
+    __slots__ = ('battery', 'row', 'target', 'old', 'nth', 'edit', 'multi')
 
-    def __init__(self, battery, row, target, old, nth=None, edit=0):
+    def __init__(self, battery, row, target, old, nth=None, edit=0,
+                 multi=False):
         self.battery = battery
         self.row = row
         self.target = target
         self.old = old
         self.nth = nth
         self.edit = edit
+        self.multi = multi
 
     @property
     def label(self):
-        return self.row if self.edit == 0 else '%s[%d]' % (self.row, self.edit)
+        """`name[i]` for every edit of a multi-edit row, INCLUDING edit 0.
+
+        Suppressing `[0]` made a stale first pair print as a bare row name,
+        indistinguishable from a stale scalar row -- so the reader could not
+        tell which of the row's edits to fix.
+        """
+        return '%s[%d]' % (self.row, self.edit) if self.multi else self.row
 
     def __repr__(self):                                    # pragma: no cover
         return '<Anchor %s %s -> %s>' % (
@@ -99,10 +132,17 @@ class Problem(object):
         self.detail = detail
 
     def __str__(self):
-        return '%s: %s %s -- matched %d time(s) in %s%s' % (
-            self.anchor.battery, self.kind, self.anchor.label, self.count,
-            os.path.relpath(self.anchor.target, ROOT).replace(os.sep, '/'),
-            ('  ' + self.detail) if self.detail else '')
+        rel = os.path.relpath(self.anchor.target, ROOT).replace(os.sep, '/')
+        if self.kind in (PROSE, CREATE_EXISTS):
+            # `count` is not an occurrence count for these, and rendering it as
+            # one printed "matched 458 time(s) in <the wrong file>".
+            head = '%s: %s %s' % (self.anchor.battery, self.kind,
+                                  self.anchor.label)
+        else:
+            head = '%s: %s %s -- matched %d time(s) in %s' % (
+                self.anchor.battery, self.kind, self.anchor.label,
+                self.count, rel)
+        return head + (('  ' + self.detail) if self.detail else '')
 
 
 # --------------------------------------------------------------------------
@@ -164,21 +204,34 @@ def _fold(node, env):
     return UNKNOWN
 
 
+def _assignments(tree):
+    """(name, value_node) for each module-level binding, in source order.
+
+    `ast.AnnAssign` is included: `ROWS: List[Row] = [...]` binds exactly as
+    `ROWS = [...]` does, and skipping it made a whole table invisible while the
+    battery still reported clean.
+    """
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name):
+                    yield tgt.id, node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            if isinstance(node.target, ast.Name):
+                yield node.target.id, node.value
+
+
 def _module_env(tree, path):
     """Module-level names a battery's tables are built from.
 
-    Walks top-level assignments in order, so a constant may be defined in terms
-    of an earlier one -- which is how every battery spells its paths
-    (`_ROOT = os.path.dirname(_TESTS)`).
+    In source order, so a constant may be defined in terms of an earlier one --
+    which is how every battery spells its paths (`_ROOT =
+    os.path.dirname(_TESTS)`). A rebound name keeps its LAST value, as Python
+    would.
     """
     env = {'__file__': os.path.abspath(path)}
-    for node in tree.body:
-        if not isinstance(node, ast.Assign):
-            continue
-        value = _fold(node.value, env)
-        for tgt in node.targets:
-            if isinstance(tgt, ast.Name):
-                env[tgt.id] = value
+    for name, value_node in _assignments(tree):
+        env[name] = _fold(value_node, env)
     return env
 
 
@@ -187,11 +240,11 @@ def _module_env(tree, path):
 # --------------------------------------------------------------------------
 
 def _is_row_table(value):
-    """A list of tuples whose first element is a string: a mutation table.
+    """A non-empty list of tuples whose first element is a string.
 
-    Every battery's table is one, and nothing else at module scope in these
-    files is. Empty lists are rejected -- a table that resolved to nothing is
-    a parse failure wearing a clean result.
+    Every battery's table is one and nothing else at module scope is. Empty
+    lists are rejected: a table that resolved to nothing is a parse failure
+    wearing a clean result.
     """
     if not isinstance(value, list) or not value:
         return False
@@ -204,18 +257,36 @@ def _is_row_table(value):
 
 
 def _tables(tree, env):
-    """[(variable name, rows)] for every module-level mutation table."""
-    out = []
-    for node in tree.body:
-        if not isinstance(node, ast.Assign):
+    """([(name, rows)], reason) for the module-level mutation tables.
+
+    Two rules, and the second is the one that matters:
+
+    * a binding whose value IS a row table is a table; and
+    * a binding whose NAME declares one (`ROWS`, `*_ROWS`) and whose value is
+      not a row table makes the whole battery UNRESOLVED.
+
+    Without the second rule a table this cannot fold -- rows built by a helper
+    call, say -- simply vanished, and the battery still printed a clean line
+    for the tables that did resolve. A resolver that answers cleanly for a file
+    it did not understand is the bug this module exists to catch.
+
+    Names are collected ONCE each. Iterating assignment NODES counted a table
+    rebound at module scope twice over, silently doubling its anchors.
+    """
+    seen, out = set(), []
+    for name, _node in _assignments(tree):
+        if name in seen:
             continue
-        for tgt in node.targets:
-            if not isinstance(tgt, ast.Name):
-                continue
-            value = env.get(tgt.id, UNKNOWN)
-            if _is_row_table(value):
-                out.append((tgt.id, value))
-    return out
+        seen.add(name)
+        value = env.get(name, UNKNOWN)
+        if _is_row_table(value):
+            out.append((name, value))
+        elif _TABLE_NAME_RE.match(name):
+            return [], ('%s is named like a mutation table but did not '
+                        'resolve to one' % name)
+    if not out:
+        return [], 'no mutation table found'
+    return out, None
 
 
 def _battery_dict_targets(tree, env):
@@ -224,77 +295,105 @@ def _battery_dict_targets(tree, env):
     Maps a table's VARIABLE NAME to the source path in the same tuple. Read off
     the AST rather than the folded value because the association is by name --
     two tables of equal content would be indistinguishable once folded.
+
+    The path goes through `_abs_target` like every other. Returning `env`'s raw
+    value made a relative constant resolve against the PROCESS CWD, so the same
+    battery answered differently depending on where it was run from.
     """
     out = {}
-    for node in tree.body:
-        if not isinstance(node, ast.Assign) or not isinstance(node.value,
-                                                              ast.Dict):
+    for _name, node in _assignments(tree):
+        if not isinstance(node, ast.Dict):
             continue
-        for val in node.value.values:
+        for val in node.values:
             if not isinstance(val, (ast.Tuple, ast.List)):
                 continue
             names = [e.id for e in val.elts if isinstance(e, ast.Name)]
-            paths = [env.get(n) for n in names]
-            table = None
-            src = None
-            for name, resolved in zip(names, paths):
+            table = src = None
+            for elt_name in names:
+                resolved = env.get(elt_name)
                 if _is_row_table(resolved):
-                    table = name
-                elif isinstance(resolved, str) and src is None:
-                    src = resolved
+                    table = elt_name
+                elif src is None:
+                    src = _abs_target(resolved)
             if table and src:
                 out[table] = src
     return out
 
 
-def _abs_target(value, env, must_exist=True):
+def _abs_target(value, must_exist=True):
     """An absolute path from a row's target slot, else None.
 
     Handles both spellings: an already-absolute constant (`mutate_760.py`) and
-    a repo-relative string (`mutate_713_*.py`).
+    a repo-relative string (`mutate_713_*.py`). Relative paths resolve against
+    the REPO ROOT, never the process CWD.
 
     `must_exist` is False for a CREATE row, whose whole point is a file that is
-    not there yet (`mutate_713_census.py`'s "a NEW file with a clock,
-    registered nowhere"). Requiring the file unconditionally made that battery
-    report UNRESOLVED -- a resolver refusing the one row that is behaving
-    exactly as designed.
+    not there yet.
     """
     if not isinstance(value, str) or not value:
         return None
     path = value if os.path.isabs(value) else os.path.join(ROOT, value)
-    if must_exist and not os.path.isfile(path):
-        return None
-    if not must_exist and not value.endswith('.py'):
-        return None
-    return path
+    if must_exist:
+        return path if os.path.isfile(path) else None
+    return path if value.endswith('.py') else None
 
 
-def _edits(old, new):
-    """[(old, ...)] for a row, expanding the list-valued multi-edit form.
+def _edits(old):
+    """The `old` of each edit in a row, expanding the list-valued form.
 
     14 batteries let `old` be a list of `(old, new)` pairs with `new` None
-    (`mutate_554.py:78-83`). Each pair is its own anchor: one of them going
-    stale breaks the row exactly as a scalar anchor would, and #877's census
-    counted the ROW rather than the pair.
+    (`mutate_554.py:78-83`); `mutate_553.py:301-310` applies them as
+    `for o, nw in edits`, so element 0 of each pair is the anchor. Each pair is
+    its own anchor -- one going stale breaks the row exactly as a scalar anchor
+    would, and #877's census counted the ROW rather than the pair.
     """
     if isinstance(old, list):
-        out = []
-        for pair in old:
-            if isinstance(pair, list) and pair and isinstance(pair[0], str):
-                out.append(pair[0])
-            else:
-                out.append(UNKNOWN)
-        return out
-    return [old]
+        return [pair[0] if isinstance(pair, list) and pair else UNKNOWN
+                for pair in old], True
+    return [old], False
+
+
+def _layout(rows, targets_map, table_target, table_name):
+    """(layout, reason) for one table: 'key', 'path' or 'lone'.
+
+    Decided ONCE for the whole table, from ALL its rows, because a table is
+    homogeneous and a per-row guess is not safe. Trying `_abs_target(row[1])`
+    per row meant a single row whose `old` happened to be a repo-relative path
+    to a real file was read as a target -- grading that row's NEW text against
+    the file its OLD text named, and reporting a false STALE. A false stale
+    costs exactly what a missed one does.
+
+    When both readings are viable the table is REFUSED, not guessed. No
+    battery in the tree is ambiguous today; one that becomes so must be read by
+    someone rather than resolved by a coin flip.
+    """
+    def creates(row):
+        return len(row) > 2 and row[2] is None
+
+    key = bool(targets_map) and all(
+        isinstance(r[1], str) and r[1] in targets_map for r in rows)
+    if key:
+        return 'key', None
+
+    path = all(_abs_target(r[1], must_exist=not creates(r)) is not None
+               for r in rows)
+    if path and table_target is not None:
+        return None, ('%s can be read two ways -- every row[1] names a real '
+                      'file AND the table has a target of its own' % table_name)
+    if path:
+        return 'path', None
+    if table_target is not None:
+        return 'lone', None
+    return None, ('%s names no target: row[1] is not a TARGETS key, not a '
+                  'resolvable path, and the table has no target of its own'
+                  % table_name)
 
 
 def resolve_static(path):
     """(anchors, unresolved_reason) for one `tests/mutate_*.py`, without import.
 
     `unresolved_reason` is a string when the file could not be read as a
-    battery at all; the caller must treat that as a failure, never as "no
-    anchors". A resolver that answers cleanly for a file it did not understand
-    is the same bug this module exists to catch.
+    battery; the caller must treat that as a failure, never as "no anchors".
     """
     battery = os.path.basename(path)
     try:
@@ -308,9 +407,9 @@ def resolve_static(path):
         return [], 'cannot parse: %s' % exc
 
     env = _module_env(tree, path)
-    tables = _tables(tree, env)
-    if not tables:
-        return [], 'no mutation table found'
+    tables, reason = _tables(tree, env)
+    if reason:
+        return [], reason
 
     targets_map = env.get('TARGETS')
     if not isinstance(targets_map, dict):
@@ -318,54 +417,45 @@ def resolve_static(path):
     by_table = _battery_dict_targets(tree, env)
 
     #: The single-target fallback: a battery with one engine file names it
-    #: ENGINE (`mutate_750.py:46`). Only consulted when the row itself carries
-    #: no target, so it cannot mask a per-row path.
-    lone = _abs_target(env.get('ENGINE'), env)
+    #: ENGINE (`mutate_750.py:46`).
+    lone = _abs_target(env.get('ENGINE'))
 
     anchors = []
     for table_name, rows in tables:
         table_target = by_table.get(table_name) or lone
-        for row in rows:
-            name = row[0]
-            slot = row[1]
+        layout, reason = _layout(rows, targets_map, table_target, table_name)
+        if reason:
+            return [], reason
 
-            # Layout A: row[1] keys the TARGETS dict.
-            if isinstance(slot, str) and slot in targets_map:
-                target = _abs_target(targets_map[slot], env)
-                old, new = row[2], row[3] if len(row) > 3 else None
-                nth = None
-            else:
-                # A CREATE row (`old is None`) names a file that does not exist
-                # yet; every other row's target must be a real file, or a typo
-                # would silently resolve and grade as stale.
+        for row in rows:
+            name, slot = row[0], row[1]
+            nth = None
+            if layout == 'key':
+                target = _abs_target(targets_map[slot])
+                old = row[2]
+            elif layout == 'path':
                 creates = len(row) > 2 and row[2] is None
-                explicit = _abs_target(slot, env, must_exist=not creates)
-                if explicit is not None:
-                    # Layouts D and E: row[1] IS the path.
-                    target = explicit
-                    old = row[2]
-                    new = row[3] if len(row) > 3 else None
-                    nth = row[4] if len(row) > 4 and isinstance(
-                        row[4], int) and not isinstance(row[4], bool) else None
-                else:
-                    # Layouts B and C: no per-row target; row[1] is the anchor.
-                    target = table_target
-                    old, new = slot, row[2]
-                    nth = None
+                target = _abs_target(slot, must_exist=not creates)
+                old = row[2] if len(row) > 2 else UNKNOWN
+                nth = (row[4] if len(row) > 4 and isinstance(row[4], int)
+                       and not isinstance(row[4], bool) else None)
+            else:
+                target, old = table_target, slot
 
             if target is None:
                 return [], ('row %r in %s names no resolvable target'
                             % (name, table_name))
 
-            for i, one in enumerate(_edits(old, new)):
+            olds, multi = _edits(old)
+            for i, one in enumerate(olds):
                 if one is UNKNOWN:
                     return [], ('row %r in %s has an anchor this cannot '
                                 'reproduce exactly' % (name, table_name))
                 if one is not None and not isinstance(one, str):
                     return [], ('row %r in %s has a non-string anchor'
                                 % (name, table_name))
-                anchors.append(Anchor(battery, name, target, one, nth,
-                                      0 if not isinstance(old, list) else i))
+                anchors.append(Anchor(battery, name, target, one, nth, i,
+                                      multi))
     return anchors, None
 
 
@@ -374,33 +464,54 @@ def resolve_static(path):
 # --------------------------------------------------------------------------
 
 def _read_target(path, cache):
-    """The target's text with UNIVERSAL NEWLINES, which is what the batteries
-    match against (`mutate_711.py:296-305`). Reading it any other way makes
-    every multi-line anchor stale on a CRLF checkout."""
+    """(universal_newline_text, as_written_text) for a target.
+
+    Both, because the batteries disagree about which they match against: this
+    module and `mutate_711.py` read universal-newline, while 18 batteries read
+    with `newline=''`. On an LF checkout the two are identical; on a CRLF one
+    they are not, and an anchor whose count differs between them is a verdict
+    that depends on the checkout rather than on the code.
+    """
     if path not in cache:
-        with open(path, encoding='utf-8', errors='replace') as fh:
-            cache[path] = fh.read()
+        with open(path, 'rb') as fh:
+            raw = fh.read().decode('utf-8', 'replace')
+        cache[path] = (raw.replace('\r\n', '\n'), raw)
     return cache[path]
 
 
 def verify(anchors, repo_wide=False):
-    """Every problem among `anchors`, worst first within each battery.
+    """Every problem among `anchors`.
 
-    Returns a list, never raises on a bad anchor: the caller decides whether a
-    problem is fatal, and a run that stops at the first one hides the rest.
+    Returns a list and never raises: the caller decides what is fatal, and a
+    run that stops at the first problem hides the rest.
     """
     problems = []
     cache = {}
     for a in anchors:
         if a.old is None:
-            # `mutate_713_census.py`'s create-this-file row. It carries no
-            # anchor; grading it as one invents a finding.
+            # A create row has no anchor, but it is not unchecked: the battery
+            # refuses when the file it means to create is already there
+            # (`mutate_713_census.py:129-132`).
+            if os.path.exists(a.target):
+                problems.append(Problem(
+                    a, CREATE_EXISTS, 0,
+                    'the row creates %s, which already exists -- the battery '
+                    'reports BROKEN'
+                    % os.path.relpath(a.target, ROOT).replace(os.sep, '/')))
             continue
         if not os.path.isfile(a.target):
             problems.append(Problem(a, MISSING_TARGET, 0,
                                     'target does not exist'))
             continue
-        n = _read_target(a.target, cache).count(a.old)
+        text, as_written = _read_target(a.target, cache)
+        n = text.count(a.old)
+        if n != as_written.count(a.old):
+            problems.append(Problem(
+                a, NEWLINE_SENSITIVE, n,
+                'as-written count is %d -- the verdict depends on how the '
+                'target is read, and the batteries disagree about that'
+                % as_written.count(a.old)))
+            continue
         if a.nth is not None:
             if n < a.nth + 1:
                 problems.append(Problem(
@@ -409,8 +520,7 @@ def verify(anchors, repo_wide=False):
                     % (a.nth, a.nth + 1)))
             continue
         if n == 0:
-            problems.append(Problem(a, STALE, 0,
-                                    'the row mutates nothing'))
+            problems.append(Problem(a, STALE, 0, 'the row mutates nothing'))
         elif n > 1:
             problems.append(Problem(
                 a, AMBIGUOUS, n,
@@ -428,10 +538,10 @@ def _prose_problems(anchors):
     comment reports SURVIVED for a mutation that changed nothing executable.
     """
     import subprocess
-    out = subprocess.run(['git', 'ls-files', '*.py', '*.md'], cwd=ROOT,
-                         capture_output=True, text=True).stdout.split()
+    listed = subprocess.run(['git', 'ls-files', '*.py', '*.md'], cwd=ROOT,
+                            capture_output=True, text=True).stdout.split()
     texts = {}
-    for rel in out:
+    for rel in listed:
         path = os.path.join(ROOT, rel)
         try:
             with open(path, encoding='utf-8', errors='replace') as fh:
@@ -443,15 +553,16 @@ def _prose_problems(anchors):
         if a.old is None:
             continue
         battery_path = os.path.abspath(os.path.join(TESTS_DIR, a.battery))
-        others = [p for p, text in texts.items()
-                  if p not in (os.path.abspath(a.target), battery_path)
-                  and a.old in text]
+        others = sorted(p for p, text in texts.items()
+                        if p not in (os.path.abspath(a.target), battery_path)
+                        and a.old in text)
         if others:
             problems.append(Problem(
-                a, 'PROSE', len(others),
-                'also in ' + ', '.join(
-                    os.path.relpath(p, ROOT).replace(os.sep, '/')
-                    for p in sorted(others)[:3])))
+                a, PROSE, len(others),
+                'also in %d other tracked file(s): %s' % (
+                    len(others),
+                    ', '.join(os.path.relpath(p, ROOT).replace(os.sep, '/')
+                              for p in others[:3]))))
     return problems
 
 
@@ -462,12 +573,12 @@ def batteries():
     return [os.path.join(TESTS_DIR, n) for n in names]
 
 
-def census():
+def census(repo_wide=False):
     """[(battery, anchors, problems, unresolved_reason)] over the whole tree."""
     out = []
     for path in batteries():
         anchors, reason = resolve_static(path)
-        problems = [] if reason else verify(anchors)
+        problems = [] if reason else verify(anchors, repo_wide=repo_wide)
         out.append((os.path.basename(path), anchors, problems, reason))
     return out
 
@@ -478,34 +589,31 @@ def main():
     ap.add_argument('--verbose', action='store_true',
                     help='print every anchor, not only the problems')
     ap.add_argument('--repo-wide', action='store_true',
-                    help="also report anchors that occur in another tracked "
-                         "file, which may be prose rather than code")
+                    help='also report anchors that occur in another tracked '
+                         'file, which may be prose rather than code')
     args = ap.parse_args()
 
-    rows = census()
+    rows = census(repo_wide=args.repo_wide)
     if args.battery:
         rows = [r for r in rows if r[0] == args.battery]
         if not rows:
             print('no battery named %r' % args.battery, file=sys.stderr)
             return 2
 
-    total = stale = ambiguous = missing = unresolved = 0
+    total = unresolved = 0
+    kinds = {}
     print('%-26s %6s %6s %6s %6s' % ('battery', 'rows', 'STALE', 'AMBIG',
                                      'UNRES'))
     for name, anchors, problems, reason in rows:
-        if args.repo_wide and not reason:
-            problems = verify(anchors, repo_wide=True)
-        n_stale = sum(1 for p in problems if p.kind == STALE)
-        n_amb = sum(1 for p in problems if p.kind == AMBIGUOUS)
-        n_missing = sum(1 for p in problems if p.kind == MISSING_TARGET)
         total += len(anchors)
-        stale += n_stale
-        ambiguous += n_amb
-        missing += n_missing
         if reason:
             unresolved += 1
+        for p in problems:
+            kinds[p.kind] = kinds.get(p.kind, 0) + 1
         print('%-26s %6s %6s %6s %6s' % (
-            name, len(anchors) if not reason else '-', n_stale, n_amb,
+            name, len(anchors) if not reason else '-',
+            sum(1 for p in problems if p.kind == STALE),
+            sum(1 for p in problems if p.kind == AMBIGUOUS),
             'YES' if reason else ''))
         if reason:
             print('    UNRESOLVED: %s' % reason)
@@ -517,10 +625,14 @@ def main():
                     a.label,
                     os.path.relpath(a.target, ROOT).replace(os.sep, '/')))
 
-    print('\n%d battery(s), %d anchor(s): %d stale, %d ambiguous, %d missing '
-          'target, %d unresolved' % (len(rows), total, stale, ambiguous,
-                                     missing, unresolved))
-    return 1 if (stale or missing or unresolved) else 0
+    summary = ', '.join('%d %s' % (kinds[k], k.lower())
+                        for k in sorted(kinds)) or 'no problems'
+    print('\n%d battery(s), %d anchor(s): %s, %d unresolved'
+          % (len(rows), total, summary, unresolved))
+    # EVERY problem kind fails, not only STALE. The exit code and the #718 gate
+    # must agree about what is wrong, or the one-second check reports green
+    # while the suite goes red on the same rows.
+    return 1 if (kinds or unresolved) else 0
 
 
 if __name__ == '__main__':

--- a/tests/mutation_anchors.py
+++ b/tests/mutation_anchors.py
@@ -20,11 +20,14 @@ implementation of that question in the tree, for two callers:
   * `tests/test_718_static_test_hygiene.py`, over every battery, without
     importing any of them (`resolve_static` -> `verify`).
 
-The second caller exists today; the batteries are converted in the same PR.
-Until that lands, the five hand-rolled `--verify-anchors` implementations
-(`mutate_714`, `726`, `837`, `847`, `850_848`) are still the shipped state, and
-`mutate_726.py:248-280`'s is STRICTER than this module's default -- its prose
-check is always on, where here it needs `--repo-wide`.
+Both callers exist. Every battery calls `preflight`, which also HANDLES
+`--verify-anchors` and strips it from `sys.argv`, so the five hand-rolled
+implementations that predate this (`mutate_714`, `726`, `837`, `847`,
+`850_848`) are no longer what answers that flag. One of them was STRICTER than
+this module's default -- `mutate_726`'s also refuses an anchor occurring in
+another tracked file, the prose trap -- so that battery passes
+`repo_wide=True`. A shared check that silently weakened a battery's own would
+be this module's defect in miniature.
 
 **Static resolution is not an optimisation, it is the only safe way.**
 `mutate_713_census.py`, `mutate_713_phase1.py` and `mutate_760.py` run their
@@ -42,8 +45,8 @@ Distinctions a plain `count(old) != 1` does not draw:
     rows as stale.
 
   * **NEWLINE_SENSITIVE**: the anchor's verdict changes with how the target is
-    read. This module reads universal-newline, and so does `mutate_711.py`
-    (`:296-305`), whose comment records that matching a raw byte decode
+    read. This module reads universal-newline, and so does `mutate_711.py`,
+    whose comment records that matching a raw byte decode
     "silently found NOTHING in three rows". But 18 batteries read their target
     with `newline=''`, so on a CRLF checkout the census and the battery would
     disagree. Dormant on this tree -- `.gitattributes` pins `*.py text eol=lf`
@@ -52,7 +55,7 @@ Distinctions a plain `count(old) != 1` does not draw:
   * A **create row** (`old is None`, `mutate_713_census.py`'s "a NEW file with
     a clock, registered nowhere") carries no anchor, but it is not unchecked:
     the battery reports BROKEN when the file it means to create already exists
-    (`mutate_713_census.py:129-132`), and that is what is graded here.
+    (`mutate_713_census.py's create-exists check`), and that is what is graded here.
 
     python3 tests/mutation_anchors.py               # census over every battery
     python3 tests/mutation_anchors.py --verbose     # every anchor, one a line
@@ -87,10 +90,10 @@ _TABLE_NAME_RE = re.compile(r'^(ROWS|[A-Z_]*_ROWS)$')
 class Anchor(object):
     """One `old` string, and the file it must occur in exactly once.
 
-    `nth` is the optional occurrence selector `mutate_760.py:65-79` implements
-    (`row[4]`), which replaces the Nth match instead of the first -- so its
-    requirement is "at least nth+1 matches", not "exactly one". No row uses it
-    today; the form is supported because the battery accepts it.
+    `nth` is the optional occurrence selector `mutate_760.py` implements as a
+    fifth row element, which replaces the Nth match instead of the first -- so
+    its requirement is "at least nth+1 matches", not "exactly one". No row uses
+    it today; the form is supported because that battery accepts it.
 
     `old is None` marks a create-this-file row, which has no anchor.
     """
@@ -256,6 +259,24 @@ def _is_row_table(value):
     return True
 
 
+def _looks_like_a_table(node):
+    """SYNTACTICALLY a mutation table: a non-empty list/tuple of tuples.
+
+    The name test alone was not enough. A second table called `GUI_TABLE`,
+    `ROWS2` or `MUTATIONS` -- or one built by a comprehension -- fell through
+    both arms of `_tables` and VANISHED, and the battery reported clean about
+    rows nobody checked. Shape catches what the name misses, and a table this
+    can see but not fold is exactly the case that must refuse rather than
+    disappear.
+    """
+    if isinstance(node, (ast.ListComp, ast.GeneratorExp)):
+        return True
+    if not isinstance(node, (ast.List, ast.Tuple)) or not node.elts:
+        return False
+    return all(isinstance(e, (ast.Tuple, ast.List, ast.Call, ast.Starred))
+               for e in node.elts)
+
+
 def _tables(tree, env):
     """([(name, rows)], reason) for the module-level mutation tables.
 
@@ -274,16 +295,16 @@ def _tables(tree, env):
     rebound at module scope twice over, silently doubling its anchors.
     """
     seen, out = set(), []
-    for name, _node in _assignments(tree):
+    for name, node in _assignments(tree):
         if name in seen:
             continue
         seen.add(name)
         value = env.get(name, UNKNOWN)
         if _is_row_table(value):
             out.append((name, value))
-        elif _TABLE_NAME_RE.match(name):
-            return [], ('%s is named like a mutation table but did not '
-                        'resolve to one' % name)
+        elif _TABLE_NAME_RE.match(name) or _looks_like_a_table(node):
+            return [], ('%s is shaped or named like a mutation table but did '
+                        'not resolve to one' % name)
     if not out:
         return [], 'no mutation table found'
     return out, None
@@ -342,7 +363,7 @@ def _edits(old):
     """The `old` of each edit in a row, expanding the list-valued form.
 
     14 batteries let `old` be a list of `(old, new)` pairs with `new` None
-    (`mutate_554.py:78-83`); `mutate_553.py:301-310` applies them as
+    (`mutate_554.py:78-83`); `mutate_553.py's edit loop` applies them as
     `for o, nw in edits`, so element 0 of each pair is the anchor. Each pair is
     its own anchor -- one going stale breaks the row exactly as a scalar anchor
     would, and #877's census counted the ROW rather than the pair.
@@ -491,7 +512,7 @@ def verify(anchors, repo_wide=False):
         if a.old is None:
             # A create row has no anchor, but it is not unchecked: the battery
             # refuses when the file it means to create is already there
-            # (`mutate_713_census.py:129-132`).
+            # (`mutate_713_census.py's create-exists check`).
             if os.path.exists(a.target):
                 problems.append(Problem(
                     a, CREATE_EXISTS, 0,
@@ -533,13 +554,21 @@ def verify(anchors, repo_wide=False):
 def _prose_problems(anchors):
     """Anchors that also occur in another tracked file.
 
-    `mutate_726.py:248-280`'s check, kept: a comment quoting code has satisfied
+    `mutate_726.py's verify_anchors`'s check, kept: a comment quoting code has satisfied
     a grep-shaped test in this repo before, and a battery that mutates a
     comment reports SURVIVED for a mutation that changed nothing executable.
     """
     import subprocess
-    listed = subprocess.run(['git', 'ls-files', '*.py', '*.md'], cwd=ROOT,
-                            capture_output=True, text=True).stdout.split()
+    r = subprocess.run(['git', 'ls-files', '*.py', '*.md'], cwd=ROOT,
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        # Zero tracked files would mean zero prose problems and a clean
+        # report -- the same shape as the defect this module polices. Refuse
+        # instead of answering from an empty list.
+        raise RuntimeError(
+            'git ls-files failed (%d), so the prose check has no corpus and '
+            'cannot answer: %s' % (r.returncode, (r.stderr or '').strip()))
+    listed = r.stdout.split()
     texts = {}
     for rel in listed:
         path = os.path.join(ROOT, rel)

--- a/tests/test_702_quench_intent_gate.py
+++ b/tests/test_702_quench_intent_gate.py
@@ -21,26 +21,46 @@ mutations in `tests/mutate_702.py` are killed only by a `by_site` assertion.
 MEASURED MUTATION TABLE, from `python3 tests/mutate_702.py`. The edits are in
 that file; these are the verdicts, recorded FROM THE RUN and not predicted:
 
-    22 rows: 19 killed, 3 survived, 0 broken, 0 disagreeing with expectation
+RE-MEASURED after #877 re-anchored eight of the rows, which had been asserting
+nothing since `c7bef8d9`:
 
-    the two survivors, recorded rather than deleted:
+    22 rows: 19 killed, 3 survived, 0 broken, 1 disagreeing with expectation
+
+The totals are unchanged from the previous recording; the MEMBERSHIP is not,
+and both moves are findings rather than noise.
+
+    the survivors, recorded rather than deleted:
       the-gate-is-built-even-with-no-intent      building an empty spec on a
                                                 board that declares nothing is
                                                 indistinguishable from not
                                                 building one -- every lookup
                                                 misses and `intent_ok` returns
-                                                on `if not spec`.
-      the-active-flag-ignores-whether-anything-bound
-                                                same reason, one level up: the
-                                                flag only guards work that is
-                                                already a no-op on an empty
-                                                spec. Kept as a detector for
-                                                the day the guard means more.
+                                                on `if not spec`. (#877
+                                                re-pointed this row at
+                                                `build_zone_spec`'s early-out,
+                                                which is where that claim now
+                                                lives.)
       the-swallow-test-ignores-the-tolerance    no arm builds a zone whose
                                                 tolerance band reaches outside
                                                 its keep-out; the row is here
                                                 so the guard exists the day one
                                                 does.
+      the-crossed-claim-check-never-fires       EXPECTS KILLED. See below.
+
+    the-active-flag-ignores-whether-anything-bound now KILLS, and was recorded
+    above as a survivor "kept as a detector for the day the guard means more".
+    That day arrived: this file has since grown two arms asserting the FLAG
+    rather than its consequences, and the mutation fails both. Re-graded in
+    `mutate_702.py`.
+
+    the-crossed-claim-check-never-fires is the one DISAGREEMENT, and it is a
+    coverage regression in THIS FILE, not in #877's work: the row, its target
+    (`floorplan.py`) and this gate are all byte-identical to the commit the
+    branch forked from, and the table above records it as KILLED when it was
+    last measured. It went quiet in between, and nobody could see it because
+    the battery was already exiting non-zero on the eight BROKEN rows. Left
+    standing as a real finding, to be fixed on its own terms rather than folded
+    into an anchor pass.
 
 Three rows exist because a mutation caught THIS FILE, not the engine:
 `the-incumbent-is-read-at-the-SEED-pose` survived until arm C was written at

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -925,6 +925,108 @@ def test_every_committed_baseline_is_declared():
           f'{len(_BASELINE_UNGATED)} ungated with a stated reason')
 
 
+#: Batteries whose row table `mutation_anchors.resolve_static` cannot read.
+#:
+#: Declared with the reason and held in BOTH directions, like `_WK_DEPENDENT`
+#: above: an entry that no longer applies is as much a defect as a missing one,
+#: because a stale exemption is indistinguishable from a gate that still covers
+#: the file. Empty today -- all 37 resolve -- and it exists so that a battery
+#: written in a shape the resolver has never seen fails LOUDLY here instead of
+#: being counted as "no anchors, nothing to check".
+_UNRESOLVABLE = {}
+
+#: Every `tests/mutate_*.py` in the tree, pinned. A resolver that quietly stops
+#: finding batteries would otherwise report a clean sweep over nothing -- the
+#: exact shape of the defect #877 is about, reproduced in its own gate.
+_BATTERY_COUNT = 37
+
+#: A floor well under today's 831, not a target. Same purpose as
+#: `test_the_scanners_still_match_something`: prove the corpus is populated.
+_MIN_ANCHORS = 600
+
+
+def test_every_mutation_anchor_matches_exactly_once():
+    """A mutation row whose anchor no longer matches guards NOTHING (#877).
+
+    A row is applied with `src.replace(old, new, 1)`. When `old` has gone --
+    a rename, a reflow, a dedent -- the row rewrites nothing, and every gate it
+    names passes for a reason that has nothing to do with the claim next to it.
+
+    Every battery does detect this and reports BROKEN rather than a kill. What
+    it cannot do is detect it CHEAPLY: the check runs per row, mid-run, after
+    the witnesses have been paid for. #877 quotes `mutate_847.py`'s own words --
+    "a stale anchor reports BROKEN 50 minutes into a run rather than in one
+    second before it". This is the one second, and it is the only thing in the
+    tree that runs over ALL the batteries: they are deliberately not named
+    `test_*`, so `run_all.discover()` never collects them, and at the time #877
+    was filed 8 of the 37 had been red for months with nobody looking.
+
+    Measured at 0aff32c0, before the re-anchoring pass: 29 stale anchors and 3
+    ambiguous ones across 9 batteries, of 831. #877 reported 24, missing
+    `mutate_834_835.py`'s 7 entirely and counting `mutate_703.py`'s 3 ambiguous
+    rows as stale.
+
+    AMBIGUOUS (>1 match) fails here as well as STALE (0). It is a milder
+    defect -- the row still mutates -- but which of the matching sites it hits
+    is decided by their order in the file rather than by the row, so the row's
+    subject is not what its name says it is.
+    """
+    sys.path.insert(0, TESTS_DIR)
+    import mutation_anchors
+
+    paths = mutation_anchors.batteries()
+    assert len(paths) == _BATTERY_COUNT, (
+        f'expected {_BATTERY_COUNT} mutation batteries, found {len(paths)}. '
+        f'If a battery was added or removed, update _BATTERY_COUNT -- the pin '
+        f'is here so a scan that stops finding them cannot report a clean '
+        f'sweep over an empty corpus.')
+
+    problems, unresolved, total = [], {}, 0
+    for path in paths:
+        name = os.path.basename(path)
+        anchors, reason = mutation_anchors.resolve_static(path)
+        if reason:
+            unresolved[name] = reason
+            continue
+        total += len(anchors)
+        assert anchors, (
+            f'{name}: resolved to ZERO anchors and reported no reason. That '
+            f'is a resolver failure wearing a clean result -- the battery has '
+            f'rows.')
+        for p in mutation_anchors.verify(anchors):
+            problems.append(str(p))
+
+    undeclared = sorted(set(unresolved) - set(_UNRESOLVABLE))
+    assert not undeclared, (
+        'battery(s) whose row table could not be resolved:\n  '
+        + '\n  '.join(f'{n}: {unresolved[n]}' for n in undeclared)
+        + '\nAn unreadable table is not an empty one. Either teach '
+          'mutation_anchors the shape, or declare it in _UNRESOLVABLE with '
+          'the reason -- silence here means the battery is unchecked.')
+    departed = sorted(set(_UNRESOLVABLE) - set(unresolved))
+    assert not departed, (
+        '_UNRESOLVABLE names battery(s) that now resolve fine:\n  '
+        + '\n  '.join(departed)
+        + '\nDrop them. A stale exemption is indistinguishable from a gate '
+          'that still covers the file.')
+
+    assert total >= _MIN_ANCHORS, (
+        f'only {total} anchor(s) resolved across {len(paths)} batteries -- the '
+        f'resolver has stopped reading the tables, so a green result here '
+        f'means nothing')
+
+    assert not problems, (
+        f'mutation row(s) whose anchor does not match its target exactly '
+        f'once:\n  ' + '\n  '.join(problems)
+        + '\nSTALE means the row rewrites nothing and the gates it names pass '
+          'for free. AMBIGUOUS means replace(..., 1) picks a site by file '
+          'order rather than by the row. Re-anchor the row to the code as it '
+          'now stands, expressing the SAME mutation -- never widen it to '
+          'whatever is convenient to quote (#877).')
+    print(f'  PASS: {total} mutation anchor(s) across {len(paths)} batteries '
+          f'each match their target exactly once')
+
+
 TESTS = [
     test_wk_dependent_tests_are_declared,
     test_no_test_spawns_a_script_that_moved,
@@ -933,6 +1035,7 @@ TESTS = [
     test_no_test_is_defined_after_its_own_runner,
     test_every_test_is_registered_in_its_files_own_list,
     test_every_committed_baseline_is_declared,
+    test_every_mutation_anchor_matches_exactly_once,
 ]
 
 

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -958,13 +958,32 @@ def test_every_mutation_anchor_matches_exactly_once():
     "a stale anchor reports BROKEN 50 minutes into a run rather than in one
     second before it". This is the one second, and it is the only thing in the
     tree that runs over ALL the batteries: they are deliberately not named
-    `test_*`, so `run_all.discover()` never collects them, and at the time #877
-    was filed 8 of the 37 had been red for months with nobody looking.
+    `test_*`, so `run_all.discover()` never collects them, and nothing else
+    does either.
+
+    HOW LONG THEY HAD BEEN RED, measured rather than guessed, because the first
+    draft of this docstring said "months" and that flattered the change: the
+    earliest staling commit is `b02761b7` (2026-08-26) and #877 was filed
+    2026-09-05, so the worst case is TEN DAYS and two batteries had been red
+    for one. The argument for this gate is not that the rot is ancient -- it is
+    that nothing in the tree could see it at all, so its age was never bounded
+    by anything but luck.
 
     Measured at 0aff32c0, before the re-anchoring pass: 29 stale anchors and 3
-    ambiguous ones across 9 batteries, of 831. #877 reported 24, missing
-    `mutate_834_835.py`'s 7 entirely and counting `mutate_703.py`'s 3 ambiguous
-    rows as stale.
+    ambiguous ones across 9 batteries, of 831 anchors in 822 rows.
+
+    #877 reported 24 of 581. Neither number reproduces, and the difference is
+    method, not drift -- both re-measure identically at the commit it cites:
+
+      * it MISSED `mutate_834_835.py` entirely, which has 7 (the third-worst);
+      * it counted `mutate_703.py`'s 3 rows as stale where they are AMBIGUOUS,
+        matching twice rather than never; and
+      * its denominators are SCALAR-ROW counts, so it dropped the 8 multi-edit
+        rows -- under its own rule the total should have read 814, not 581.
+
+    So 24 = 28 (stale scalar rows) - 7 (missed) + 3 (miscounted); the 29th
+    stale anchor is the second edit of a multi-edit row, which it could not
+    see.
 
     AMBIGUOUS (>1 match) fails here as well as STALE (0). It is a milder
     defect -- the row still mutates -- but which of the matching sites it hits

--- a/tests/test_877_mutation_anchors.py
+++ b/tests/test_877_mutation_anchors.py
@@ -17,7 +17,7 @@ reported a clean result for all five. They are kept as change detectors:
   3. a table bound twice at module scope, which was counted TWICE -- and an
      inflated anchor count is invisible against a floor;
   4. a create-this-file row aimed at a file that already exists, the one
-     condition `mutate_713_census.py:129-132` reports BROKEN for and the one
+     condition `mutate_713_census.py's create-exists check` reports BROKEN for and the one
      the first draft skipped outright;
   5. a table both layouts fit, which must be REFUSED rather than guessed; and
   6. a row whose `old` is itself a path to a real file, which was read as the
@@ -125,6 +125,34 @@ def test_a_helper_built_table_is_refused_not_dropped():
     print('  PASS: a helper-built table is named, not dropped')
 
 
+def test_an_unreadable_table_is_refused_whatever_it_is_called():
+    """The refusal must rest on SHAPE, not only on the name `*_ROWS`.
+
+    The first fix keyed only on the name, so a second table called `GUI_TABLE`,
+    `ROWS2` or `MUTATIONS` -- or one built by a comprehension -- still vanished
+    and the battery still reported clean. Each fixture below hides a row whose
+    anchor matches nothing, so a silent drop is a silent false pass.
+    """
+    bodies = {
+        'GUI_TABLE': 'GUI_TABLE = [_row(%r, %r, %r)]\n' % ('r2', GONE, 'y'),
+        'ROWS2': 'ROWS2 = [_row(%r, %r, %r)]\n' % ('r2', GONE, 'y'),
+        'MUTATIONS': ('MUTATIONS = [(n, %r, "y") for n in ("r2",)]\n' % GONE),
+    }
+    missed = []
+    for name, extra in bodies.items():
+        with _Fixture() as fx:
+            _a, reason, _p = fx.battery('mutate_probe_%s.py' % name.lower(), (
+                'def _row(a, b, c):\n    return (a, b, c)\n'
+                'ROWS = [(%r, %r, %r)]\n' % ('r1', UNIQUE, 'x')) + extra)
+        if reason is None:
+            missed.append(name)
+    assert not missed, (
+        f'a second, unreadable table named {missed} was dropped in silence. '
+        f'The guard must key on the SHAPE of the value -- a list of tuples '
+        f'that would not fold -- not only on the name matching *_ROWS.')
+    print('  PASS: an unreadable table is refused whatever it is called')
+
+
 def test_an_annotated_table_assignment_is_seen():
     """`ROWS: List[Row] = [...]` binds exactly as `ROWS = [...]` does.
 
@@ -170,12 +198,16 @@ def test_a_create_row_whose_file_exists_is_reported():
     """The one condition a create row can fail, graded rather than skipped.
 
     A create row carries no anchor, so skipping it looked right -- but
-    `mutate_713_census.py:129-132` reports BROKEN when the file it means to
+    `mutate_713_census.py's create-exists check` reports BROKEN when the file it means to
     create is already there. Skipping meant the row the resolver singles out
     for special handling was the one row it checked nothing about.
     """
     with _Fixture() as fx:
-        rel = os.path.relpath(fx.engine, ROOT).replace(os.sep, '/')
+        # ABSOLUTE, not repo-relative: `os.path.relpath` raises
+        # ValueError when TEMP and the repo are on different Windows
+        # drives, which turned this gate into an error on an ordinary
+        # C:-temp / D:-repo box. `_abs_target` takes either.
+        rel = fx.engine.replace(os.sep, '/')
         _a, reason, problems = fx.battery('mutate_probe_h.py', (
             'GATE = ENGINE_TEST\n'
             'ROWS = [(%r, %r, None, %r, %r)]\n'
@@ -196,7 +228,11 @@ def test_an_ambiguous_table_is_refused_not_guessed():
     read by a person.
     """
     with _Fixture() as fx:
-        rel = os.path.relpath(fx.engine, ROOT).replace(os.sep, '/')
+        # ABSOLUTE, not repo-relative: `os.path.relpath` raises
+        # ValueError when TEMP and the repo are on different Windows
+        # drives, which turned this gate into an error on an ordinary
+        # C:-temp / D:-repo box. `_abs_target` takes either.
+        rel = fx.engine.replace(os.sep, '/')
         _a, reason, _p = fx.battery('mutate_probe_i.py', (
             'ROWS = [(%r, %r, %r)]\n' % ('r', rel, 'x')))
     assert reason and 'two ways' in reason, (
@@ -287,6 +323,7 @@ def test_the_corpus_is_populated():
 
 TESTS = [
     test_a_helper_built_table_is_refused_not_dropped,
+    test_an_unreadable_table_is_refused_whatever_it_is_called,
     test_an_annotated_table_assignment_is_seen,
     test_a_table_bound_twice_is_counted_once,
     test_a_create_row_whose_file_exists_is_reported,

--- a/tests/test_877_mutation_anchors.py
+++ b/tests/test_877_mutation_anchors.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Does `tests/mutation_anchors.py` actually bite? (#877)
+
+The module exists to stop a mutation row asserting nothing. A checker that
+answers "no problems" for a battery it did not understand has the same defect
+it was written to find, one level up -- so every gate below is a battery-shaped
+file built to be WRONG in a specific way, and the assertion is that the
+resolver says so.
+
+Every case here was found by an adversarial review of the first draft, which
+reported a clean result for all five. They are kept as change detectors:
+
+  1. a second table whose rows a helper builds -- `_fold` cannot read it, and
+     the table used to VANISH while the battery still printed a clean line;
+  2. a table bound with an ANNOTATED assignment (`ROWS: List[Row] = [...]`),
+     which the first draft's `ast.Assign`-only walk did not see at all;
+  3. a table bound twice at module scope, which was counted TWICE -- and an
+     inflated anchor count is invisible against a floor;
+  4. a create-this-file row aimed at a file that already exists, the one
+     condition `mutate_713_census.py:129-132` reports BROKEN for and the one
+     the first draft skipped outright;
+  5. a table both layouts fit, which must be REFUSED rather than guessed; and
+  6. a row whose `old` is itself a path to a real file, which was read as the
+     row's TARGET -- grading the row's new text against the file its old text
+     named, and reporting a FALSE STALE. A false stale costs what a missed one
+     does.
+
+Nothing here reads a battery in the repo and nothing imports one: three run
+their runner at module scope, so importing them rewrites engine files. The
+fixtures are written into a temporary directory and handed to
+`resolve_static` as data, which is exactly how the #718 gate uses it.
+
+    python3 tests/test_877_mutation_anchors.py
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(TESTS_DIR)
+sys.path.insert(0, TESTS_DIR)
+
+import mutation_anchors as ma                                     # noqa: E402
+
+#: The stand-in engine every fixture battery mutates. Self-contained on
+#: purpose: a fixture anchored to a real repo file would go stale exactly the
+#: way the rows this module polices do, and then this gate would be testing
+#: its own rot instead of the resolver.
+ENGINE_TEXT = (
+    'def alpha():\n'
+    '    return 1\n'
+    '\n'
+    'def beta():\n'
+    '    return 2\n'
+    '\n'
+    'def gamma():\n'
+    '    return 2\n'
+)
+
+#: Occurs exactly once in ENGINE_TEXT.
+UNIQUE = 'def alpha():'
+#: Occurs exactly twice.
+TWICE = '    return 2\n'
+#: Occurs nowhere.
+GONE = 'def delta():'
+
+
+class _Fixture(object):
+    """A temporary directory holding an engine file and battery-shaped files."""
+
+    def __enter__(self):
+        self.dir = tempfile.mkdtemp(prefix='mut877_')
+        self.engine = os.path.join(self.dir, 'engine.py')
+        with open(self.engine, 'w', encoding='utf-8', newline='') as fh:
+            fh.write(ENGINE_TEXT)
+        return self
+
+    def __exit__(self, *exc):
+        shutil.rmtree(self.dir, ignore_errors=True)
+        return False
+
+    def battery(self, name, body, with_engine=True):
+        """Write a battery-shaped file and resolve it. Never imported.
+
+        `with_engine` mirrors a real distinction: `mutate_750.py` names its one
+        target `ENGINE`, and `mutate_713_census.py` / `mutate_760.py` name no
+        table-level target at all and carry the path in each row. A fixture
+        that always defined `ENGINE` could not express the second shape.
+        """
+        path = os.path.join(self.dir, name)
+        head = ('import os\n'
+                'ENGINE_TEST = %r\n'
+                'OTHER = %r\n' % (self.engine, self.engine))
+        if with_engine:
+            head += 'ENGINE = %r\n' % self.engine
+        with open(path, 'w', encoding='utf-8', newline='') as fh:
+            fh.write(head + body)
+        anchors, reason = ma.resolve_static(path)
+        problems = [] if reason else ma.verify(anchors)
+        return anchors, reason, problems
+
+
+def test_a_helper_built_table_is_refused_not_dropped():
+    """A table `_fold` cannot read must fail the battery, not disappear.
+
+    `resolve_static` returns as soon as ONE table resolves, so a second table
+    it could not fold was silently absent and the battery reported clean. The
+    name is the signal: a binding called `*_ROWS` that is not a row table means
+    the resolver has met a shape it does not know.
+    """
+    with _Fixture() as fx:
+        _a, reason, _p = fx.battery('mutate_probe_a.py', (
+            'def _row(a, b, c):\n    return (a, b, c)\n'
+            'ENGINE_ROWS = [(%r, %r, %r)]\n'
+            'GUI_ROWS = [_row(%r, %r, %r)]\n'
+            'BATTERIES = {"e": (ENGINE, ENGINE_TEST, ENGINE_ROWS),\n'
+            '             "g": (OTHER, ENGINE_TEST, GUI_ROWS)}\n'
+            % ('r1', UNIQUE, 'x', 'r2', GONE, 'y')))
+    assert reason and 'GUI_ROWS' in reason, (
+        f'a table built by a helper call resolved to {reason!r} -- it must '
+        f'name the table it could not read. A vanished table is a battery '
+        f'reporting clean about rows nobody checked.')
+    print('  PASS: a helper-built table is named, not dropped')
+
+
+def test_an_annotated_table_assignment_is_seen():
+    """`ROWS: List[Row] = [...]` binds exactly as `ROWS = [...]` does.
+
+    An `ast.Assign`-only walk skips `ast.AnnAssign`, so the whole table was
+    invisible -- and invisible reads as clean.
+    """
+    with _Fixture() as fx:
+        anchors, reason, problems = fx.battery('mutate_probe_d.py', (
+            'from typing import List, Tuple\n'
+            'ENGINE_ROWS = [(%r, %r, %r)]\n'
+            'GUI_ROWS: List[Tuple[str, str, str]] = [(%r, %r, %r)]\n'
+            'BATTERIES = {"e": (ENGINE, ENGINE_TEST, ENGINE_ROWS),\n'
+            '             "g": (OTHER, ENGINE_TEST, GUI_ROWS)}\n'
+            % ('r1', UNIQUE, 'x', 'r2', GONE, 'y')))
+    assert reason is None and len(anchors) == 2, (
+        f'an annotated table assignment resolved to {len(anchors)} anchor(s), '
+        f'reason={reason!r} -- both tables must be read')
+    assert [p.kind for p in problems] == [ma.STALE], (
+        f'the annotated table must still be GRADED, got '
+        f'{[p.kind for p in problems]}')
+    print('  PASS: an annotated table assignment is seen and graded')
+
+
+def test_a_table_bound_twice_is_counted_once():
+    """N assignments to one name are one table, at its LAST value.
+
+    Counting assignment NODES emitted every row once per binding. An inflated
+    anchor count is invisible against a floor, and it is the flattering
+    direction: more anchors, all passing.
+    """
+    with _Fixture() as fx:
+        anchors, reason, _p = fx.battery('mutate_probe_f.py', (
+            'ROWS = [(%r, %r, %r)]\n'
+            'ROWS = [(%r, %r, %r), (%r, %r, %r)]\n'
+            % ('a', UNIQUE, 'x', 'b', UNIQUE, 'y', 'c', UNIQUE, 'z')))
+    assert reason is None and [a.row for a in anchors] == ['b', 'c'], (
+        f'a rebound table resolved to {[a.row for a in anchors]} -- it must be '
+        f"the LAST binding's rows, once each")
+    print('  PASS: a table bound twice is counted once, at its last value')
+
+
+def test_a_create_row_whose_file_exists_is_reported():
+    """The one condition a create row can fail, graded rather than skipped.
+
+    A create row carries no anchor, so skipping it looked right -- but
+    `mutate_713_census.py:129-132` reports BROKEN when the file it means to
+    create is already there. Skipping meant the row the resolver singles out
+    for special handling was the one row it checked nothing about.
+    """
+    with _Fixture() as fx:
+        rel = os.path.relpath(fx.engine, ROOT).replace(os.sep, '/')
+        _a, reason, problems = fx.battery('mutate_probe_h.py', (
+            'GATE = ENGINE_TEST\n'
+            'ROWS = [(%r, %r, None, %r, %r)]\n'
+            % ('makes-an-existing-file', rel, 'body', 'why')),
+            with_engine=False)
+    assert reason is None and [p.kind for p in problems] == [ma.CREATE_EXISTS], (
+        f'a create row aimed at an existing file gave reason={reason!r}, '
+        f'problems={[p.kind for p in problems]} -- expected CREATE_EXISTS')
+    print('  PASS: a create row whose file already exists is reported')
+
+
+def test_an_ambiguous_table_is_refused_not_guessed():
+    """Two viable readings must refuse, never resolve by a coin flip.
+
+    When a table has a target of its own AND every row[1] names a real file,
+    row[1] is either the anchor or the target and nothing in the file says
+    which. No battery in the tree is ambiguous; one that becomes so should be
+    read by a person.
+    """
+    with _Fixture() as fx:
+        rel = os.path.relpath(fx.engine, ROOT).replace(os.sep, '/')
+        _a, reason, _p = fx.battery('mutate_probe_i.py', (
+            'ROWS = [(%r, %r, %r)]\n' % ('r', rel, 'x')))
+    assert reason and 'two ways' in reason, (
+        f'an ambiguous table resolved to reason={reason!r} -- it must refuse')
+    print('  PASS: a table both layouts fit is refused, not guessed')
+
+
+def test_an_anchor_that_looks_like_a_path_stays_an_anchor():
+    """A row's `old` is not a target just because it parses as one.
+
+    Probing `_abs_target(row[1])` per row meant a single row whose anchor was a
+    repo-relative path to a real file was read as that row's TARGET -- the
+    row's new text graded against the file its old text named, reported as a
+    FALSE STALE. The layout is decided once per table, from all its rows.
+    """
+    with _Fixture() as fx:
+        _a, reason, problems = fx.battery('mutate_probe_c.py', (
+            'ROWS = [(%r, %r, %r)]\n'
+            % ('drop-the-path', 'py_router/route_v2.py', 'replacement')))
+    assert reason is None, f'reason={reason!r}'
+    assert [p.kind for p in problems] == [ma.STALE], (
+        f'expected the anchor graded against ENGINE, got '
+        f'{[p.kind for p in problems]}')
+    assert problems[0].anchor.old == 'py_router/route_v2.py', (
+        f'row[1] was read as a TARGET, not as the anchor: '
+        f'old={problems[0].anchor.old!r}')
+    assert problems[0].anchor.target.endswith('engine.py'), (
+        f'the target must come from the table, got {problems[0].anchor.target}')
+    print('  PASS: an anchor that looks like a path stays an anchor')
+
+
+def test_stale_ambiguous_and_ok_are_told_apart():
+    """The three verdicts, on one table, against known content.
+
+    #877 reported `mutate_703.py`'s three 2-match rows as stale. They are a
+    different defect: a stale row rewrites nothing, an ambiguous one rewrites
+    whichever site comes first.
+    """
+    with _Fixture() as fx:
+        anchors, reason, problems = fx.battery('mutate_probe_v.py', (
+            'ROWS = [(%r, %r, %r), (%r, %r, %r), (%r, %r, %r)]\n'
+            % ('fine', UNIQUE, 'x', 'gone', GONE, 'y', 'twice', TWICE, 'z')))
+    assert reason is None and len(anchors) == 3, f'reason={reason!r}'
+    got = {p.anchor.row: p.kind for p in problems}
+    assert got == {'gone': ma.STALE, 'twice': ma.AMBIGUOUS}, (
+        f'expected one STALE and one AMBIGUOUS and the third clean, got {got}')
+    print('  PASS: stale, ambiguous and matching are told apart')
+
+
+def test_a_multi_edit_row_labels_every_edit():
+    """Each `(old, new)` pair of a list-valued row is its own anchor.
+
+    Edit 0 used to print as a bare row name, so a stale FIRST pair looked
+    exactly like a stale scalar row and the reader could not tell which edit to
+    fix.
+    """
+    with _Fixture() as fx:
+        anchors, reason, problems = fx.battery('mutate_probe_m.py', (
+            'ROWS = [(%r, [(%r, %r), (%r, %r)], None, %r)]\n'
+            % ('pair', GONE, 'a', UNIQUE, 'b', 'KILLED')))
+    assert reason is None and len(anchors) == 2, f'reason={reason!r}'
+    assert [a.label for a in anchors] == ['pair[0]', 'pair[1]'], (
+        f'every edit of a multi-edit row must be labelled, got '
+        f'{[a.label for a in anchors]}')
+    assert [(p.anchor.label, p.kind) for p in problems] == [
+        ('pair[0]', ma.STALE)], (
+        f'the stale FIRST pair must be named, got '
+        f'{[(p.anchor.label, p.kind) for p in problems]}')
+    print('  PASS: every edit of a multi-edit row is labelled and graded')
+
+
+def test_the_corpus_is_populated():
+    """A resolver that stopped reading the tree would pass every gate above.
+
+    Those run on fixtures; this one asserts the real corpus is still there, so
+    a green suite cannot mean "found nothing to check". A floor, not a target.
+    """
+    paths = ma.batteries()
+    assert len(paths) >= 30, (
+        f'only {len(paths)} mutation batteries found -- the scan has stopped '
+        f'finding them')
+    total = sum(len(ma.resolve_static(p)[0]) for p in paths)
+    assert total >= 600, (
+        f'only {total} anchor(s) resolved across {len(paths)} batteries -- the '
+        f'resolver has stopped reading the tables')
+    print(f'  PASS: {total} anchor(s) across {len(paths)} real batteries')
+
+
+TESTS = [
+    test_a_helper_built_table_is_refused_not_dropped,
+    test_an_annotated_table_assignment_is_seen,
+    test_a_table_bound_twice_is_counted_once,
+    test_a_create_row_whose_file_exists_is_reported,
+    test_an_ambiguous_table_is_refused_not_guessed,
+    test_an_anchor_that_looks_like_a_path_stays_an_anchor,
+    test_stale_ambiguous_and_ok_are_told_apart,
+    test_a_multi_edit_row_labels_every_edit,
+    test_the_corpus_is_populated,
+]
+
+
+if __name__ == '__main__':
+    for t in TESTS:
+        print(f'--- {t.__name__}')
+        t()
+    print('ALL PASS')


### PR DESCRIPTION
Closes #877.

A mutation row is applied with `src.replace(old, new, 1)`. When `old` no longer occurs in the target, the row rewrites nothing and every gate it names passes for a reason unrelated to the claim beside it. These are the gates that certify the repo's other gates.

## What the census actually says

I re-measured statically (`ast`, never importing — three batteries run their runner at module scope) and reconciled against the issue. **#877 understates the problem and misstates the mechanism.**

|  | #877 | measured at `0aff32c0` |
|---|---|---|
| stale | 24 | **29 anchors** in 28 scalar rows + 1 edit of a multi-edit row |
| ambiguous | (folded into stale) | **3**, in a 9th battery |
| denominator | 581 | **831 anchors** in 822 rows |
| batteries affected | 8 of 37 | 8 stale + 1 ambiguous |

Three divergences, each re-checked at `5828b839` (the commit #877 cites) so none is drift since filing:

1. **`mutate_834_835.py` is missing from the issue entirely — 7 of 22 stale**, the third-worst battery.
2. **`mutate_703.py`'s 3 rows are AMBIGUOUS (2 matches), not stale.** They still mutate; which site they hit is decided by file order rather than by the row. A different defect, not a smaller one.
3. **The 581 denominator is inconsistent with the issue's own per-battery figures**, which are exactly the *scalar-row* counts — so it dropped the 8 multi-edit rows. Under its own rule the total should have read 814.

Reconciliation is exact: `24 = 28 − 7 (missed) + 3 (miscounted)`.

### The mechanism in the title does not ship

The issue says such rows "report KILLED". **They do not.** Every affected battery counts the anchor before writing and reports `BROKEN`, and every one exits non-zero — verified individually (`mutate_702.py:342`, `703:412`, `730:330`, `554:432`, `747:402`, `768:395`, `799:360`, `829:386`, `834_835:480`). A no-op `replace` leaves the witnesses passing, which reports **SURVIVED**, not KILLED.

The real defect is worth stating correctly:

- a stale anchor is found **mid-run**, after the witnesses have been paid for, instead of in one second — only 5 of 37 batteries could pre-flight, and only 3 ran it automatically;
- **8 batteries were red and nobody could see it**, because they are deliberately not named `test_*`, `run_all.discover()` globs only `tests/test_*.py`, and the sole CI workflow runs no tests;
- and the 29 rows asserted nothing until re-anchored.

I originally wrote "red for months". Measured, the earliest staling commit is `b02761b7` (2026-08-26) against a 2026-09-05 filing: **10 days**, and two batteries for one day. The argument for the gate isn't that the rot is old — it's that nothing bounded its age but luck.

## What shipped

**`tests/mutation_anchors.py`** — one implementation of *"does this anchor match its target exactly once?"*, used from both sides: each battery's `--verify-anchors`, and a gate over all 37. It resolves every row table statically and never imports a battery.

**`preflight(__file__)` in all 37 batteries**, one line each, placed after the row table by `ast`. It also *is* `--verify-anchors` — the flag is handled inside and stripped from `sys.argv` — so no battery needs a flag or a branch of its own. That matters: the alternative was a 38th hand-rolled copy per file, which is how only 5 had the check at all.

**A standing check in `tests/test_718_static_test_hygiene.py`**, in the `--fast` bucket, in 0.35 s.

**The 29 stale + 3 ambiguous rows re-anchored**, each naming the commit that staled it and expressing the *same* mutation.

### Deviation from the issue's suggested fix, stated plainly

#877 proposes "one shared runner the 37 batteries import". The batteries are not 37 copies of one thing — there are five incompatible row layouts (`TARGETS` dict; two tables in a `BATTERIES` dict; no target slot; path-at-index-1 with an optional Nth-occurrence selector; repo-relative path with `old=None` meaning *create the file*), 8 multi-edit rows whose `old` is a list of pairs, and four verdict vocabularies. Rewriting 37 certification gates in the same PR that re-anchors 29 of their rows would leave nothing independently checkable. So this extracts the one genuinely common thing and leaves each runner alone.

### Scoped in beyond the issue

Same failure class — a battery that cannot be trusted to leave the tree as it found it:

- `mutate_837`, `mutate_713_census`, `mutate_713_phase1`, `mutate_760` wrote targets with **no `newline=''`**. `.gitattributes` pins `*.py text eol=lf`, so on Windows one run rewrote every target in CRLF. Worse, it was invisible to the one guard that might have caught it: `git diff --quiet` applies the clean filter and calls a pure CRLF rewrite *clean*. All four now restore from raw bytes.
- `mutate_760` also wrote with no encoding and had no dirty-tree refusal.
- `mutate_837` had **no inline anchor count** — its only protection was the pre-flight.
- The three module-scope runners now raise `ImportError` naming `resolve_static`, so the accident that produced #877's own inflated numbers cannot recur.

## Verification

```
census at 0aff32c0   37 batteries, 831 anchors: 29 stale, 3 ambiguous, 0 unresolved
census at HEAD       37 batteries, 831 anchors: 0, 0, 0
--verify-anchors     37 of 37 exit 0, tree byte-identical
negative control     stale one anchor, run with NO flag -> exit 2 in 0.1 s,
                     engine untouched, offending row named
run_all.py --fast    385 passed, 0 failed
```

A clean census does **not** establish that a row still means what its name says — this branch's own `mutate_702` keepout row matched exactly once while mutating nothing, and only the run caught it. So every battery whose rows changed was run:

| battery | rows | killed | survived | broken | disagreeing |
|---|---|---|---|---|---|
| mutate_702 | 22 | 19 | 3 | 0 | 1 |
| mutate_703 | 29 | 27 | 2 | 0 | 0 |
| mutate_554 | 30 | 26 | 4 | 0 | 0 |
| mutate_730 | 28 | 25 | 3 | 0 | 0 |
| mutate_747 | 22 | 20 | 2 | 0 | 0 |
| mutate_768 | 31 | 31 | 0 | 0 | 0 |
| mutate_799 | 22 | 18 | 4 | 0 | 0 |
| mutate_829 | 23 | 22 | 1 | 0 | 0 |
| mutate_834_835 | 22 | 18 | 4 | 0 | 0 |
| **total** | **229** | **206** | **23** | **0** | **1** |

`mutate_702` was 14 usable rows and 8 BROKEN before this. Every survivor is a declared one, and each run left the tree byte-identical — checked with **both** `git status --porcelain` and `git diff --stat`, since a pure CRLF flip shows in the first and not the second.

## One finding left standing, deliberately

`mutate_702`'s `the-crossed-claim-check-never-fires` survives where it expects KILLED. It is **not** from this work: the row, `floorplan.py` and the witness are byte-identical to `main`, and `test_702_quench_intent_gate.py`'s own table records it as KILLED when last measured — so it is a **coverage regression in that gate** that went quiet in between, invisible because the battery was already exiting non-zero on the eight BROKEN rows. Disclosed at the row and in both tables, and left for its own fix rather than folded into an anchor pass.

## Review

A code reviewer and an independent fact-checker ran against the branch before push; between them 22 findings, all fixed in `e59e8cf9` and `54fbfa3c`. The two that mattered most:

- **`mutate_730`'s hoist row would have reported green while measuring an exception.** I had re-spelled its replacement to `_npth_floor` for consistency, but that edit lands at the top of `PartPads.__init__` while the name binds sixteen lines lower — every construction would raise `UnboundLocalError` and the row would report its expected KILLED for the wrong reason. Caught by disassembling the mutant.
- **Four line citations in this PR's own new code went stale**, broken by its own `preflight` insertions — in a PR about anchors that no longer match the code they quote. All four now name the symbol.

The fact-checker also caught three claims of mine that flattered the change (the "months", the wrong-direction KILLED, and a false dirty-tree consequence); those are corrected in the shipped prose, not just here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuQQFQjwZftzzprsnjvk5J
