### PR TITLE
#878: the far-face area currency, measured before it was chosen

### DIFF
--- a/docs/design-brief.md
+++ b/docs/design-brief.md
@@ -94,7 +94,10 @@ back-populated board whose front carries the label is `assembly.sides: "B"`
 with `user_top_side: "F"`, and that is coherent. `user_top_side` is carried and
 graded by nothing, and the brief report says so under `not_graded`;
 `assembly.sides` is graded by `rule_assembly_side` and charged by
-`options.grow_board`.
+`options.grow_board` — which since
+[#878](https://github.com/drandyhaas/KiCadRoutingTools/issues/878) also charges
+a through-hole part's leads against the face it is *not* mounted on, so the
+busier face is the busier **obstructed** one.
 
 Every key is optional. Strictness is the same as the intent's, at every level
 and for the same reason (#710): a typo'd key that loads clean is a constraint

--- a/docs/floorplan-intent.md
+++ b/docs/floorplan-intent.md
@@ -501,9 +501,17 @@ about one of them.
 | instrument | its question | near face | far face |
 |---|---|---|---|
 | `legality.rect_on` | may these two parts overlap? | courtyard | **drilled-pad rect** |
-| `options.grow_board` | does the area fit on a face? | courtyard | **drilled-pad rect** (#878) |
+| `options.grow_board`, undeclared | does the area fit on the busier face? | courtyard | **drilled-pad rect** (#878) |
+| `options.grow_board`, declared `F`/`B` | does every part fit on the one populated face? | courtyard | **nothing** — see below |
 | `check_pockets.courtyard_cover` | is this window clear? | courtyard | **whole courtyard** |
 | `floorplan.rule_assembly_side` | how many reflow passes? | body face only | **nothing** |
+
+`grow_board` charges the far face **only when no face is declared**. Under a
+declared `F`/`B` the number is `sum` over the populated dict — each part exactly
+once, on the one face the fab builds — and a part's leads come out on the face
+nobody populates, where they compete with nothing. Charging them there would be
+the same area twice; measured, it would double-charge 10 of the 15 one-face
+boards. The `NOT MODELLED` line on such a run says so explicitly.
 
 `check_pockets` charges the whole courtyard because a window under a part is not
 clear on either face — it asks about *cover*, never about a sum, so overstating

--- a/docs/floorplan-intent.md
+++ b/docs/floorplan-intent.md
@@ -488,6 +488,38 @@ Its leads pass through. `keepout` tests the courtyard **and** the drilled-pad
 rect against every face the part occupies, so a mounting-hole keep-out cannot be
 walked through from the back.
 
+### Four instruments charge a through-hole part per face, and they differ
+
+A drilled part's body is on one face and its leads come out on the other, so
+every per-face instrument has to decide what the far face costs. They do not all
+answer the same way, and that is deliberate — they are not all asking the same
+question. Written down here because until
+[#878](https://github.com/drandyhaas/KiCadRoutingTools/issues/878) the only
+place any of it was recorded was a code comment, and that comment was wrong
+about one of them.
+
+| instrument | its question | near face | far face |
+|---|---|---|---|
+| `legality.rect_on` | may these two parts overlap? | courtyard | **drilled-pad rect** |
+| `options.grow_board` | does the area fit on a face? | courtyard | **drilled-pad rect** (#878) |
+| `check_pockets.courtyard_cover` | is this window clear? | courtyard | **whole courtyard** |
+| `floorplan.rule_assembly_side` | how many reflow passes? | body face only | **nothing** |
+
+`check_pockets` charges the whole courtyard because a window under a part is not
+clear on either face — it asks about *cover*, never about a sum, so overstating
+cannot double-count anything. `rule_assembly_side` charges nothing because a
+through-hole part on the front demands wave or hand soldering, not a second
+reflow pass.
+
+**`floorplan.rule_keepout` is not a fifth model**, though #878's own table listed
+it as one. It uses `part.sides` only to decide *which* keep-outs bind, then hands
+`keepout_hit` both rects and takes a `max` over them, consulting no face at all.
+
+`splitflap_driver` is the board where all four answers are visibly different: 65
+parts, every one on `F.Cu`, 24 of them drilled. Its populated back area is
+`0.00 mm²`, its obstructed back area is `558.34 mm²`, `sides_occupied` calls it
+two-sided, and `rule_assembly_side` calls it `F`.
+
 ### A zone a keep-out leaves no room in is refused
 
 [#702](https://github.com/drandyhaas/KiCadRoutingTools/issues/702) refuses an

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -245,16 +245,26 @@ Since [#878](https://github.com/drandyhaas/KiCadRoutingTools/issues/878) the
 **busier face is the busier _obstructed_ face**, not the busier populated one. A
 through-hole part's leads come out on the face it is not mounted on and block it
 there, so they are charged to it, at the drilled-pad rect — the same rect
-`legality.rect_on` presents on the far side for the placement search. Three keys
+`legality.rect_on` presents on the far side for the placement search. Four keys
 report it: `obstructed_area_by_side_mm2` beside the unchanged
-`part_area_by_side_mm2`, plus `far_face_area_mm2` and `far_face_parts`.
+`part_area_by_side_mm2`, plus `far_face_area_mm2`, `far_face_parts` and
+`far_face_basis` (a string, so it stays out of the text digest — the prose
+channel for the basis is the `NOT MODELLED` line).
+
+**Reconcile `utilisation` against `obstructed_area_by_side_mm2`**, not against
+`part_area_by_side_mm2`, whenever no `assembly.sides` is declared. The two
+differ on any board carrying a drilled part, and the second is the populated
+area, which is no longer what the busier-face verdict divides.
 
 The `F + B` row above is deliberately **not** affected. That sum is each part
 exactly once — the demand on the single face the fab populates — and a part's
 leads land on the face nobody populates, so charging them there would be the
 same area twice. Measured over the tracked corpus: the far-face charge moves the
-busier face on **1 of 22** boards (`rp2350_fpga_eensy_prePlane`, utilisation
-0.6220 → 0.6566) and flips **no** board's verdict; folding it into the one-face
+busier face's **area** on **1 of 22** boards (`rp2350_fpga_eensy_prePlane`,
+utilisation 0.6220 → 0.6566) and flips **no** board's verdict. It changes
+*which* face is busier on **none** of them — the only board where the binding
+face moves at all is `ulx3s`, and only under the whole-courtyard currency that
+was not adopted. Folding the charge into the one-face
 sum instead would double-charge 10 of the 15 one-face boards, worst
 `flat_hierarchy` 5927.41 → 9404.40 mm². `tests/measure_878_far_face_area.py`
 regenerates all of that, and `tests/878_far_face_currency.json` is the recorded

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -241,6 +241,25 @@ rule produced `utilisation` in both the text digest and `JSON_SUMMARY` — a
 utilisation whose basis you cannot see is a number that cannot be compared with
 another one.
 
+Since [#878](https://github.com/drandyhaas/KiCadRoutingTools/issues/878) the
+**busier face is the busier _obstructed_ face**, not the busier populated one. A
+through-hole part's leads come out on the face it is not mounted on and block it
+there, so they are charged to it, at the drilled-pad rect — the same rect
+`legality.rect_on` presents on the far side for the placement search. Three keys
+report it: `obstructed_area_by_side_mm2` beside the unchanged
+`part_area_by_side_mm2`, plus `far_face_area_mm2` and `far_face_parts`.
+
+The `F + B` row above is deliberately **not** affected. That sum is each part
+exactly once — the demand on the single face the fab populates — and a part's
+leads land on the face nobody populates, so charging them there would be the
+same area twice. Measured over the tracked corpus: the far-face charge moves the
+busier face on **1 of 22** boards (`rp2350_fpga_eensy_prePlane`, utilisation
+0.6220 → 0.6566) and flips **no** board's verdict; folding it into the one-face
+sum instead would double-charge 10 of the 15 one-face boards, worst
+`flat_hierarchy` 5927.41 → 9404.40 mm². `tests/measure_878_far_face_area.py`
+regenerates all of that, and `tests/878_far_face_currency.json` is the recorded
+argument for which rect was chosen.
+
 The face has to be **named**: `single` is refused, because single-sided does not
 mean front-sided. `ulx3s` is back-dominant (163 of its 226 pad-bearing parts),
 so "single implies F.Cu" would be wrong about most of a shipping board.

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -44,6 +44,7 @@ from bga_fanout.grid import analyze_bga_grid
 from placement.parser import extract_courtyard_bboxes, extract_locked_refs
 from placement.utility import compute_footprint_bbox_local, snap_to_grid
 from placement.legality import (BoardOutlineGate, PadClearanceModel, PadFloor,
+                                footprint_side, side_of_layer,
                                 _pad_carries_copper, format_required_clause,
                                 pad_half_extents, point_to_seg_dist,
                                 rect_gap, ring_is_rect,
@@ -594,7 +595,7 @@ class _Cap:
 
     def __init__(self, fp, courtyard_local, model=None, board_copper=None):
         self.ref = fp.reference
-        self.side = 'B' if (fp.layer or '').startswith('B') else 'F'
+        self.side = footprint_side(fp)
         self.seed_x, self.seed_y = fp.x, fp.y
         self.seed_rot = fp.rotation % 360
         self.x, self.y, self.rot = fp.x, fp.y, fp.rotation % 360
@@ -1193,7 +1194,7 @@ class _Repair:
                     self.caps[ref] = cap
                     continue
             # everything else is a static obstacle
-            side = 'B' if (fp.layer or '').startswith('B') else 'F'
+            side = footprint_side(fp)
             b = _rotate_local_bounds(*lb, fp.rotation)
             self.static_rects.append(((fp.x + b[0], fp.y + b[1],
                                        fp.x + b[2], fp.y + b[3]), side))
@@ -1719,8 +1720,13 @@ class _Repair:
     def _seg_side(layer):
         """The 'F'/'B' collapse the track prune used to be keyed on, kept ONLY
         as the fallback for a cap whose real pad layers are unavailable.
-        Byte-identical to what __init__ computed before #731."""
-        return 'B' if (layer or '').startswith('B') else 'F'
+
+        Still the fallback, and still byte-identical to what __init__
+        computed before #731 -- but it now CALLS that rule instead of
+        spelling it again (#878), so the claim in the line above is
+        structural rather than a promise two copies have to keep.
+        """
+        return side_of_layer(layer)
 
     def _cap_seg_scope(self, cap):
         """(per-pad copper layer sets, their union) for the TRACK channel, or

--- a/py_placer/placement/labels.py
+++ b/py_placer/placement/labels.py
@@ -34,6 +34,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 from kicad_parser import _global_to_local, local_to_global
 from placement.legality import (BoardOutlineGate, build_part_pads,
+                                side_of_layer,
                                 footprint_side, rect_gap, rect_overlap_area,
                                 rotate_local_bounds)
 from placement.parser import courtyard_for_side, extract_courtyard_sides
@@ -121,7 +122,7 @@ def label_side(label) -> str:
     """'F' or 'B' from the label's own layer (a B-side part CAN carry an
     F-side label; the layer, not the footprint, decides what it collides
     with)."""
-    return 'B' if str(label.layer).startswith('B') else 'F'
+    return side_of_layer(label.layer)
 
 
 def label_world_rect(fp, label, text: Optional[str] = None,

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -247,9 +247,15 @@ def side_of_layer(layer) -> str:
 
     `str(...)` where the old spelling had `or ''` is a widening, not a change:
     the old form raised `AttributeError` on a truthy non-string layer, and every
-    caller in the tree passes a `str` or `None`. Measured across the 22 tracked
-    boards, 1406 footprints: exactly two distinct layer values (`F.Cu`, `B.Cu`)
-    and zero disagreements between this and the five expressions it replaces.
+    caller in the tree passes a `str` or `None`.
+
+    On a `str` or `None` layer this and the spellings it replaced are
+    ALGEBRAICALLY equal, so the corpus cannot separate them -- it carries
+    exactly two layer values, `F.Cu` and `B.Cu`, over 1349 footprints. The
+    corpus check in `tests/test_878_side_rule_sites.py` is therefore a change
+    detector for THIS function, not evidence that the spellings differ; the
+    inputs that do separate them (a falsy layer, a truthy non-string) are
+    exercised there synthetically, because no board can supply them.
     """
     return 'B' if str(layer or '').startswith('B') else 'F'
 

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -252,6 +252,60 @@ def footprint_has_through_pads(fp) -> bool:
     return any((getattr(p, 'drill', 0) or 0) > 0 for p in (fp.pads or []))
 
 
+def through_pad_bounds_local(fp):
+    """Local bbox over a footprint's DRILLED pads, or None if it has none.
+
+    PUBLIC and living here since #878. It is the far half of `rect_on`
+    below and of `LocalBounds.tht_local`, so it is legality's own concept.
+    It used to sit in `quench` under a leading underscore and be reached
+    from here by a function-local import -- a private name across a module
+    boundary, which this repo already records as a rule it does not keep
+    (see `options.hosts_the_design`). The import had to be function-local
+    because `quench` imports `legality` at module scope, so the dependency
+    ran backwards; now it does not, and `options.grow_board` can charge the
+    far face without pulling the whole quench search engine into a
+    reporting CLI's import graph.
+
+    This is the footprint's footprint on the OPPOSITE board side: its body and
+    courtyard live on its own side, but its leads pass through, so a part on the
+    far side may not sit inside this box (#456 item 1). Deliberately the drill
+    hole's own extent rather than the pad copper's -- the far side sees the
+    barrel and the lead, and the annular ring on that side is part of it.
+    """
+    # `local_x/local_y` is the pad ANCHOR in the footprint's frame, and for a
+    # drilled pad the anchor IS the hole: kicad_parser records hole_x/hole_y as
+    # the pre-offset position and only then shifts global_x/global_y to the
+    # copper centre. So the hole needs no offset correction at all -- an earlier
+    # version "corrected" local_* by (hole - global), which is minus the offset,
+    # landing the box one full offset on the WRONG side of the hole.
+    #
+    # size_x/size_y are BOARD-axis resolved (kicad_parser swaps them for a pad at
+    # ~90 degrees), so they cannot be used as local half-extents directly -- that
+    # transposed the box on every 90/270-degree footprint (kit-dev SW_ONOFF201
+    # modelled 2.54 x 13.97 where the truth is 3.81 x 12.70, under-blocking
+    # 1.27mm). Project them through the pad's local tilt exactly as
+    # placement/utility.compute_footprint_bbox_local does.
+    xs, ys = [], []
+    for p in (fp.pads or []):
+        d = getattr(p, 'drill', 0) or 0
+        if d <= 0:
+            continue
+        local_tilt = math.radians((getattr(p, 'rect_rotation', 0.0) or 0.0)
+                                  + (fp.rotation or 0.0))
+        c, s = abs(math.cos(local_tilt)), abs(math.sin(local_tilt))
+        hx, hy = (getattr(p, 'size_x', 0) or 0) / 2.0, (getattr(p, 'size_y', 0) or 0) / 2.0
+        # An oval/slotted hole is bounded by the pad extent it sits in; taking
+        # the larger of drill radius and half pad size keeps a slot covered.
+        r = d / 2.0
+        rx = max(r, hx * c + hy * s)
+        ry = max(r, hx * s + hy * c)
+        xs += [p.local_x - rx, p.local_x + rx]
+        ys += [p.local_y - ry, p.local_y + ry]
+    if not xs:
+        return None
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
 def sides_occupied(side: str, has_tht: bool) -> frozenset:
     """The board sides a part physically obstructs."""
     return BOTH_SIDES if has_tht else frozenset((side,))
@@ -1098,7 +1152,6 @@ def part_local_bounds(pcb_data, pcb_file: Optional[str] = None
     `graded_parts_from_file` skips, so both consumers see one universe.
     """
     from placement.parser import courtyard_for_side, extract_courtyard_sides
-    from placement.quench import _through_pad_bounds_local
     from placement.utility import compute_footprint_bbox_local
 
     path = pcb_file or getattr(pcb_data, 'source_path', None)
@@ -1129,7 +1182,7 @@ def part_local_bounds(pcb_data, pcb_file: Optional[str] = None
         tht_local = None
         has_tht = footprint_has_through_pads(fp)
         if has_tht:
-            tht_local = _through_pad_bounds_local(fp)
+            tht_local = through_pad_bounds_local(fp)
         out[ref] = LocalBounds(ref=ref, side=own, local=tuple(local),
                                tht_local=(tuple(tht_local)
                                           if tht_local is not None else None),

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -236,10 +236,28 @@ def ring_is_rect(ring):
 
 # --- board side model --------------------------------------------------------
 
+def side_of_layer(layer) -> str:
+    """'F' or 'B' from a LAYER NAME. Anything not starting with 'B' is front.
+
+    THE string-level rule (#878). `footprint_side` below is this applied to an
+    object's `.layer`; every other site in the tree that carried its own copy
+    of the same collapse now calls one of the two, and
+    `tests/test_878_side_rule_sites.py` refuses a new copy rather than letting
+    a ninth appear.
+
+    `str(...)` where the old spelling had `or ''` is a widening, not a change:
+    the old form raised `AttributeError` on a truthy non-string layer, and every
+    caller in the tree passes a `str` or `None`. Measured across the 22 tracked
+    boards, 1406 footprints: exactly two distinct layer values (`F.Cu`, `B.Cu`)
+    and zero disagreements between this and the five expressions it replaces.
+    """
+    return 'B' if str(layer or '').startswith('B') else 'F'
+
+
 def footprint_side(fp) -> str:
     """'F' or 'B' from a footprint's layer. Anything not B.* reads as front,
     matching how the rest of the package resolves side from `fp.layer`."""
-    return 'B' if (getattr(fp, 'layer', '') or '').startswith('B') else 'F'
+    return side_of_layer(getattr(fp, 'layer', ''))
 
 
 def footprint_has_through_pads(fp) -> bool:

--- a/py_placer/placement/options.py
+++ b/py_placer/placement/options.py
@@ -323,9 +323,11 @@ def grow_board(pcb_data, pcb_file: str, *, clearance: float,
     # nothing changes, and that is not an oversight -- see `charged`.
     busiest = max(obstructed.values()) if obstructed else 0.0
     # #837. WHICH area the utilisation is computed from. `busiest` keeps its
-    # own meaning and its own key on both bases -- it is still the busiest
-    # side's area, and it stops being the number the verdict rests on rather
-    # than becoming a lie.
+    # own key on both bases and stops being the number the verdict rests on
+    # rather than becoming a lie. #878 changed WHAT it is the busiest of: the
+    # busiest OBSTRUCTED face, not the busiest populated one. It is still "the
+    # busiest side's area" only if that phrase means obstruction, which is why
+    # it is spelled out here rather than left to the reader.
     one_face = assembly_sides in ('F', 'B')
     # #878: `per_side`, deliberately, and it is the half of this that is easy
     # to get wrong. Under a one-face policy `sum(per_side)` is each part
@@ -345,10 +347,19 @@ def grow_board(pcb_data, pcb_file: str, *, clearance: float,
         'ran': True,
         'measured': {
             'part_area_mm2': round(total, 2),
-            # Both sides, and the one utilisation is computed from. Reported
-            # because `part_area_mm2` alone cannot be checked against
-            # `utilisation` on a two-sided board, and a reader who tries will
-            # conclude the number is wrong.
+            # Both sides, as POPULATED. Reported because `part_area_mm2` alone
+            # cannot be checked against `utilisation` on a two-sided board,
+            # and a reader who tries will conclude the number is wrong.
+            #
+            # #878: on the busiest basis `utilisation` is NO LONGER computed
+            # from this dict -- it comes from `obstructed_area_by_side_mm2`
+            # below, and the two differ on any board with a drilled part. This
+            # comment used to say "and the one utilisation is computed from",
+            # which after #878 sent a reader to the wrong key and produced
+            # exactly the disagreement the key exists to prevent
+            # (rp2350_fpga_eensy_prePlane: max(this)/usable is 0.6220 against a
+            # reported 0.6566). Reconcile against `obstructed_...` on the
+            # busiest basis and against this one under a declared `F`/`B`.
             'part_area_by_side_mm2': {k: round(v, 2)
                                       for k, v in sorted(per_side.items())},
             # #878. What each face is OBSTRUCTED by, which is not what each
@@ -412,12 +423,41 @@ def grow_board(pcb_data, pcb_file: str, *, clearance: float,
         # either. The one-face basis is deliberately untouched -- see
         # `charged` above. `tests/878_far_face_currency.json` is the sweep.
         'not_modelled': '; '.join(
-            [f'a through-hole part is charged {FAR_FACE_BASIS} on the far '
-             f'face, not its whole courtyard -- '
-             f'`check_pockets.courtyard_cover` charges the whole courtyard on '
-             f'both faces and the two per-face models still differ by that '
-             f'much (#878 charged the smaller one, which is the model the '
-             f'placement search itself enforces)']
+            # BASIS-SPECIFIC, because the far charge does not reach this
+            # board's number on every basis, and a blanket sentence would
+            # claim it does. #878's own pre-registered rule said the
+            # disclosure had to become basis-specific if a basis kept
+            # `none`; the one-face basis does, by the post-hoc finding above.
+            # And it is dropped entirely when the board has no drilled part:
+            # on qfn_interior_pads or routed_output the old wording claimed
+            # two models "differ by that much" when they differ by nothing.
+            ([] if not far_parts else
+             [f'a through-hole part is charged {FAR_FACE_BASIS}, not its '
+              f'whole courtyard -- `check_pockets.courtyard_cover` charges '
+              f'the whole courtyard on both faces, and the two per-face '
+              f'models differ by that much (#878 charged the smaller one, '
+              f'which is the model the placement search itself enforces)'
+              + (' -- and NONE of it reaches `utilisation` here, because a '
+                 'declared one-face policy charges each part exactly once on '
+                 'the face the fab populates, where the leads compete with '
+                 'nothing' if one_face else '')])
+            # The container blind spot, named rather than left to be found.
+            # A container is exempted BEFORE the far charge, and the same
+            # exemption is in the sweep that chose the currency -- so no arm
+            # of that measurement could see it. On rp2350_fpga_eensy_prePlane
+            # the excluded U8 is a through-hole module whose drilled-pad box
+            # equals its courtyard: 728.3 mm2 on the far face, 7x the whole
+            # board's reported far charge. Charging it would take that board
+            # to utilisation 1.60 and `fits_by_area` False, on hardware that
+            # ships. The near-face exemption's argument -- a frame hosts the
+            # parts inside it -- does NOT transfer to the far face, where
+            # nothing is hosted and the pins are real copper. So this is an
+            # open question, disclosed, not a settled one.
+            + ([] if not containers else
+               [f'the far-face area of {len(containers)} excluded container(s)'
+                f' ({", ".join(r for _a, r in sorted(containers, reverse=True))})'
+                f' -- they are exempted before the charge, and the #878 sweep'
+                f' shares that exemption, so it did not measure them'])
             + ([] if assembly_sides else [
                 'whether the back side will be POPULATED -- no assembly.sides '
                 'was declared, so the busier face is charged and back-side '

--- a/py_placer/placement/options.py
+++ b/py_placer/placement/options.py
@@ -145,6 +145,44 @@ def hosts_the_design(ref, gx0, gy0, gx1, gy1, fp, footprints) -> bool:
 _hosts_the_design = hosts_the_design
 
 
+#: WHICH rect a through-hole part presents on the face it is not mounted on
+#: (#878). Named once, so the arithmetic below and the disclosure string cannot
+#: drift apart -- they are the two halves of one claim.
+#:
+#: Decided by measurement, not preference: `tests/measure_878_far_face_area.py`
+#: swept three candidate currencies over the tracked corpus and its
+#: pre-registered rule selected this one. `legality.rect_on` is the only place
+#: in the tree where the far-face rect is DECIDED rather than sidestepped, and
+#: it answers the drilled-pad rect; `check_pockets.courtyard_cover` charges the
+#: whole courtyard, but it answers a per-window COVER question where summing
+#: never arises, so it is not a competing answer to this one. The measurement's
+#: falsifier: charging the whole courtyard makes flat_hierarchy's far charge
+#: equal its near charge part-for-part (64 of 64 pad-bearing parts drilled),
+#: which is the same area counted twice.
+FAR_FACE_BASIS = ('the drilled-pad rect, the same rect legality.rect_on '
+                  'presents on the far side')
+
+
+def _far_face_area(fp, clearance: float) -> float:
+    """mm2 a drilled part obstructs on the face it is NOT mounted on.
+
+    0.0 when the part reaches no other face. The SAME `+clearance` on each axis
+    as the near charge at `grow_board`'s `a = (w + clearance) * (h + clearance)`
+    -- charged differently, the two would not be commensurate and the per-side
+    sums could not be compared with each other or with `usable`.
+    """
+    from placement.legality import (footprint_has_through_pads,
+                                    rotate_local_bounds,
+                                    through_pad_bounds_local)
+    if not footprint_has_through_pads(fp):
+        return 0.0
+    tb = through_pad_bounds_local(fp)
+    if tb is None:      # same drill>0 predicate as the guard above; belt only
+        return 0.0
+    tx0, ty0, tx1, ty1 = rotate_local_bounds(*tb, fp.rotation or 0.0)
+    return (tx1 - tx0 + clearance) * (ty1 - ty0 + clearance)
+
+
 def grow_board(pcb_data, pcb_file: str, *, clearance: float,
                board_edge_clearance: float,
                assembly_sides: Optional[str] = None) -> Dict:
@@ -198,6 +236,16 @@ def grow_board(pcb_data, pcb_file: str, *, clearance: float,
                                     rotate_local_bounds)
     from placement.utility import compute_footprint_bbox_local
     per_side = {'F.Cu': 0.0, 'B.Cu': 0.0}
+    # #878. TWO dicts, because they answer two different questions and the
+    # tree needed both. `per_side` is the POPULATION charge -- each part once,
+    # on the face a reflow pass places it on -- and it is what the one-face
+    # sum below reads. `obstructed` is the OBSTRUCTION charge: a through-hole
+    # part's leads come out on the far face and block it there too, and that
+    # area was charged to NOBODY. `busiest` reads this one, because what a
+    # face can still hold is what is not already blocked on it.
+    obstructed = {'F.Cu': 0.0, 'B.Cu': 0.0}
+    far_area = 0.0
+    far_parts = 0
     containers = []
     outline_area = (x1 - x0) * (y1 - y0)
     for ref, fp in sorted(pcb_data.footprints.items()):
@@ -244,6 +292,22 @@ def grow_board(pcb_data, pcb_file: str, *, clearance: float,
         # per-side instrument in the tree read.
         layer = 'B.Cu' if footprint_side(fp) == 'B' else 'F.Cu'
         per_side[layer] = per_side.get(layer, 0.0) + a
+        # #878. `layer` again rather than a second `footprint_side` call: ONE
+        # side decision per part, so the near and far charges cannot land on
+        # inconsistent faces.
+        obstructed[layer] = obstructed.get(layer, 0.0) + a
+        far = _far_face_area(fp, clearance)
+        if far > 0.0:
+            other = 'F.Cu' if layer == 'B.Cu' else 'B.Cu'
+            obstructed[other] = obstructed.get(other, 0.0) + far
+            far_area += far
+            far_parts += 1
+        # NOT the far charge: `biggest` feeds `largest_parts_mm2`, which
+        # `smaller_footprint` ranks to answer "which part is big enough that
+        # its SIZE is the constraint". That is a question about a part's own
+        # body, so adding its leads' far-face area would charge the same part
+        # twice into a ranking, and move a report this change has no business
+        # moving.
         biggest.append((round(a, 2), ref))
     biggest.sort(reverse=True)
 
@@ -253,12 +317,27 @@ def grow_board(pcb_data, pcb_file: str, *, clearance: float,
     # against 1088.58 usable -- each side fits, their sum (1364.11, util
     # 1.2531) does not. A part on B.Cu does not compete for F.Cu area.
     # (ulx3s flips the same way, 1.3373 -> 0.9018.)
-    busiest = max(per_side.values()) if per_side else 0.0
+    # #878: the busiest side is the most OBSTRUCTED face, not the most
+    # POPULATED one. A face's remaining capacity is what is not already blocked
+    # on it, and a through-hole part blocks both. On the one-face basis below
+    # nothing changes, and that is not an oversight -- see `charged`.
+    busiest = max(obstructed.values()) if obstructed else 0.0
     # #837. WHICH area the utilisation is computed from. `busiest` keeps its
     # own meaning and its own key on both bases -- it is still the busiest
     # side's area, and it stops being the number the verdict rests on rather
     # than becoming a lie.
     one_face = assembly_sides in ('F', 'B')
+    # #878: `per_side`, deliberately, and it is the half of this that is easy
+    # to get wrong. Under a one-face policy `sum(per_side)` is each part
+    # EXACTLY ONCE -- the demand on the single face the fab populates. A
+    # through-hole part's leads come out on the face nobody populates, so they
+    # compete with nothing there, and adding them here would be the same area
+    # counted twice. Measured on the tracked corpus: charging the far face
+    # into this sum double-charges 10 of the 15 one-face boards, worst
+    # flat_hierarchy 5927.41 -> 9404.40 mm2. So the far charge lives in
+    # `busiest` alone. `tests/878_far_face_currency.json` records it as
+    # `post_hoc.one_face_charged_once`, which is True only when nothing is
+    # charged far.
     charged = sum(per_side.values()) if one_face else busiest
     util = (charged / usable) if usable > 0 else float('inf')
     fits = charged <= usable
@@ -272,7 +351,22 @@ def grow_board(pcb_data, pcb_file: str, *, clearance: float,
             # conclude the number is wrong.
             'part_area_by_side_mm2': {k: round(v, 2)
                                       for k, v in sorted(per_side.items())},
+            # #878. What each face is OBSTRUCTED by, which is not what each
+            # face is POPULATED with: a drilled part's leads block the far
+            # side. `part_area_by_side_mm2` above stays the population charge
+            # and still sums to `part_area_mm2`; this one does not, and the
+            # difference is exactly `far_face_area_mm2`.
+            'obstructed_area_by_side_mm2': {
+                k: round(v, 2) for k, v in sorted(obstructed.items())},
             'busiest_side_area_mm2': round(busiest, 2),
+            'far_face_area_mm2': round(far_area, 2),
+            'far_face_parts': far_parts,
+            # A STRING deliberately, so `_digest` skips it (its `else:
+            # continue`) and it can never take a slot in the text channel.
+            # The human channel for the basis is `not_modelled`, which
+            # `format_text` prints at option level -- the same split #837 made
+            # between the `charged_area_is_sum` bool and the prose.
+            'far_face_basis': FAR_FACE_BASIS,
             # #837: the area `utilisation` is ACTUALLY computed from, and a
             # BOOL saying which rule produced it. The bool is not a stylistic
             # choice -- `_digest` skips string values before it reaches the
@@ -300,18 +394,30 @@ def grow_board(pcb_data, pcb_file: str, *, clearance: float,
         # never sees it, and inside `measured` it printed nowhere). Every
         # other option puts it here for the same reason.
         #
-        # A through-hole part is charged to its footprint layer only; its
-        # leads occupy the far face and that area is not charged. Every other
-        # per-side instrument in the tree charges a drilled part to both faces
-        # -- and they do not agree with each other about HOW
-        # (`check_pockets.courtyard_cover` charges the whole courtyard,
-        # `floorplan.rule_keepout` charges the courtyard near and the
-        # through-pad rect far), so picking one is its own measurement rather
-        # than a ride-along on this one. Deliberately deferred: 17 of the 22
-        # tracked boards carry through-hole parts, but under the busiest-side
-        # basis the fix moves `busiest` on 2 of them and flips no verdict.
+        # #878, and what is left after it. A through-hole part's leads ARE now
+        # charged on the far face, at `FAR_FACE_BASIS` -- the drilled-pad rect,
+        # the model `legality.rect_on` already enforces for the placement
+        # search. What remains not-modelled is the DISAGREEMENT: the other
+        # per-face instrument, `check_pockets.courtyard_cover`, charges the
+        # whole courtyard on both faces instead, and the two still differ by
+        # that amount. (The issue's own table also named
+        # `floorplan.rule_keepout` as a third model; it is not one -- it uses
+        # `part.sides` only to BIND which keep-outs apply, then hands
+        # `keepout_hit` both rects and takes a max, consulting no side.)
+        #
+        # 17 of the 22 tracked boards carry through-hole parts. Measured on
+        # the busiest-side basis, this moves `busiest` on ONE of them
+        # (rp2350_fpga_eensy_prePlane, utilisation 0.6220 -> 0.6566) and flips
+        # no verdict; the whole-courtyard alternative moves two and flips none
+        # either. The one-face basis is deliberately untouched -- see
+        # `charged` above. `tests/878_far_face_currency.json` is the sweep.
         'not_modelled': '; '.join(
-            ['through-hole leads on the far face are not charged']
+            [f'a through-hole part is charged {FAR_FACE_BASIS} on the far '
+             f'face, not its whole courtyard -- '
+             f'`check_pockets.courtyard_cover` charges the whole courtyard on '
+             f'both faces and the two per-face models still differ by that '
+             f'much (#878 charged the smaller one, which is the model the '
+             f'placement search itself enforces)']
             + ([] if assembly_sides else [
                 'whether the back side will be POPULATED -- no assembly.sides '
                 'was declared, so the busier face is charged and back-side '

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -51,6 +51,7 @@ from placement import legality
 from placement.legality import (CONTAINER_RATIO, CONTAINMENT_FRAC,
                                 BoardOutlineGate, containment_frac,
                                 footprint_has_through_pads,
+                                through_pad_bounds_local,
                                 footprint_side, pair_min_gap, rect_gap,
                                 rect_overlap_area,
                                 rotate_local_bounds, sides_occupied)
@@ -574,49 +575,6 @@ def _count_crossings_within(a: np.ndarray,
     return half, weighted / 2.0
 
 
-def _through_pad_bounds_local(fp):
-    """Local bbox over a footprint's DRILLED pads, or None if it has none.
-
-    This is the footprint's footprint on the OPPOSITE board side: its body and
-    courtyard live on its own side, but its leads pass through, so a part on the
-    far side may not sit inside this box (#456 item 1). Deliberately the drill
-    hole's own extent rather than the pad copper's -- the far side sees the
-    barrel and the lead, and the annular ring on that side is part of it.
-    """
-    # `local_x/local_y` is the pad ANCHOR in the footprint's frame, and for a
-    # drilled pad the anchor IS the hole: kicad_parser records hole_x/hole_y as
-    # the pre-offset position and only then shifts global_x/global_y to the
-    # copper centre. So the hole needs no offset correction at all -- an earlier
-    # version "corrected" local_* by (hole - global), which is minus the offset,
-    # landing the box one full offset on the WRONG side of the hole.
-    #
-    # size_x/size_y are BOARD-axis resolved (kicad_parser swaps them for a pad at
-    # ~90 degrees), so they cannot be used as local half-extents directly -- that
-    # transposed the box on every 90/270-degree footprint (kit-dev SW_ONOFF201
-    # modelled 2.54 x 13.97 where the truth is 3.81 x 12.70, under-blocking
-    # 1.27mm). Project them through the pad's local tilt exactly as
-    # placement/utility.compute_footprint_bbox_local does.
-    xs, ys = [], []
-    for p in (fp.pads or []):
-        d = getattr(p, 'drill', 0) or 0
-        if d <= 0:
-            continue
-        local_tilt = math.radians((getattr(p, 'rect_rotation', 0.0) or 0.0)
-                                  + (fp.rotation or 0.0))
-        c, s = abs(math.cos(local_tilt)), abs(math.sin(local_tilt))
-        hx, hy = (getattr(p, 'size_x', 0) or 0) / 2.0, (getattr(p, 'size_y', 0) or 0) / 2.0
-        # An oval/slotted hole is bounded by the pad extent it sits in; taking
-        # the larger of drill radius and half pad size keeps a slot covered.
-        r = d / 2.0
-        rx = max(r, hx * c + hy * s)
-        ry = max(r, hx * s + hy * c)
-        xs += [p.local_x - rx, p.local_x + rx]
-        ys += [p.local_y - ry, p.local_y + ry]
-    if not xs:
-        return None
-    return (min(xs), min(ys), max(xs), max(ys))
-
-
 class _Part:
     __slots__ = ('ref', 'pads_local', 'pin_count', 'bounds_by_rot',
                  'seed_x', 'seed_y', 'x', 'y', 'rot', 'locked',
@@ -638,7 +596,7 @@ class _Part:
         if lb is None:
             lb = compute_footprint_bbox_local(fp)
         self.bounds_by_rot = {r: _rotate_local_bounds(*lb, r) for r in ROTATIONS}
-        tlb = _through_pad_bounds_local(fp) if self.has_tht else None
+        tlb = through_pad_bounds_local(fp) if self.has_tht else None
         self.tht_by_rot = ({r: _rotate_local_bounds(*tlb, r) for r in ROTATIONS}
                            if tlb is not None else None)
         # A non-90-degree seed rotation brings its WHOLE 90-degree lattice:

--- a/py_placer/placement/writer.py
+++ b/py_placer/placement/writer.py
@@ -642,7 +642,12 @@ def _flip_graphic(node: str, head: str, ref: str) -> str:
     return node
 
 
+# #878: the rule itself lives in `legality`; this module reads it off
+# raw text rather than off a parsed object, which is why it keeps its
+# own function and only the collapse is shared. `legality`'s module
+# scope is `math` + `typing`, so this edge introduces no cycle.
 def _block_side(fp_text: str) -> str:
+    from placement.legality import side_of_layer
     """'F' or 'B' from the block's own `(layer ...)`.
 
     The same first-character rule `legality.footprint_side` applies to the
@@ -650,7 +655,7 @@ def _block_side(fp_text: str) -> str:
     cannot disagree about what a block says it is.
     """
     m = re.search(r'\(layer\s+"([^"]+)"\)', fp_text)
-    return 'B' if (m and m.group(1).startswith('B')) else 'F'
+    return side_of_layer(m.group(1) if m else '')
 
 
 def _flip_footprint_block(fp_text: str, ref: str, old_rot: float,

--- a/py_placer/placement/writer.py
+++ b/py_placer/placement/writer.py
@@ -647,13 +647,18 @@ def _flip_graphic(node: str, head: str, ref: str) -> str:
 # own function and only the collapse is shared. `legality`'s module
 # scope is `math` + `typing`, so this edge introduces no cycle.
 def _block_side(fp_text: str) -> str:
-    from placement.legality import side_of_layer
     """'F' or 'B' from the block's own `(layer ...)`.
 
     The same first-character rule `legality.footprint_side` applies to the
     parsed object, read here off the text so the writer and the side model
-    cannot disagree about what a block says it is.
+    cannot disagree about what a block says it is. Since #878 it CALLS that
+    rule (`legality.side_of_layer`) rather than spelling it again, so the
+    sentence above is structural instead of a promise two copies must keep.
     """
+    # Below the docstring, deliberately: an import placed above it makes the
+    # string a discarded expression and `__doc__` None, which is how this
+    # function silently lost its documentation once already.
+    from placement.legality import side_of_layer
     m = re.search(r'\(layer\s+"([^"]+)"\)', fp_text)
     return side_of_layer(m.group(1) if m else '')
 

--- a/py_tools/render_placement.py
+++ b/py_tools/render_placement.py
@@ -1827,9 +1827,15 @@ def main(argv=None):
             print(f"No placement blocks from sources {args.group_by!r}.")
             return 0
         print(f"{len(blocks)} placement block(s) from {args.group_by!r}:")
+        # #878: the CANONICAL side rule, not a fourth copy of it. NOT
+        # `sides_occupied` -- that answers which faces a part OBSTRUCTS, so a
+        # through-hole part counts on both, and splitflap_driver (65 parts, all
+        # on F.Cu, 24 of them drilled) would report 24 back-side parts and get
+        # a B-side panel drawn for a board with nothing on its back.
+        from placement.legality import footprint_side
         for n, refs in sorted(blocks.items(), key=lambda kv: (-len(kv[1]), kv[0])):
             back = sum(1 for r in refs
-                       if (pcb.footprints[r].layer or '').startswith('B'))
+                       if footprint_side(pcb.footprints[r]) == 'B')
             print(f"  {short_name(n):34s} parts={len(refs):3d}  "
                   f"front={len(refs) - back:3d} back={back:3d}")
         return 0
@@ -1969,8 +1975,12 @@ def main(argv=None):
     # exactly how run 5's JP1(B)-under-SW1(F) -- correct, identical on the
     # human board -- read as an overlap to the human eye. --per-side keeps
     # forcing panels; --flat restores the old single view.
+    # #878: the canonical rule. Deliberately NOT `sides_occupied` -- see the
+    # note at --list-groups above; it would force a B-side panel onto
+    # splitflap_driver, which has nothing on its back.
+    from placement.legality import footprint_side
     back = sum(1 for fp in pcb.footprints.values()
-               if (fp.layer or '').startswith('B'))
+               if footprint_side(fp) == 'B')
     want_sides = args.per_side or (back > 0 and not args.flat)
     sides = ('F', 'B') if want_sides else (None,)
     if args.per_side and back == 0 \

--- a/tests/878_far_face_currency.json
+++ b/tests/878_far_face_currency.json
@@ -1898,7 +1898,19 @@
   ],
   "nc2_mismatches": []
  },
- "engine_sha": "c487e00ff88e8d7709de9b5b55fe6f9562ea4408",
+ "engine_sha": "c9c9c2cd61acfbbbecaaaf126ef3fb638b54c696",
+ "engine_tree_dirty": true,
+ "engine_tree_dirty_files": [
+  "py_placer/placement/options.py",
+  "py_placer/placement/writer.py",
+  "tests/878_far_face_currency.json",
+  "tests/measure_878_far_face_area.py",
+  "tests/mutate_837.py",
+  "tests/test_878_far_face_currency.py",
+  "tests/test_878_side_rule_sites.py",
+  "tests/test_capacity_options.py",
+  "y_placer/placement/legality.py"
+ ],
  "headline": {
   "double": {
    "busiest.courtyard": [

--- a/tests/878_far_face_currency.json
+++ b/tests/878_far_face_currency.json
@@ -1886,7 +1886,7 @@
   "courtyard_sides_drawn": 2
  },
  "control": {
-  "nc1_fields_per_row": 8,
+  "nc1_fields_per_row": 9,
   "nc1_mismatches": [],
   "nc1_rows": 37,
   "nc2_boards": [
@@ -1898,7 +1898,7 @@
   ],
   "nc2_mismatches": []
  },
- "engine_sha": "b58d5924f3644576634d29600d53502f16ab0d9a",
+ "engine_sha": "c487e00ff88e8d7709de9b5b55fe6f9562ea4408",
  "headline": {
   "double": {
    "busiest.courtyard": [

--- a/tests/878_far_face_currency.json
+++ b/tests/878_far_face_currency.json
@@ -1,0 +1,2785 @@
+{
+ "basis": {
+  "board_edge_clearance": 0.5,
+  "board_edge_clearance_sensitivity": 0.55,
+  "clearance": 0.2,
+  "corpus": "run_utils.corpus_boards() -- the git-TRACKED set",
+  "n_boards": 22
+ },
+ "boards": {
+  "cap_chain": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 51.57,
+      "far_charge_mm2": 47.05,
+      "far_over_near": 0.9123,
+      "fits_by_area": true,
+      "utilisation": 0.1086
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 51.57,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1086
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 51.57,
+      "far_charge_mm2": 16.87,
+      "far_over_near": 0.3271,
+      "fits_by_area": true,
+      "utilisation": 0.1086
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 98.62,
+      "far_charge_mm2": 47.05,
+      "far_over_near": 0.9123,
+      "fits_by_area": true,
+      "utilisation": 0.2076
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 51.57,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1086
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 68.45,
+      "far_charge_mm2": 16.87,
+      "far_over_near": 0.3271,
+      "fits_by_area": true,
+      "utilisation": 0.1441
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 98.62,
+      "far_charge_mm2": 47.05,
+      "far_over_near": 0.9123,
+      "fits_by_area": true,
+      "utilisation": 0.2076
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 51.57,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1086
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 68.45,
+      "far_charge_mm2": 16.87,
+      "far_over_near": 0.3271,
+      "fits_by_area": true,
+      "utilisation": 0.1441
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 4,
+   "through_hole_plated": 2,
+   "tht_obstructing": 2,
+   "usable_area_mm2": 475.0
+  },
+  "esp_prog": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 215.46,
+      "far_charge_mm2": 100.21,
+      "far_over_near": 0.4651,
+      "fits_by_area": true,
+      "utilisation": 0.519
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 215.46,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.519
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 215.46,
+      "far_charge_mm2": 93.76,
+      "far_over_near": 0.4352,
+      "fits_by_area": true,
+      "utilisation": 0.519
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 315.68,
+      "far_charge_mm2": 100.21,
+      "far_over_near": 0.4651,
+      "fits_by_area": true,
+      "utilisation": 0.7604
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 215.46,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.519
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 309.23,
+      "far_charge_mm2": 93.76,
+      "far_over_near": 0.4352,
+      "fits_by_area": true,
+      "utilisation": 0.7449
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 315.68,
+      "far_charge_mm2": 100.21,
+      "far_over_near": 0.4651,
+      "fits_by_area": true,
+      "utilisation": 0.7604
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 215.46,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.519
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 309.23,
+      "far_charge_mm2": 93.76,
+      "far_over_near": 0.4352,
+      "fits_by_area": true,
+      "utilisation": 0.7449
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 18,
+   "through_hole_plated": 3,
+   "tht_obstructing": 3,
+   "usable_area_mm2": 415.12
+  },
+  "flat_hierarchy": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 5927.41,
+      "far_charge_mm2": 5927.41,
+      "far_over_near": 1.0,
+      "fits_by_area": true,
+      "utilisation": 0.3801
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 5927.41,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.3801
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 5927.41,
+      "far_charge_mm2": 3476.99,
+      "far_over_near": 0.5866,
+      "fits_by_area": true,
+      "utilisation": 0.3801
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 11854.82,
+      "far_charge_mm2": 5927.41,
+      "far_over_near": 1.0,
+      "fits_by_area": true,
+      "utilisation": 0.7602
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 5927.41,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.3801
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 9404.4,
+      "far_charge_mm2": 3476.99,
+      "far_over_near": 0.5866,
+      "fits_by_area": true,
+      "utilisation": 0.6031
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 11854.82,
+      "far_charge_mm2": 5927.41,
+      "far_over_near": 1.0,
+      "fits_by_area": true,
+      "utilisation": 0.7602
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 5927.41,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.3801
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 9404.4,
+      "far_charge_mm2": 3476.99,
+      "far_over_near": 0.5866,
+      "fits_by_area": true,
+      "utilisation": 0.6031
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 64,
+   "through_hole_plated": 58,
+   "tht_obstructing": 64,
+   "usable_area_mm2": 15593.5
+  },
+  "glasgow_revC": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 3047.11,
+      "far_charge_mm2": 1887.28,
+      "far_over_near": 0.5654,
+      "fits_by_area": true,
+      "utilisation": 0.8036
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 3047.11,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.8036
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 3047.11,
+      "far_charge_mm2": 642.04,
+      "far_over_near": 0.1923,
+      "fits_by_area": true,
+      "utilisation": 0.8036
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 5225.47,
+      "far_charge_mm2": 1887.28,
+      "far_over_near": 0.5654,
+      "fits_by_area": false,
+      "utilisation": 1.3781
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 3338.2,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.8804
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 3980.24,
+      "far_charge_mm2": 642.04,
+      "far_over_near": 0.1923,
+      "fits_by_area": false,
+      "utilisation": 1.0497
+     }
+    },
+    "one_face_observed": null
+   },
+   "census_sides": "both",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": true,
+   "pad_bearing_B": 92,
+   "parts_charged": 264,
+   "through_hole_plated": 17,
+   "tht_obstructing": 18,
+   "usable_area_mm2": 3791.77
+  },
+  "haasoscope_pro_max_test": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 8,
+   "through_hole_plated": 0,
+   "tht_obstructing": 0,
+   "usable_area_mm2": 6111.61
+  },
+  "interf_u_unrouted": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 6045.77,
+      "far_charge_mm2": 5307.93,
+      "far_over_near": 0.878,
+      "fits_by_area": true,
+      "utilisation": 0.4922
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 6045.77,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.4922
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 6045.77,
+      "far_charge_mm2": 3336.86,
+      "far_over_near": 0.5519,
+      "fits_by_area": true,
+      "utilisation": 0.4922
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 11353.71,
+      "far_charge_mm2": 5307.93,
+      "far_over_near": 0.878,
+      "fits_by_area": true,
+      "utilisation": 0.9244
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 6045.77,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.4922
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 9382.64,
+      "far_charge_mm2": 3336.86,
+      "far_over_near": 0.5519,
+      "fits_by_area": true,
+      "utilisation": 0.7639
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 11353.71,
+      "far_charge_mm2": 5307.93,
+      "far_over_near": 0.878,
+      "fits_by_area": true,
+      "utilisation": 0.9244
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 6045.77,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.4922
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 9382.64,
+      "far_charge_mm2": 3336.86,
+      "far_over_near": 0.5519,
+      "fits_by_area": true,
+      "utilisation": 0.7639
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 1,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 24,
+   "through_hole_plated": 23,
+   "tht_obstructing": 23,
+   "usable_area_mm2": 12282.36
+  },
+  "interf_u_unrouted_placed": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 6045.77,
+      "far_charge_mm2": 5307.93,
+      "far_over_near": 0.878,
+      "fits_by_area": true,
+      "utilisation": 0.4922
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 6045.77,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.4922
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 6045.77,
+      "far_charge_mm2": 3336.86,
+      "far_over_near": 0.5519,
+      "fits_by_area": true,
+      "utilisation": 0.4922
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 11353.71,
+      "far_charge_mm2": 5307.93,
+      "far_over_near": 0.878,
+      "fits_by_area": true,
+      "utilisation": 0.9244
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 6045.77,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.4922
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 9382.64,
+      "far_charge_mm2": 3336.86,
+      "far_over_near": 0.5519,
+      "fits_by_area": true,
+      "utilisation": 0.7639
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 11353.71,
+      "far_charge_mm2": 5307.93,
+      "far_over_near": 0.878,
+      "fits_by_area": true,
+      "utilisation": 0.9244
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 6045.77,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.4922
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 9382.64,
+      "far_charge_mm2": 3336.86,
+      "far_over_near": 0.5519,
+      "fits_by_area": true,
+      "utilisation": 0.7639
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 1,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 24,
+   "through_hole_plated": 23,
+   "tht_obstructing": 23,
+   "usable_area_mm2": 12282.36
+  },
+  "kit-dev-coldfire-xilinx_5213": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 7771.44,
+      "far_charge_mm2": 5473.34,
+      "far_over_near": 0.6946,
+      "fits_by_area": true,
+      "utilisation": 0.5491
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 7771.44,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.5491
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 7771.44,
+      "far_charge_mm2": 2054.17,
+      "far_over_near": 0.2607,
+      "fits_by_area": true,
+      "utilisation": 0.5491
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 13353.65,
+      "far_charge_mm2": 5473.34,
+      "far_over_near": 0.6946,
+      "fits_by_area": true,
+      "utilisation": 0.9436
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 7880.31,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.5568
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 9934.48,
+      "far_charge_mm2": 2054.17,
+      "far_over_near": 0.2607,
+      "fits_by_area": true,
+      "utilisation": 0.702
+     }
+    },
+    "one_face_observed": null
+   },
+   "census_sides": "both",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": true,
+   "pad_bearing_B": 14,
+   "parts_charged": 160,
+   "through_hole_plated": 41,
+   "tht_obstructing": 41,
+   "usable_area_mm2": 14152.05
+  },
+  "lvds_converter_dualclk": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 411.13,
+      "far_charge_mm2": 160.97,
+      "far_over_near": 0.3915,
+      "fits_by_area": true,
+      "utilisation": 0.2468
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 411.13,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.2468
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 411.13,
+      "far_charge_mm2": 74.78,
+      "far_over_near": 0.1819,
+      "fits_by_area": true,
+      "utilisation": 0.2468
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 572.1,
+      "far_charge_mm2": 160.97,
+      "far_over_near": 0.3915,
+      "fits_by_area": true,
+      "utilisation": 0.3434
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 411.13,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.2468
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 485.92,
+      "far_charge_mm2": 74.78,
+      "far_over_near": 0.1819,
+      "fits_by_area": true,
+      "utilisation": 0.2917
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 572.1,
+      "far_charge_mm2": 160.97,
+      "far_over_near": 0.3915,
+      "fits_by_area": true,
+      "utilisation": 0.3434
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 411.13,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.2468
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 485.92,
+      "far_charge_mm2": 74.78,
+      "far_over_near": 0.1819,
+      "fits_by_area": true,
+      "utilisation": 0.2917
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 13,
+   "through_hole_plated": 2,
+   "tht_obstructing": 2,
+   "usable_area_mm2": 1666.0
+  },
+  "lvds_converter_dualclk_gnd": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 411.13,
+      "far_charge_mm2": 160.97,
+      "far_over_near": 0.3915,
+      "fits_by_area": true,
+      "utilisation": 0.2468
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 411.13,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.2468
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 411.13,
+      "far_charge_mm2": 74.78,
+      "far_over_near": 0.1819,
+      "fits_by_area": true,
+      "utilisation": 0.2468
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 572.1,
+      "far_charge_mm2": 160.97,
+      "far_over_near": 0.3915,
+      "fits_by_area": true,
+      "utilisation": 0.3434
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 411.13,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.2468
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 485.92,
+      "far_charge_mm2": 74.78,
+      "far_over_near": 0.1819,
+      "fits_by_area": true,
+      "utilisation": 0.2917
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 572.1,
+      "far_charge_mm2": 160.97,
+      "far_over_near": 0.3915,
+      "fits_by_area": true,
+      "utilisation": 0.3434
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 411.13,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.2468
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 485.92,
+      "far_charge_mm2": 74.78,
+      "far_over_near": 0.1819,
+      "fits_by_area": true,
+      "utilisation": 0.2917
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 13,
+   "through_hole_plated": 2,
+   "tht_obstructing": 2,
+   "usable_area_mm2": 1666.0
+  },
+  "orangecrab_ext_pll": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 999.94,
+      "far_charge_mm2": 385.35,
+      "far_over_near": 0.2825,
+      "fits_by_area": true,
+      "utilisation": 0.9186
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 999.94,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.9186
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 999.94,
+      "far_charge_mm2": 245.11,
+      "far_over_near": 0.1797,
+      "fits_by_area": true,
+      "utilisation": 0.9186
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1749.46,
+      "far_charge_mm2": 385.35,
+      "far_over_near": 0.2825,
+      "fits_by_area": false,
+      "utilisation": 1.6071
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1364.11,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": false,
+      "utilisation": 1.2531
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1609.22,
+      "far_charge_mm2": 245.11,
+      "far_over_near": 0.1797,
+      "fits_by_area": false,
+      "utilisation": 1.4783
+     }
+    },
+    "one_face_observed": null
+   },
+   "census_sides": "both",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "B",
+   "declared_is_hypothetical": true,
+   "pad_bearing_B": 83,
+   "parts_charged": 164,
+   "through_hole_plated": 6,
+   "tht_obstructing": 8,
+   "usable_area_mm2": 1088.58
+  },
+  "qfn_csi_underpad_diff": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 113.05,
+      "far_charge_mm2": 42.49,
+      "far_over_near": 0.3758,
+      "fits_by_area": true,
+      "utilisation": 0.1385
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 113.05,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1385
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 113.05,
+      "far_charge_mm2": 18.09,
+      "far_over_near": 0.16,
+      "fits_by_area": true,
+      "utilisation": 0.1385
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 155.53,
+      "far_charge_mm2": 42.49,
+      "far_over_near": 0.3758,
+      "fits_by_area": true,
+      "utilisation": 0.1906
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 113.05,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1385
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 131.13,
+      "far_charge_mm2": 18.09,
+      "far_over_near": 0.16,
+      "fits_by_area": true,
+      "utilisation": 0.1607
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 155.53,
+      "far_charge_mm2": 42.49,
+      "far_over_near": 0.3758,
+      "fits_by_area": true,
+      "utilisation": 0.1906
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 113.05,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1385
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 131.13,
+      "far_charge_mm2": 18.09,
+      "far_over_near": 0.16,
+      "fits_by_area": true,
+      "utilisation": 0.1607
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 2,
+   "through_hole_plated": 1,
+   "tht_obstructing": 1,
+   "usable_area_mm2": 816.0
+  },
+  "qfn_diffpair_escape": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 1,
+   "through_hole_plated": 0,
+   "tht_obstructing": 0,
+   "usable_area_mm2": 361.0
+  },
+  "qfn_interior_pads": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 1,
+   "through_hole_plated": 0,
+   "tht_obstructing": 0,
+   "usable_area_mm2": 361.0
+  },
+  "qfn_underpad_coupling": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 41.73,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1156
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 1,
+   "through_hole_plated": 0,
+   "tht_obstructing": 0,
+   "usable_area_mm2": 361.0
+  },
+  "routed_output": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1168.6,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.1912
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 8,
+   "through_hole_plated": 0,
+   "tht_obstructing": 0,
+   "usable_area_mm2": 6111.61
+  },
+  "rp2350_fpga_eensy_prePlane": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 393.58,
+      "far_charge_mm2": 205.08,
+      "far_over_near": 0.4171,
+      "fits_by_area": true,
+      "utilisation": 0.6737
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 363.34,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.622
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 383.55,
+      "far_charge_mm2": 98.83,
+      "far_over_near": 0.201,
+      "fits_by_area": true,
+      "utilisation": 0.6566
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 696.74,
+      "far_charge_mm2": 205.08,
+      "far_over_near": 0.4171,
+      "fits_by_area": false,
+      "utilisation": 1.1927
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 491.66,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.8416
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 590.49,
+      "far_charge_mm2": 98.83,
+      "far_over_near": 0.201,
+      "fits_by_area": false,
+      "utilisation": 1.0108
+     }
+    },
+    "one_face_observed": null
+   },
+   "census_sides": "both",
+   "containers_excluded": [
+    "U8"
+   ],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": true,
+   "pad_bearing_B": 4,
+   "parts_charged": 60,
+   "through_hole_plated": 3,
+   "tht_obstructing": 3,
+   "usable_area_mm2": 584.18
+  },
+  "sonde_u": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 2230.95,
+      "far_charge_mm2": 1218.8,
+      "far_over_near": 0.4309,
+      "fits_by_area": true,
+      "utilisation": 0.6661
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 2230.95,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.6661
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 2230.95,
+      "far_charge_mm2": 769.08,
+      "far_over_near": 0.2719,
+      "fits_by_area": true,
+      "utilisation": 0.6661
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 4047.34,
+      "far_charge_mm2": 1218.8,
+      "far_over_near": 0.4309,
+      "fits_by_area": false,
+      "utilisation": 1.2085
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 2828.55,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.8446
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 3597.63,
+      "far_charge_mm2": 769.08,
+      "far_over_near": 0.2719,
+      "fits_by_area": false,
+      "utilisation": 1.0742
+     }
+    },
+    "one_face_observed": null
+   },
+   "census_sides": "both",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": true,
+   "pad_bearing_B": 1,
+   "parts_charged": 25,
+   "through_hole_plated": 23,
+   "tht_obstructing": 23,
+   "usable_area_mm2": 3349.09
+  },
+  "splitflap_driver": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 2936.52,
+      "far_charge_mm2": 1857.42,
+      "far_over_near": 0.6325,
+      "fits_by_area": true,
+      "utilisation": 0.5053
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 2936.52,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.5053
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 2936.52,
+      "far_charge_mm2": 558.34,
+      "far_over_near": 0.1901,
+      "fits_by_area": true,
+      "utilisation": 0.5053
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 4793.93,
+      "far_charge_mm2": 1857.42,
+      "far_over_near": 0.6325,
+      "fits_by_area": true,
+      "utilisation": 0.825
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 2936.52,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.5053
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 3494.86,
+      "far_charge_mm2": 558.34,
+      "far_over_near": 0.1901,
+      "fits_by_area": true,
+      "utilisation": 0.6014
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 4793.93,
+      "far_charge_mm2": 1857.42,
+      "far_over_near": 0.6325,
+      "fits_by_area": true,
+      "utilisation": 0.825
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 2936.52,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.5053
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 3494.86,
+      "far_charge_mm2": 558.34,
+      "far_over_near": 0.1901,
+      "fits_by_area": true,
+      "utilisation": 0.6014
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 65,
+   "through_hole_plated": 22,
+   "tht_obstructing": 24,
+   "usable_area_mm2": 5811.1
+  },
+  "tigard": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1407.62,
+      "far_charge_mm2": 792.85,
+      "far_over_near": 0.5558,
+      "fits_by_area": true,
+      "utilisation": 0.6952
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1407.62,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.6952
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1407.62,
+      "far_charge_mm2": 353.33,
+      "far_over_near": 0.2477,
+      "fits_by_area": true,
+      "utilisation": 0.6952
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 2219.37,
+      "far_charge_mm2": 792.85,
+      "far_over_near": 0.5558,
+      "fits_by_area": false,
+      "utilisation": 1.0961
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1426.52,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.7045
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 1779.85,
+      "far_charge_mm2": 353.33,
+      "far_over_near": 0.2477,
+      "fits_by_area": true,
+      "utilisation": 0.879
+     }
+    },
+    "one_face_observed": null
+   },
+   "census_sides": "both",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": true,
+   "pad_bearing_B": 2,
+   "parts_charged": 89,
+   "through_hole_plated": 8,
+   "tht_obstructing": 12,
+   "usable_area_mm2": 2024.79
+  },
+  "ulx3s": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "B.Cu",
+      "charged_area_mm2": 4226.53,
+      "far_charge_mm2": 2209.87,
+      "far_over_near": 0.3569,
+      "fits_by_area": true,
+      "utilisation": 0.9128
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 4175.64,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.9018
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 4175.64,
+      "far_charge_mm2": 819.34,
+      "far_over_near": 0.1323,
+      "fits_by_area": true,
+      "utilisation": 0.9018
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "B.Cu",
+      "charged_area_mm2": 8402.17,
+      "far_charge_mm2": 2209.87,
+      "far_over_near": 0.3569,
+      "fits_by_area": false,
+      "utilisation": 1.8146
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 6192.3,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": false,
+      "utilisation": 1.3373
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 7011.64,
+      "far_charge_mm2": 819.34,
+      "far_over_near": 0.1323,
+      "fits_by_area": false,
+      "utilisation": 1.5143
+     }
+    },
+    "one_face_observed": null
+   },
+   "census_sides": "both",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "B",
+   "declared_is_hypothetical": true,
+   "pad_bearing_B": 163,
+   "parts_charged": 226,
+   "through_hole_plated": 11,
+   "tht_obstructing": 12,
+   "usable_area_mm2": 4630.4
+  },
+  "watchy": {
+   "arms": {
+    "busiest": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 739.8,
+      "far_charge_mm2": 169.87,
+      "far_over_near": 0.2296,
+      "fits_by_area": true,
+      "utilisation": 0.5018
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 739.8,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.5018
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 739.8,
+      "far_charge_mm2": 48.71,
+      "far_over_near": 0.0658,
+      "fits_by_area": true,
+      "utilisation": 0.5018
+     }
+    },
+    "one_face_declared": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 909.67,
+      "far_charge_mm2": 169.87,
+      "far_over_near": 0.2296,
+      "fits_by_area": true,
+      "utilisation": 0.617
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 739.8,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.5018
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 788.51,
+      "far_charge_mm2": 48.71,
+      "far_over_near": 0.0658,
+      "fits_by_area": true,
+      "utilisation": 0.5348
+     }
+    },
+    "one_face_observed": {
+     "courtyard": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 909.67,
+      "far_charge_mm2": 169.87,
+      "far_over_near": 0.2296,
+      "fits_by_area": true,
+      "utilisation": 0.617
+     },
+     "none": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 739.8,
+      "far_charge_mm2": 0.0,
+      "far_over_near": 0.0,
+      "fits_by_area": true,
+      "utilisation": 0.5018
+     },
+     "tht": {
+      "binding_side": "F.Cu",
+      "charged_area_mm2": 788.51,
+      "far_charge_mm2": 48.71,
+      "far_over_near": 0.0658,
+      "fits_by_area": true,
+      "utilisation": 0.5348
+     }
+    }
+   },
+   "census_sides": "F",
+   "containers_excluded": [],
+   "courtyard_sides_differ": 0,
+   "courtyard_sides_drawn": 0,
+   "declared_face": "F",
+   "declared_is_hypothetical": false,
+   "pad_bearing_B": 0,
+   "parts_charged": 84,
+   "through_hole_plated": 1,
+   "tht_obstructing": 5,
+   "usable_area_mm2": 1474.31
+  }
+ },
+ "confound": {
+  "courtyard_sides_differ": 0,
+  "courtyard_sides_drawn": 2
+ },
+ "control": {
+  "nc1_fields_per_row": 8,
+  "nc1_mismatches": [],
+  "nc1_rows": 37,
+  "nc2_boards": [
+   "haasoscope_pro_max_test",
+   "qfn_diffpair_escape",
+   "qfn_interior_pads",
+   "qfn_underpad_coupling",
+   "routed_output"
+  ],
+  "nc2_mismatches": []
+ },
+ "engine_sha": "b58d5924f3644576634d29600d53502f16ab0d9a",
+ "headline": {
+  "double": {
+   "busiest.courtyard": [
+    [
+     "flat_hierarchy",
+     1.0
+    ],
+    [
+     "cap_chain",
+     0.9123
+    ],
+    [
+     "interf_u_unrouted",
+     0.878
+    ],
+    [
+     "interf_u_unrouted_placed",
+     0.878
+    ],
+    [
+     "kit-dev-coldfire-xilinx_5213",
+     0.6946
+    ],
+    [
+     "splitflap_driver",
+     0.6325
+    ],
+    [
+     "glasgow_revC",
+     0.5654
+    ],
+    [
+     "tigard",
+     0.5558
+    ],
+    [
+     "esp_prog",
+     0.4651
+    ],
+    [
+     "sonde_u",
+     0.4309
+    ],
+    [
+     "rp2350_fpga_eensy_prePlane",
+     0.4171
+    ],
+    [
+     "lvds_converter_dualclk",
+     0.3915
+    ],
+    [
+     "lvds_converter_dualclk_gnd",
+     0.3915
+    ],
+    [
+     "qfn_csi_underpad_diff",
+     0.3758
+    ],
+    [
+     "ulx3s",
+     0.3569
+    ],
+    [
+     "orangecrab_ext_pll",
+     0.2825
+    ],
+    [
+     "watchy",
+     0.2296
+    ]
+   ],
+   "busiest.tht": [
+    [
+     "flat_hierarchy",
+     0.5866
+    ],
+    [
+     "interf_u_unrouted",
+     0.5519
+    ],
+    [
+     "interf_u_unrouted_placed",
+     0.5519
+    ],
+    [
+     "esp_prog",
+     0.4352
+    ],
+    [
+     "cap_chain",
+     0.3271
+    ],
+    [
+     "sonde_u",
+     0.2719
+    ],
+    [
+     "kit-dev-coldfire-xilinx_5213",
+     0.2607
+    ],
+    [
+     "tigard",
+     0.2477
+    ],
+    [
+     "rp2350_fpga_eensy_prePlane",
+     0.201
+    ],
+    [
+     "glasgow_revC",
+     0.1923
+    ],
+    [
+     "splitflap_driver",
+     0.1901
+    ],
+    [
+     "lvds_converter_dualclk",
+     0.1819
+    ],
+    [
+     "lvds_converter_dualclk_gnd",
+     0.1819
+    ],
+    [
+     "orangecrab_ext_pll",
+     0.1797
+    ],
+    [
+     "qfn_csi_underpad_diff",
+     0.16
+    ],
+    [
+     "ulx3s",
+     0.1323
+    ],
+    [
+     "watchy",
+     0.0658
+    ]
+   ],
+   "one_face_declared.courtyard": [
+    [
+     "flat_hierarchy",
+     1.0
+    ],
+    [
+     "cap_chain",
+     0.9123
+    ],
+    [
+     "interf_u_unrouted",
+     0.878
+    ],
+    [
+     "interf_u_unrouted_placed",
+     0.878
+    ],
+    [
+     "kit-dev-coldfire-xilinx_5213",
+     0.6946
+    ],
+    [
+     "splitflap_driver",
+     0.6325
+    ],
+    [
+     "glasgow_revC",
+     0.5654
+    ],
+    [
+     "tigard",
+     0.5558
+    ],
+    [
+     "esp_prog",
+     0.4651
+    ],
+    [
+     "sonde_u",
+     0.4309
+    ],
+    [
+     "rp2350_fpga_eensy_prePlane",
+     0.4171
+    ],
+    [
+     "lvds_converter_dualclk",
+     0.3915
+    ],
+    [
+     "lvds_converter_dualclk_gnd",
+     0.3915
+    ],
+    [
+     "qfn_csi_underpad_diff",
+     0.3758
+    ],
+    [
+     "ulx3s",
+     0.3569
+    ],
+    [
+     "orangecrab_ext_pll",
+     0.2825
+    ],
+    [
+     "watchy",
+     0.2296
+    ]
+   ],
+   "one_face_declared.tht": [
+    [
+     "flat_hierarchy",
+     0.5866
+    ],
+    [
+     "interf_u_unrouted",
+     0.5519
+    ],
+    [
+     "interf_u_unrouted_placed",
+     0.5519
+    ],
+    [
+     "esp_prog",
+     0.4352
+    ],
+    [
+     "cap_chain",
+     0.3271
+    ],
+    [
+     "sonde_u",
+     0.2719
+    ],
+    [
+     "kit-dev-coldfire-xilinx_5213",
+     0.2607
+    ],
+    [
+     "tigard",
+     0.2477
+    ],
+    [
+     "rp2350_fpga_eensy_prePlane",
+     0.201
+    ],
+    [
+     "glasgow_revC",
+     0.1923
+    ],
+    [
+     "splitflap_driver",
+     0.1901
+    ],
+    [
+     "lvds_converter_dualclk",
+     0.1819
+    ],
+    [
+     "lvds_converter_dualclk_gnd",
+     0.1819
+    ],
+    [
+     "orangecrab_ext_pll",
+     0.1797
+    ],
+    [
+     "qfn_csi_underpad_diff",
+     0.16
+    ],
+    [
+     "ulx3s",
+     0.1323
+    ],
+    [
+     "watchy",
+     0.0658
+    ]
+   ],
+   "one_face_observed.courtyard": [
+    [
+     "flat_hierarchy",
+     1.0
+    ],
+    [
+     "cap_chain",
+     0.9123
+    ],
+    [
+     "interf_u_unrouted",
+     0.878
+    ],
+    [
+     "interf_u_unrouted_placed",
+     0.878
+    ],
+    [
+     "splitflap_driver",
+     0.6325
+    ],
+    [
+     "esp_prog",
+     0.4651
+    ],
+    [
+     "lvds_converter_dualclk",
+     0.3915
+    ],
+    [
+     "lvds_converter_dualclk_gnd",
+     0.3915
+    ],
+    [
+     "qfn_csi_underpad_diff",
+     0.3758
+    ],
+    [
+     "watchy",
+     0.2296
+    ]
+   ],
+   "one_face_observed.tht": [
+    [
+     "flat_hierarchy",
+     0.5866
+    ],
+    [
+     "interf_u_unrouted",
+     0.5519
+    ],
+    [
+     "interf_u_unrouted_placed",
+     0.5519
+    ],
+    [
+     "esp_prog",
+     0.4352
+    ],
+    [
+     "cap_chain",
+     0.3271
+    ],
+    [
+     "splitflap_driver",
+     0.1901
+    ],
+    [
+     "lvds_converter_dualclk",
+     0.1819
+    ],
+    [
+     "lvds_converter_dualclk_gnd",
+     0.1819
+    ],
+    [
+     "qfn_csi_underpad_diff",
+     0.16
+    ],
+    [
+     "watchy",
+     0.0658
+    ]
+   ]
+  },
+  "flips": {
+   "busiest.courtyard": [],
+   "busiest.tht": [],
+   "one_face_declared.courtyard": [
+    [
+     "glasgow_revC",
+     0.8804,
+     1.3781,
+     3791.77
+    ],
+    [
+     "rp2350_fpga_eensy_prePlane",
+     0.8416,
+     1.1927,
+     584.18
+    ],
+    [
+     "sonde_u",
+     0.8446,
+     1.2085,
+     3349.09
+    ],
+    [
+     "tigard",
+     0.7045,
+     1.0961,
+     2024.79
+    ]
+   ],
+   "one_face_declared.tht": [
+    [
+     "glasgow_revC",
+     0.8804,
+     1.0497,
+     3791.77
+    ],
+    [
+     "rp2350_fpga_eensy_prePlane",
+     0.8416,
+     1.0108,
+     584.18
+    ],
+    [
+     "sonde_u",
+     0.8446,
+     1.0742,
+     3349.09
+    ]
+   ],
+   "one_face_observed.courtyard": [],
+   "one_face_observed.tht": []
+  },
+  "moves": {
+   "busiest.courtyard": {
+    "boards": [
+     [
+      "rp2350_fpga_eensy_prePlane",
+      0.0517
+     ],
+     [
+      "ulx3s",
+      0.011
+     ]
+    ],
+    "max": 0.0517,
+    "median": 0.0314,
+    "n": 2
+   },
+   "busiest.tht": {
+    "boards": [
+     [
+      "rp2350_fpga_eensy_prePlane",
+      0.0346
+     ]
+    ],
+    "max": 0.0346,
+    "median": 0.0346,
+    "n": 1
+   },
+   "one_face_declared.courtyard": {
+    "boards": [
+     [
+      "glasgow_revC",
+      0.4977
+     ],
+     [
+      "ulx3s",
+      0.4773
+     ],
+     [
+      "interf_u_unrouted",
+      0.4322
+     ],
+     [
+      "interf_u_unrouted_placed",
+      0.4322
+     ],
+     [
+      "tigard",
+      0.3916
+     ],
+     [
+      "kit-dev-coldfire-xilinx_5213",
+      0.3868
+     ],
+     [
+      "flat_hierarchy",
+      0.3801
+     ],
+     [
+      "sonde_u",
+      0.3639
+     ],
+     [
+      "orangecrab_ext_pll",
+      0.354
+     ],
+     [
+      "rp2350_fpga_eensy_prePlane",
+      0.3511
+     ],
+     [
+      "splitflap_driver",
+      0.3197
+     ],
+     [
+      "esp_prog",
+      0.2414
+     ],
+     [
+      "watchy",
+      0.1152
+     ],
+     [
+      "cap_chain",
+      0.099
+     ],
+     [
+      "lvds_converter_dualclk",
+      0.0966
+     ],
+     [
+      "lvds_converter_dualclk_gnd",
+      0.0966
+     ],
+     [
+      "qfn_csi_underpad_diff",
+      0.0521
+     ]
+    ],
+    "max": 0.4977,
+    "median": 0.354,
+    "n": 17
+   },
+   "one_face_declared.tht": {
+    "boards": [
+     [
+      "interf_u_unrouted",
+      0.2717
+     ],
+     [
+      "interf_u_unrouted_placed",
+      0.2717
+     ],
+     [
+      "sonde_u",
+      0.2296
+     ],
+     [
+      "esp_prog",
+      0.2259
+     ],
+     [
+      "orangecrab_ext_pll",
+      0.2252
+     ],
+     [
+      "flat_hierarchy",
+      0.223
+     ],
+     [
+      "ulx3s",
+      0.177
+     ],
+     [
+      "tigard",
+      0.1745
+     ],
+     [
+      "glasgow_revC",
+      0.1693
+     ],
+     [
+      "rp2350_fpga_eensy_prePlane",
+      0.1692
+     ],
+     [
+      "kit-dev-coldfire-xilinx_5213",
+      0.1452
+     ],
+     [
+      "splitflap_driver",
+      0.0961
+     ],
+     [
+      "lvds_converter_dualclk",
+      0.0449
+     ],
+     [
+      "lvds_converter_dualclk_gnd",
+      0.0449
+     ],
+     [
+      "cap_chain",
+      0.0355
+     ],
+     [
+      "watchy",
+      0.033
+     ],
+     [
+      "qfn_csi_underpad_diff",
+      0.0222
+     ]
+    ],
+    "max": 0.2717,
+    "median": 0.1693,
+    "n": 17
+   },
+   "one_face_observed.courtyard": {
+    "boards": [
+     [
+      "interf_u_unrouted",
+      0.4322
+     ],
+     [
+      "interf_u_unrouted_placed",
+      0.4322
+     ],
+     [
+      "flat_hierarchy",
+      0.3801
+     ],
+     [
+      "splitflap_driver",
+      0.3197
+     ],
+     [
+      "esp_prog",
+      0.2414
+     ],
+     [
+      "watchy",
+      0.1152
+     ],
+     [
+      "cap_chain",
+      0.099
+     ],
+     [
+      "lvds_converter_dualclk",
+      0.0966
+     ],
+     [
+      "lvds_converter_dualclk_gnd",
+      0.0966
+     ],
+     [
+      "qfn_csi_underpad_diff",
+      0.0521
+     ]
+    ],
+    "max": 0.4322,
+    "median": 0.1783,
+    "n": 10
+   },
+   "one_face_observed.tht": {
+    "boards": [
+     [
+      "interf_u_unrouted",
+      0.2717
+     ],
+     [
+      "interf_u_unrouted_placed",
+      0.2717
+     ],
+     [
+      "esp_prog",
+      0.2259
+     ],
+     [
+      "flat_hierarchy",
+      0.223
+     ],
+     [
+      "splitflap_driver",
+      0.0961
+     ],
+     [
+      "lvds_converter_dualclk",
+      0.0449
+     ],
+     [
+      "lvds_converter_dualclk_gnd",
+      0.0449
+     ],
+     [
+      "cap_chain",
+      0.0355
+     ],
+     [
+      "watchy",
+      0.033
+     ],
+     [
+      "qfn_csi_underpad_diff",
+      0.0222
+     ]
+    ],
+    "max": 0.2717,
+    "median": 0.0705,
+    "n": 10
+   }
+  },
+  "robustness": {
+   "not_robust": [],
+   "unmeasured": [
+    "per-board clearance from a sibling .kicad_pro (#441): most tracked boards carry none"
+   ]
+  }
+ },
+ "post_hoc": {
+  "finding": "no far-face charge belongs in the one-face SUM; the far face is charged into `busiest` only",
+  "generalises": "F1, which is a threshold on the same mechanism and fires only for `courtyard` on this corpus",
+  "one_face_charged_once": {
+   "courtyard": {
+    "boards_double_charged": [
+     [
+      "flat_hierarchy",
+      5927.41,
+      11854.82
+     ],
+     [
+      "interf_u_unrouted",
+      6045.77,
+      11353.71
+     ],
+     [
+      "interf_u_unrouted_placed",
+      6045.77,
+      11353.71
+     ],
+     [
+      "splitflap_driver",
+      2936.52,
+      4793.93
+     ],
+     [
+      "watchy",
+      739.8,
+      909.67
+     ],
+     [
+      "lvds_converter_dualclk",
+      411.13,
+      572.1
+     ],
+     [
+      "lvds_converter_dualclk_gnd",
+      411.13,
+      572.1
+     ],
+     [
+      "esp_prog",
+      215.46,
+      315.68
+     ],
+     [
+      "cap_chain",
+      51.57,
+      98.62
+     ],
+     [
+      "qfn_csi_underpad_diff",
+      113.05,
+      155.53
+     ]
+    ],
+    "charged_once": false
+   },
+   "none": {
+    "boards_double_charged": [],
+    "charged_once": true
+   },
+   "tht": {
+    "boards_double_charged": [
+     [
+      "flat_hierarchy",
+      5927.41,
+      9404.4
+     ],
+     [
+      "interf_u_unrouted",
+      6045.77,
+      9382.64
+     ],
+     [
+      "interf_u_unrouted_placed",
+      6045.77,
+      9382.64
+     ],
+     [
+      "splitflap_driver",
+      2936.52,
+      3494.86
+     ],
+     [
+      "esp_prog",
+      215.46,
+      309.23
+     ],
+     [
+      "lvds_converter_dualclk",
+      411.13,
+      485.92
+     ],
+     [
+      "lvds_converter_dualclk_gnd",
+      411.13,
+      485.92
+     ],
+     [
+      "watchy",
+      739.8,
+      788.51
+     ],
+     [
+      "qfn_csi_underpad_diff",
+      113.05,
+      131.13
+     ],
+     [
+      "cap_chain",
+      51.57,
+      68.45
+     ]
+    ],
+    "charged_once": false
+   }
+  },
+  "status": "POST-HOC -- reasoned after the numbers were visible, NOT part of PREREGISTRATION, and it only makes the change more conservative than the rule required",
+  "why": "sum(per_side) is each part exactly once, the demand on the one populated face. Leads on the unpopulated face compete with nothing, so any far charge there is the same area twice."
+ },
+ "preregistration": {
+  "F1_DOUBLE_MAX": 0.9,
+  "F1_WITNESS": "flat_hierarchy",
+  "F1_WITNESS_PREDICTION": 1.0,
+  "MOVE_EPS": 0.005,
+  "NC2_BOARDS": [
+   "haasoscope_pro_max_test",
+   "qfn_diffpair_escape",
+   "qfn_interior_pads",
+   "qfn_underpad_coupling",
+   "routed_output"
+  ],
+  "assembly_predicate": "legality.assembly_census (pad_is_plated_through)",
+  "bases": [
+   "busiest",
+   "one_face_observed",
+   "one_face_declared"
+  ],
+  "basis_population": {
+   "busiest": "every tracked board; charged = max(per_side)",
+   "one_face_declared": "every tracked board, declaring the census face where there is one and the majority pad-bearing face otherwise; REPORTED ONLY, never read by the rule -- on a two-sided board it is a counterfactual",
+   "one_face_observed": "boards whose assembly_census['sides'] is 'F' or 'B'; charged = sum(per_side)"
+  },
+  "currencies": [
+   "none",
+   "tht",
+   "courtyard"
+  ],
+  "decision_bases": [
+   "busiest",
+   "one_face_observed"
+  ],
+  "default_currency": "tht",
+  "default_reason": "legality.rect_on is the only place in the tree where the far-face rect is DECIDED rather than sidestepped, and it answers tht_rect. check_pockets.courtyard_cover is not a competing decision: it answers a per-window COVER question where summing never arises. grow_board giving a third answer is a second answer to a settled question.",
+  "obstruction_predicate": "legality.footprint_has_through_pads (drill > 0)",
+  "question": "which rect does a through-hole part present on the FAR face when grow_board charges part area: the whole courtyard, the drilled-pad rect, or nothing",
+  "rules": [
+   "STEP 0  if NC1 or NC2 fails on any row, the sweep decides NOTHING.",
+   "STEP 0b if courtyard_sides_differ > 0, the `courtyard` arm is confounded by the both-sides union grow_board reads and must be split into union/own-side before it may be selected.",
+   "STEP 1  F1: on a one-face basis, a currency with far_over_near >= F1_DOUBLE_MAX on any board is REJECTED for that basis.",
+   "STEP 2  F2: a currency with 0 flips and 0 moves on every decision basis is INDISTINGUISHABLE from `none` on this corpus.",
+   "STEP 3  per decision basis, among currencies neither rejected nor inert: `tht` is selected on default_reason. `courtyard` displaces it only if it survives F1 on that basis AND flips strictly more boards. If only `none` survives, that basis keeps `none` and the not_modelled disclosure becomes basis-specific.",
+   "STEP 4  if the robustness arm reports NOT ROBUST, a selection may not be taken from flips; it falls back to default_currency on default_reason alone, and the verdict says so."
+  ]
+ },
+ "verdict": {
+  "bound_by": {
+   "busiest": "default_reason (legality.rect_on)",
+   "one_face_observed": "default_reason (legality.rect_on)"
+  },
+  "f1_rejected": {
+   "busiest": [],
+   "one_face_observed": [
+    "courtyard"
+   ]
+  },
+  "f2_inert": [],
+  "selected": {
+   "busiest": "tht",
+   "one_face_observed": "tht"
+  },
+  "why": []
+ }
+}

--- a/tests/measure_878_far_face_area.py
+++ b/tests/measure_878_far_face_area.py
@@ -466,6 +466,61 @@ def apply_rule(doc):
     return out
 
 
+#: POST-HOC, and labelled so, because it was reasoned AFTER the numbers were
+#: visible and is therefore not part of what `PREREGISTRATION` notarised.
+#:
+#: F1 rejects a currency on a one-face basis at a THRESHOLD (far/near >= 0.9),
+#: and on this corpus it fires for `courtyard` (flat_hierarchy 1.000) and not
+#: for `tht` (worst 0.5866). But the mechanism F1 is a proxy for is not a
+#: threshold at all, it is structural: under a one-face policy `charged` is
+#: `sum(per_side)`, which is defined as EACH PART EXACTLY ONCE -- the demand on
+#: the single face the fab populates. A through-hole part's leads come out on
+#: the face nobody populates, so they compete with nothing there. ANY far-face
+#: charge entering that sum is the same area counted twice, `tht` included.
+#:
+#: So the implementation charges the far face into `busiest` ONLY, which is
+#: strictly more conservative than the rule selected. `one_face_charged_once`
+#: is the check that says so in numbers rather than in prose: it is True
+#: exactly when a currency leaves the one-face sum equal to `part_area_mm2`.
+#: Recording it here rather than editing the pre-registration is the point --
+#: a threshold moved after seeing the answers is how a measurement stops
+#: meaning anything.
+POST_HOC = {
+    'finding': ('no far-face charge belongs in the one-face SUM; the far face '
+                'is charged into `busiest` only'),
+    'why': ('sum(per_side) is each part exactly once, the demand on the one '
+            'populated face. Leads on the unpopulated face compete with '
+            'nothing, so any far charge there is the same area twice.'),
+    'generalises': ('F1, which is a threshold on the same mechanism and fires '
+                    'only for `courtyard` on this corpus'),
+    'status': ('POST-HOC -- reasoned after the numbers were visible, NOT part '
+               'of PREREGISTRATION, and it only makes the change more '
+               'conservative than the rule required'),
+}
+
+
+def one_face_charged_once(rows):
+    """Per currency: does the one-face sum stay `part_area_mm2` (each part once)?
+
+    True only for `none`. This is the POST_HOC finding as a measurement.
+    """
+    out = {}
+    for c in CURRENCIES:
+        offenders = []
+        for name, d in rows:
+            arm = d['arms'].get('one_face_observed')
+            if not arm:
+                continue
+            once = arm['none']['charged_area_mm2']
+            got = arm[c]['charged_area_mm2']
+            if abs(got - once) > 0.011:
+                offenders.append([name, once, got])
+        out[c] = {'charged_once': not offenders,
+                  'boards_double_charged': sorted(offenders,
+                                                  key=lambda r: r[1] - r[2])}
+    return out
+
+
 def headline(rows):
     flips, moves, double = {}, {}, {}
     for basis in BASES:
@@ -602,6 +657,15 @@ def table_headline(doc, rows):
             dd = hl['double'].get('%s.%s' % (basis, c), [])[:3]
             if dd:
                 print('    %-28s %s' % ('%s.%s' % (basis, c), dd))
+    ph = doc['post_hoc']['one_face_charged_once']
+    print('\n  POST-HOC (not pre-registered): the one-face sum is each '
+          'part ONCE only under:')
+    print('    %s' % [c for c in CURRENCIES if ph[c]['charged_once']])
+    for c in CURRENCIES:
+        bad = ph[c]['boards_double_charged']
+        if bad:
+            print('    %-10s double-charges %d board(s), worst %s'
+                  % (c, len(bad), bad[0]))
     nr = hl['robustness']['not_robust']
     print('\n  robustness: %s' % ('ROBUST' if not nr else 'NOT ROBUST'))
     for r in nr:
@@ -683,12 +747,57 @@ def build(paths):
         'boards': {n: d for n, d in rows},
     }
     doc['headline'] = headline(rows)
+    doc['post_hoc'] = dict(POST_HOC)
+    doc['post_hoc']['one_face_charged_once'] = one_face_charged_once(rows)
     doc['verdict'] = apply_rule(doc)
     return doc, rows, failed
 
 
 DIFF_KEYS = ('utilisation', 'fits_by_area', 'charged_area_mm2',
              'far_charge_mm2', 'binding_side')
+
+#: What a COMMITTED run keeps per (board, basis, currency). The full in-process
+#: record carries fourteen fields per arm and the eight-field control row for
+#: every board; dumping all of it is 126 KB of numbers the gate re-derives in
+#: 17 seconds anyway, and this repo has already had one 276 KB regenerable
+#: table asked back out of a PR. So the artifact keeps the cells the verdict
+#: actually rests on, and `--out-full` still exists for a debugging dump.
+KEEP_PER_ARM = ('utilisation', 'fits_by_area', 'charged_area_mm2',
+                'far_charge_mm2', 'far_over_near', 'binding_side')
+KEEP_PER_BOARD = ('census_sides', 'parts_charged', 'tht_obstructing',
+                  'through_hole_plated', 'declared_face',
+                  'declared_is_hypothetical', 'usable_area_mm2',
+                  'containers_excluded', 'courtyard_sides_drawn',
+                  'courtyard_sides_differ')
+
+
+def compact(doc):
+    """The committed shape: the deciding cells, not the whole record."""
+    out = {k: doc[k] for k in ('engine_sha', 'preregistration', 'basis',
+                               'confound', 'headline', 'post_hoc',
+                               'verdict')}
+    out['control'] = {
+        'nc1_rows': sum(1 for b in doc['boards'].values()
+                        for r in b['control'] if 'mismatches' in r),
+        'nc1_fields_per_row': len(NC1_FIELDS),
+        'nc1_mismatches': [m for b in doc['boards'].values()
+                           for r in b['control']
+                           for m in r.get('mismatches', ())],
+        'nc2_boards': doc['control']['nc2_boards'],
+        'nc2_mismatches': doc['control']['nc2_mismatches'],
+    }
+    boards = {}
+    for name, d in doc['boards'].items():
+        rec = {k: d[k] for k in KEEP_PER_BOARD}
+        rec['pad_bearing_B'] = d['pad_bearing'].get('B', 0)
+        rec['arms'] = {
+            basis: (None if d['arms'].get(basis) is None else
+                    {c: {k: d['arms'][basis][c][k] for k in KEEP_PER_ARM}
+                     for c in CURRENCIES})
+            for basis in BASES}
+        boards[name] = rec
+    out['boards'] = boards
+    return out
 
 
 def _diff(before, after):
@@ -735,7 +844,9 @@ def main():
     ap.add_argument('--table', default='control,census,charge,headline,verdict',
                     help='comma-separated: %s' % ', '.join(TABLES))
     ap.add_argument('--boards', nargs='*', help='basenames to restrict to')
-    ap.add_argument('--out', help='write the figures as json')
+    ap.add_argument('--out', help='write the committed figures as json')
+    ap.add_argument('--out-full', help='write the UNCOMPACTED record (a '
+                                       'debugging dump, not for committing)')
     ap.add_argument('--diff', nargs=2, metavar=('BEFORE', 'AFTER'))
     args = ap.parse_args()
 
@@ -784,8 +895,12 @@ def main():
 
     if args.out:
         with open(args.out, 'w', encoding='utf-8') as f:
-            json.dump(doc, f, indent=1, sort_keys=True)
+            json.dump(compact(doc), f, indent=1, sort_keys=True)
         print('\nwrote %s' % args.out)
+    if args.out_full:
+        with open(args.out_full, 'w', encoding='utf-8') as f:
+            json.dump(doc, f, indent=1, sort_keys=True)
+        print('wrote %s (uncompacted)' % args.out_full)
     return 0
 
 

--- a/tests/measure_878_far_face_area.py
+++ b/tests/measure_878_far_face_area.py
@@ -1,0 +1,793 @@
+#!/usr/bin/env python3
+"""#878: what a through-hole part's leads cost on the FAR face, measured.
+
+`options.grow_board` charges a part's area to its footprint layer only
+(`options.py:245-246`). A drilled part's leads occupy the other face too, and
+that area is charged to nobody. Three instruments in this tree charge a drilled
+part per face and they do not agree about WHAT the far face costs, so #878 asks
+for the currency to be DECIDED BY MEASUREMENT before the engine changes. This
+is that measurement.
+
+    python3 -X utf8 tests/measure_878_far_face_area.py
+    python3 -X utf8 tests/measure_878_far_face_area.py --table control,charge
+    python3 -X utf8 tests/measure_878_far_face_area.py --boards flat_hierarchy tigard
+    python3 -X utf8 tests/measure_878_far_face_area.py --out after.json
+    python3 -X utf8 tests/measure_878_far_face_area.py --diff before.json after.json
+
+BOTH ARMS ARE MEASURED IN ONE PROCESS. This file carries its own copy of
+`grow_board`'s charging loop, parametrised by currency, and prints all three
+side by side -- so no column depends on checking out a parent commit, and the
+"before" column re-measures when the next change lands. It is the discipline
+`tests/measure_850_848_faces.py` states, for the same reason.
+
+The copy CALLS the engine's helpers rather than re-deriving them
+(`extract_courtyard_bboxes`, `compute_footprint_bbox_local`,
+`rotate_local_bounds`, `footprint_side`, `hosts_the_design`, `CONTAINER_RATIO`,
+`footprint_has_through_pads`, `part_local_bounds`), and it reaches nothing
+private: the far-face box comes from `legality.part_local_bounds(...).tht_local`,
+the public reader, not from `quench._through_pad_bounds_local`.
+
+TWO NEGATIVE CONTROLS, and a failure of either REFUSES the whole report:
+
+  NC1  currency `none` must reproduce `options.grow_board` EXACTLY -- eight
+       fields per (board, basis), not just the answer. This is what proves the
+       harness measures the engine and not itself. A report whose control did
+       not reproduce is a page of numbers about nothing.
+  NC2  a board carrying NO drilled pad must be bit-identical under all three
+       currencies on every basis. If a currency moves one of those, the harness
+       is charging something other than the far face and every cell is suspect.
+
+THE OBSTRUCTION PREDICATE IS NOT THE ASSEMBLY PREDICATE, and conflating them is
+the easiest way to get this wrong. Which parts reach the far face is
+`footprint_has_through_pads` -- plain `drill > 0`, because an unplated hole
+blocks the far side exactly as a plated one does (`legality.py:245-252`). Which
+FACES a board is populated on is `assembly_census`, which asks
+`pad_is_plated_through`, because an NPTH alignment post is not a soldered pin
+(`legality.py:296-305`). #878's own per-board figures were counted with the
+second rule; this file reports both columns so they cannot be read as one.
+
+Boards come from `run_utils.corpus_boards()` -- the git-TRACKED set, 22 today.
+A plain glob of `kicad_files/` also returns generated boards and gives 27-33.
+"""
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(_HERE)
+for _p in (_HERE, ROOT, os.path.join(ROOT, 'py_placer'),
+           os.path.join(ROOT, 'py_router'), os.path.join(ROOT, 'py_tools'),
+           os.path.join(ROOT, 'py_placer', 'placement')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import run_utils                                             # noqa: E402
+from kicad_parser import parse_kicad_pcb                     # noqa: E402
+from placement import legality as L                          # noqa: E402
+from placement import options as O                           # noqa: E402
+from placement.parser import extract_courtyard_bboxes        # noqa: E402
+from placement.parser import extract_courtyard_sides         # noqa: E402
+from placement.utility import compute_footprint_bbox_local   # noqa: E402
+
+SKIP_EXIT = 77
+
+#: ONE BASIS, stated rather than defaulted. 0.2 / 0.5 are what
+#: `tests/test_capacity_options.py` grades `grow_board` at, so every number
+#: here is comparable with the assertions that pin the engine.
+#: `check_capacity.py`'s own default edge clearance is 0.55, which is why the
+#: robustness arm re-runs the verdict there (H5).
+CLEARANCE = 0.2
+BOARD_EDGE_CLEARANCE = 0.5
+EDGE_SENSITIVITY = 0.55
+
+CURRENCIES = ('none', 'tht', 'courtyard')
+
+#: The three bases, and which of them the pre-registered rule is allowed to
+#: read. `one_face_declared` exists because `--assembly-sides F` is a supported
+#: flag a designer can point at ANY board to ask "could this be built on one
+#: side?" -- but on a board the census calls two-sided that is a counterfactual,
+#: and a counterfactual printed beside real numbers WILL be quoted as evidence.
+#: So it is measured, labelled `hypothetical`, and pre-registered as NOT
+#: decision-bearing.
+BASES = ('busiest', 'one_face_observed', 'one_face_declared')
+DECISION_BASES = ('busiest', 'one_face_observed')
+
+PREREGISTRATION = {
+    'question': ('which rect does a through-hole part present on the FAR face '
+                 'when grow_board charges part area: the whole courtyard, the '
+                 'drilled-pad rect, or nothing'),
+    'currencies': list(CURRENCIES),
+    'bases': list(BASES),
+    'decision_bases': list(DECISION_BASES),
+    'basis_population': {
+        'busiest': 'every tracked board; charged = max(per_side)',
+        'one_face_observed':
+            "boards whose assembly_census['sides'] is 'F' or 'B'; charged = "
+            'sum(per_side)',
+        'one_face_declared':
+            'every tracked board, declaring the census face where there is '
+            'one and the majority pad-bearing face otherwise; REPORTED ONLY, '
+            'never read by the rule -- on a two-sided board it is a '
+            'counterfactual',
+    },
+    'obstruction_predicate': 'legality.footprint_has_through_pads (drill > 0)',
+    'assembly_predicate': 'legality.assembly_census (pad_is_plated_through)',
+    # The granularity of grow_board's OWN output: its action string prints
+    # `{util:.0%}` (options.py:358), so 0.005 is exactly where the number a
+    # human reads changes. Not a round number chosen to reach a conclusion.
+    'MOVE_EPS': 0.005,
+    # A one-face board's `charged` is sum(per_side). A currency that charges
+    # the far face as much as the near one is putting the same physical area
+    # into that sum twice. The bound carries its own counterexample and the
+    # counterexample is knowable from the part census WITHOUT running the
+    # sweep: flat_hierarchy is 64 pad-bearing parts, all 64 drilled, census
+    # 'F'. Under `courtyard` the far charge IS the near charge part for part,
+    # so far/near == 1.000 and the utilisation exactly doubles. 0.9 sits below
+    # that provable 1.0 and above what a mixed board reaches.
+    'F1_DOUBLE_MAX': 0.9,
+    'F1_WITNESS': 'flat_hierarchy',
+    'F1_WITNESS_PREDICTION': 1.0,
+    # Boards carrying no drilled pad at all: NC2's population, known a priori.
+    'NC2_BOARDS': ['haasoscope_pro_max_test', 'qfn_diffpair_escape',
+                   'qfn_interior_pads', 'qfn_underpad_coupling',
+                   'routed_output'],
+    'default_currency': 'tht',
+    'default_reason': (
+        'legality.rect_on is the only place in the tree where the far-face '
+        'rect is DECIDED rather than sidestepped, and it answers tht_rect. '
+        'check_pockets.courtyard_cover is not a competing decision: it answers '
+        'a per-window COVER question where summing never arises. grow_board '
+        'giving a third answer is a second answer to a settled question.'),
+    'rules': [
+        'STEP 0  if NC1 or NC2 fails on any row, the sweep decides NOTHING.',
+        'STEP 0b if courtyard_sides_differ > 0, the `courtyard` arm is '
+        'confounded by the both-sides union grow_board reads and must be '
+        'split into union/own-side before it may be selected.',
+        'STEP 1  F1: on a one-face basis, a currency with far_over_near >= '
+        'F1_DOUBLE_MAX on any board is REJECTED for that basis.',
+        'STEP 2  F2: a currency with 0 flips and 0 moves on every decision '
+        'basis is INDISTINGUISHABLE from `none` on this corpus.',
+        'STEP 3  per decision basis, among currencies neither rejected nor '
+        'inert: `tht` is selected on default_reason. `courtyard` displaces it '
+        'only if it survives F1 on that basis AND flips strictly more boards. '
+        'If only `none` survives, that basis keeps `none` and the '
+        'not_modelled disclosure becomes basis-specific.',
+        'STEP 4  if the robustness arm reports NOT ROBUST, a selection may '
+        'not be taken from flips; it falls back to default_currency on '
+        'default_reason alone, and the verdict says so.',
+    ],
+}
+
+
+# --- the charging loop, parametrised by currency ----------------------------
+
+def _board_geometry(pcb, path):
+    """Per-part rows: the near box grow_board charges, and the far box.
+
+    Deliberately one pass that yields BOTH boxes, so no arm can differ from
+    another by geometry source rather than by currency.
+    """
+    cy = extract_courtyard_bboxes(path) or {}
+    lb = L.part_local_bounds(pcb, path)
+    bb = pcb.board_info.board_bounds
+    x0, y0, x1, y1 = bb
+    outline_area = (x1 - x0) * (y1 - y0)
+    rows, containers, from_courtyard, from_pads, no_geometry = [], [], 0, 0, 0
+    # `sorted(...)` matches options.py:203 so float accumulation order matches.
+    for ref, fp in sorted(pcb.footprints.items()):
+        box = cy.get(ref)
+        if box:
+            from_courtyard += 1
+        elif fp.pads:
+            box = compute_footprint_bbox_local(fp)
+            from_pads += 1
+        else:
+            no_geometry += 1
+            continue
+        gx0, gy0, gx1, gy1 = L.rotate_local_bounds(*box, fp.rotation or 0.0)
+        w, h = gx1 - gx0, gy1 - gy0
+        if (outline_area > 0 and (w * h) >= L.CONTAINER_RATIO * outline_area
+                and O.hosts_the_design(ref, gx0, gy0, gx1, gy1, fp,
+                                       pcb.footprints)):
+            containers.append((round(w * h, 2), ref))
+            continue
+        own = 'B.Cu' if L.footprint_side(fp) == 'B' else 'F.Cu'
+        far = 'F.Cu' if own == 'B.Cu' else 'B.Cu'
+        near = (w + CLEARANCE) * (h + CLEARANCE)
+        # The far box, through the PUBLIC reader. `.tht_local` only -- `.local`
+        # is NOT grow_board's near box (it uses courtyard_for_side rather than
+        # the union, and keeps zero-pad parts as `synthetic` where grow_board
+        # drops them), so swapping it wholesale would make every arm differ by
+        # geometry source. NC1 would catch that; this comment is so nobody has
+        # to learn it from a refusal.
+        has_tht = L.footprint_has_through_pads(fp)
+        tw = th = 0.0
+        rec = lb.get(ref)
+        tloc = getattr(rec, 'tht_local', None) if rec is not None else None
+        if has_tht and tloc is not None:
+            tx0, ty0, tx1, ty1 = L.rotate_local_bounds(*tloc, fp.rotation or 0.0)
+            tw, th = tx1 - tx0, ty1 - ty0
+        rows.append({'ref': ref, 'own': own, 'far': far, 'near': near,
+                     'has_tht': has_tht, 'tht_w': tw, 'tht_h': th,
+                     'tht_box': (has_tht and tloc is not None)})
+    return {'rows': rows, 'containers': containers,
+            'from_courtyard': from_courtyard, 'from_pads': from_pads,
+            'no_geometry': no_geometry, 'outline_area': outline_area,
+            'bounds': bb}
+
+
+def _per_side(geom, currency, *, bare_far=False):
+    """`per_side` under one currency. `none` reproduces options.py:245-246."""
+    per = {'F.Cu': 0.0, 'B.Cu': 0.0}
+    near_total = far_total = 0.0
+    for r in geom['rows']:
+        per[r['own']] += r['near']
+        near_total += r['near']
+        if currency == 'none' or not r['has_tht']:
+            continue
+        if currency == 'courtyard':
+            # THT-GATED, exactly like check_pockets.courtyard_cover, whose
+            # `_side_key` is GradedPart.sides == sides_occupied(side, has_tht).
+            # Charging an SMD part's courtyard to the far face would not be
+            # this currency; it would be a bug that made this the biggest arm
+            # for the wrong reason.
+            add = r['near']
+        elif currency == 'tht':
+            if not r['tht_box']:
+                continue
+            add = (r['tht_w'] * r['tht_h'] if bare_far else
+                   (r['tht_w'] + CLEARANCE) * (r['tht_h'] + CLEARANCE))
+        else:
+            raise ValueError(currency)
+        per[r['far']] += add
+        far_total += add
+    return per, near_total, far_total
+
+
+def _usable(bounds, edge):
+    x0, y0, x1, y1 = bounds
+    return (max(0.0, (x1 - x0) - 2 * edge) * max(0.0, (y1 - y0) - 2 * edge))
+
+
+def _arm(geom, currency, basis, *, edge=BOARD_EDGE_CLEARANCE, bare_far=False):
+    per, near_total, far_total = _per_side(geom, currency, bare_far=bare_far)
+    usable = _usable(geom['bounds'], edge)
+    busiest = max(per.values()) if per else 0.0
+    one_face = basis != 'busiest'
+    charged = sum(per.values()) if one_face else busiest
+    util = (charged / usable) if usable > 0 else float('inf')
+    binding = max(per, key=lambda k: per[k])
+    return {
+        'charged_area_mm2': round(charged, 2),
+        'utilisation': round(util, 4),
+        'fits_by_area': charged <= usable,
+        'part_area_by_side_mm2': {k: round(v, 2) for k, v in sorted(per.items())},
+        'busiest_side_area_mm2': round(busiest, 2),
+        'near_charge_mm2': round(near_total, 2),
+        'far_charge_mm2': round(far_total, 2),
+        'far_over_near': round(far_total / near_total, 4) if near_total else 0.0,
+        # "Report WHICH term binds": on a board whose back face is barely
+        # populated, a far-face charge can make the UNBUILT face the binding
+        # one. That has to be visible, not inferable.
+        'binding_side': binding,
+        'binding_rule': 'sum' if one_face else 'max',
+        'usable_area_mm2': round(usable, 2),
+    }
+
+
+# --- the negative controls ---------------------------------------------------
+
+#: The eight fields NC1 compares. Chosen to pin the CHAIN, not just the answer:
+#: each one fails for a different reason.
+NC1_FIELDS = ('charged_area_mm2', 'utilisation', 'fits_by_area',
+              'busiest_side_area_mm2', 'part_area_by_side_mm2',
+              'containers_excluded', 'extent_from_courtyard',
+              'extent_from_pad_bbox')
+
+
+def _control_row(pcb, path, geom, basis, declared):
+    """currency `none` against the real engine, eight fields."""
+    eng = O.grow_board(pcb, path, clearance=CLEARANCE,
+                       board_edge_clearance=BOARD_EDGE_CLEARANCE,
+                       assembly_sides=declared)
+    if not eng.get('ran'):
+        return {'basis': basis, 'skipped': eng.get('reason', 'did not run')}
+    m = eng['measured']
+    mine = _arm(geom, 'none', basis)
+    mine_extra = {
+        'containers_excluded': [r for _a, r in sorted(geom['containers'],
+                                                      reverse=True)],
+        'extent_from_courtyard': geom['from_courtyard'],
+        'extent_from_pad_bbox': geom['from_pads'],
+    }
+    got = dict(mine)
+    got.update(mine_extra)
+    bad = []
+    for f in NC1_FIELDS:
+        a, b = m.get(f, eng.get(f)), got.get(f)
+        if f == 'fits_by_area':
+            a = eng.get('fits_by_area')
+        if a != b:
+            bad.append({'field': f, 'engine': a, 'harness': b})
+    return {'basis': basis, 'engine_charged': m.get('charged_area_mm2'),
+            'harness_charged': got['charged_area_mm2'],
+            'engine_util': m.get('utilisation'),
+            'harness_util': got['utilisation'],
+            'engine_fits': eng.get('fits_by_area'),
+            'harness_fits': got['fits_by_area'], 'mismatches': bad}
+
+
+# --- per board ---------------------------------------------------------------
+
+def measure_board(path):
+    pcb = parse_kicad_pcb(path)
+    if pcb.board_info.board_bounds is None:
+        return None
+    geom = _board_geometry(pcb, path)
+    cen = L.assembly_census(pcb)
+    sides = cen['sides']
+    pad_bearing = cen['pad_bearing']
+    observed = sides if sides in ('F', 'B') else None
+    majority = 'B' if pad_bearing.get('B', 0) > pad_bearing.get('F', 0) else 'F'
+    tht_obstruct = sum(1 for r in geom['rows'] if r['has_tht'])
+
+    arms = {}
+    for basis in BASES:
+        if basis == 'one_face_observed' and observed is None:
+            arms[basis] = None
+            continue
+        arms[basis] = {c: _arm(geom, c, basis) for c in CURRENCIES}
+        for c in CURRENCIES:
+            arms[basis][c]['far_charge_bare_mm2'] = _arm(
+                geom, c, basis, bare_far=True)['far_charge_mm2']
+            arms[basis][c]['fits_at_edge_055'] = _arm(
+                geom, c, basis, edge=EDGE_SENSITIVITY)['fits_by_area']
+
+    # The union confound: how many footprints draw a courtyard on both sides,
+    # and on how many do the two boxes actually DIFFER. grow_board reads the
+    # union (parser.py:198-214) where legality reads the per-side view
+    # (parser.py:217-224); the arm is only clean while `differ` is 0.
+    try:
+        cs = extract_courtyard_sides(path) or {}
+    except Exception:                                        # noqa: BLE001
+        cs = {}
+    drawn = sum(1 for d in cs.values() if len(d) > 1)
+    differ = sum(1 for d in cs.values()
+                 if len(d) > 1 and len(set(map(tuple, d.values()))) > 1)
+
+    controls = [_control_row(pcb, path, geom, 'busiest', None)]
+    if observed is not None:
+        controls.append(_control_row(pcb, path, geom,
+                                     'one_face_observed', observed))
+    return {
+        'census_sides': sides,
+        'pad_bearing': pad_bearing,
+        'blocks': cen['blocks'],
+        'through_hole_plated': cen['through_hole'],
+        'tht_obstructing': tht_obstruct,
+        'parts_charged': len(geom['rows']),
+        'declared_face': observed or majority,
+        'declared_is_hypothetical': observed is None,
+        'outline_area_mm2': round(geom['outline_area'], 2),
+        'usable_area_mm2': round(_usable(geom['bounds'],
+                                         BOARD_EDGE_CLEARANCE), 2),
+        'containers_excluded': [r for _a, r in sorted(geom['containers'],
+                                                      reverse=True)],
+        'courtyard_sides_drawn': drawn,
+        'courtyard_sides_differ': differ,
+        'arms': arms,
+        'control': controls,
+    }
+
+
+def boards(only=None):
+    tracked = run_utils.corpus_boards()
+    if not tracked:
+        return None
+    paths = {os.path.splitext(os.path.basename(p))[0]: p for p in tracked}
+    if only:
+        paths = {k: v for k, v in paths.items() if k in set(only)}
+    return paths
+
+
+# --- the rule, applied mechanically -----------------------------------------
+
+def apply_rule(doc):
+    """The pre-registered rule. Pure, so the gate can re-run it."""
+    pre = doc['preregistration']
+    out = {'selected': {}, 'bound_by': {}, 'f1_rejected': {}, 'f2_inert': [],
+           'why': []}
+
+    nc1 = sum(len(r['mismatches']) for b in doc['boards'].values()
+              for r in b['control'] if 'mismatches' in r)
+    nc2 = doc['control']['nc2_mismatches']
+    if nc1 or nc2:
+        out['why'].append('STEP 0: a negative control failed; decides nothing')
+        return out
+    confounded = any(b['courtyard_sides_differ']
+                     for b in doc['boards'].values())
+    if confounded:
+        out['why'].append('STEP 0b: courtyard_sides_differ > 0; the '
+                          '`courtyard` arm is confounded and unavailable')
+
+    hl = doc['headline']
+    for basis in pre['decision_bases']:
+        rejected = []
+        if basis.startswith('one_face'):
+            for c in ('tht', 'courtyard'):
+                worst = max((v for _b, v in hl['double'].get(
+                    '%s.%s' % (basis, c), [])), default=0.0)
+                if worst >= pre['F1_DOUBLE_MAX']:
+                    rejected.append(c)
+        if confounded and 'courtyard' not in rejected:
+            rejected.append('courtyard')
+        out['f1_rejected'][basis] = rejected
+
+        alive = []
+        for c in ('tht', 'courtyard'):
+            if c in rejected:
+                continue
+            flips = len(hl['flips'].get('%s.%s' % (basis, c), []))
+            moves = hl['moves'].get('%s.%s' % (basis, c), {}).get('n', 0)
+            if flips == 0 and moves == 0:
+                continue
+            alive.append(c)
+
+        robust = not hl['robustness']['not_robust']
+        if not alive:
+            out['selected'][basis] = 'none'
+            out['bound_by'][basis] = (
+                'every currency rejected or inert on this basis')
+        elif not robust:
+            out['selected'][basis] = pre['default_currency']
+            out['bound_by'][basis] = (
+                'STEP 4: not robust, so default_reason alone')
+        else:
+            sel = pre['default_currency'] if pre['default_currency'] in alive \
+                else alive[0]
+            if 'courtyard' in alive and 'tht' in alive:
+                if (len(hl['flips'].get('%s.courtyard' % basis, []))
+                        > len(hl['flips'].get('%s.tht' % basis, []))):
+                    sel = 'courtyard'
+            out['selected'][basis] = sel
+            out['bound_by'][basis] = (
+                'default_reason (legality.rect_on)' if sel == 'tht'
+                else 'STEP 3: strictly more flips than tht')
+
+    # Inertness is a corpus-wide statement, reported apart from selection.
+    for c in ('tht', 'courtyard'):
+        if all(len(hl['flips'].get('%s.%s' % (b, c), [])) == 0
+               and hl['moves'].get('%s.%s' % (b, c), {}).get('n', 0) == 0
+               for b in pre['decision_bases']):
+            out['f2_inert'].append(c)
+    return out
+
+
+def headline(rows):
+    flips, moves, double = {}, {}, {}
+    for basis in BASES:
+        for c in ('tht', 'courtyard'):
+            key = '%s.%s' % (basis, c)
+            f, mv, dd = [], [], []
+            for name, d in rows:
+                arm = (d['arms'].get(basis) or {})
+                if not arm:
+                    continue
+                base, cur = arm['none'], arm[c]
+                if base['fits_by_area'] != cur['fits_by_area']:
+                    f.append([name, base['utilisation'], cur['utilisation'],
+                              d['usable_area_mm2']])
+                delta = cur['utilisation'] - base['utilisation']
+                if abs(delta) >= PREREGISTRATION['MOVE_EPS']:
+                    mv.append([name, round(delta, 4)])
+                if cur['far_over_near']:
+                    dd.append([name, cur['far_over_near']])
+            flips[key] = f
+            deltas = [d for _n, d in mv]
+            moves[key] = {'n': len(mv), 'max': max(deltas, default=0.0),
+                          'median': (round(statistics.median(deltas), 4)
+                                     if deltas else 0.0),
+                          'boards': sorted(mv, key=lambda r: -abs(r[1]))}
+            double[key] = sorted(dd, key=lambda r: -r[1])
+
+    # H5: the same flip sets under two named perturbations.
+    not_robust = []
+    for basis in DECISION_BASES:
+        for c in ('tht', 'courtyard'):
+            key = '%s.%s' % (basis, c)
+            names = {r[0] for r in flips[key]}
+            edge = set()
+            for name, d in rows:
+                arm = (d['arms'].get(basis) or {})
+                if not arm:
+                    continue
+                if arm['none']['fits_at_edge_055'] != arm[c]['fits_at_edge_055']:
+                    edge.add(name)
+            if edge != names:
+                not_robust.append({'arm': key, 'perturbation': 'edge 0.55',
+                                   'primary': sorted(names),
+                                   'perturbed': sorted(edge)})
+    return {'flips': flips, 'moves': moves, 'double': double,
+            'robustness': {'not_robust': not_robust,
+                           'unmeasured': ['per-board clearance from a sibling '
+                                          '.kicad_pro (#441): most tracked '
+                                          'boards carry none']}}
+
+
+# --- tables ------------------------------------------------------------------
+
+def table_control(doc, rows):
+    print('\n== control: currency `none` against the engine, %d fields =='
+          % len(NC1_FIELDS))
+    n = bad = 0
+    for name, d in rows:
+        for r in d['control']:
+            if 'mismatches' not in r:
+                continue
+            n += 1
+            bad += len(r['mismatches'])
+            if r['mismatches']:
+                print('  %-30s %-18s MISMATCH %s'
+                      % (name, r['basis'], r['mismatches'][:2]))
+    print('NC1: %d (board, basis) rows, %d fields each, %d mismatch(es).'
+          % (n, len(NC1_FIELDS), bad))
+    c = doc['control']
+    print('NC2: %d board(s) with no drilled pad; %d differ across currencies.'
+          % (len(c['nc2_boards']), len(c['nc2_mismatches'])))
+    print('confound: %d footprint(s) draw both courtyards, %d differ.'
+          % (doc['confound']['courtyard_sides_drawn'],
+             doc['confound']['courtyard_sides_differ']))
+
+
+def table_census(doc, rows):
+    print('\n== census: the two predicates, side by side ==')
+    print('%-30s %5s %5s %6s %6s %6s' % ('board', 'sides', 'parts',
+                                         'THTobs', 'THTpl', 'B.pads'))
+    for name, d in rows:
+        print('%-30s %5s %5d %6d %6d %6d'
+              % (name, d['census_sides'], d['parts_charged'],
+                 d['tht_obstructing'], d['through_hole_plated'],
+                 d['pad_bearing'].get('B', 0)))
+    print('THTobs = footprint_has_through_pads (drill>0), the OBSTRUCTION rule '
+          'this fix uses.')
+    print('THTpl  = assembly_census (pad_is_plated_through), the ASSEMBLY rule '
+          '#878 counted with.')
+
+
+def table_charge(doc, rows):
+    for basis in BASES:
+        pop = [(n, d) for n, d in rows if d['arms'].get(basis)]
+        note = ''
+        if basis == 'one_face_declared':
+            note = '  [REPORTED ONLY -- not decision-bearing]'
+        print('\n== charge, basis %s (%d boards)%s ==' % (basis, len(pop), note))
+        print('%-30s %5s | %8s %4s | %8s %4s | %8s %4s | %8s'
+              % ('board', 'THT', 'none', 'fit', 'tht', 'fit',
+                 'crtyd', 'fit', 'usable'))
+        for name, d in pop:
+            a = d['arms'][basis]
+            flag = ' *' if a['none']['binding_side'] != a['tht']['binding_side'] \
+                else ''
+            print('%-30s %5d | %8.4f %4s | %8.4f %4s | %8.4f %4s | %8.1f%s'
+                  % (name, d['tht_obstructing'],
+                     a['none']['utilisation'],
+                     'Y' if a['none']['fits_by_area'] else 'N',
+                     a['tht']['utilisation'],
+                     'Y' if a['tht']['fits_by_area'] else 'N',
+                     a['courtyard']['utilisation'],
+                     'Y' if a['courtyard']['fits_by_area'] else 'N',
+                     d['usable_area_mm2'], flag))
+        print('  * = the binding side moved between `none` and `tht`.')
+
+
+def table_headline(doc, rows):
+    hl = doc['headline']
+    print('\n== headline ==')
+    for basis in BASES:
+        for c in ('tht', 'courtyard'):
+            k = '%s.%s' % (basis, c)
+            f, m = hl['flips'][k], hl['moves'][k]
+            tag = '' if basis in DECISION_BASES else '  [reported only]'
+            print('  %-28s flips=%-2d moves=%-2d max|d util|=%.4f%s'
+                  % (k, len(f), m['n'], abs(m['max']), tag))
+            for row in f:
+                print('        FLIP %-26s util %.4f -> %.4f (usable %.1f)'
+                      % (row[0], row[1], row[2], row[3]))
+    print('\n  double-count (far/near) on the one-face bases, worst first:')
+    for basis in ('one_face_observed', 'one_face_declared'):
+        for c in ('tht', 'courtyard'):
+            dd = hl['double'].get('%s.%s' % (basis, c), [])[:3]
+            if dd:
+                print('    %-28s %s' % ('%s.%s' % (basis, c), dd))
+    nr = hl['robustness']['not_robust']
+    print('\n  robustness: %s' % ('ROBUST' if not nr else 'NOT ROBUST'))
+    for r in nr:
+        print('    %s under %s: %s vs %s'
+              % (r['arm'], r['perturbation'], r['primary'], r['perturbed']))
+
+
+def table_verdict(doc, rows):
+    v = doc['verdict']
+    print('\n== verdict (the pre-registered rule, applied) ==')
+    for r in doc['preregistration']['rules']:
+        print('  %s' % r)
+    print()
+    for basis in DECISION_BASES:
+        print('  %-20s -> %-10s  (%s)'
+              % (basis, v['selected'].get(basis, '?'),
+                 v['bound_by'].get(basis, '')))
+    if v['f1_rejected']:
+        print('  F1 rejected: %s' % v['f1_rejected'])
+    if v['f2_inert']:
+        print('  F2 inert (indistinguishable from `none`): %s' % v['f2_inert'])
+    for w in v['why']:
+        print('  %s' % w)
+
+
+TABLES = {'control': table_control, 'census': table_census,
+          'charge': table_charge, 'headline': table_headline,
+          'verdict': table_verdict}
+
+
+# --- assembly ----------------------------------------------------------------
+
+def build(paths):
+    rows, failed = [], []
+    for name, path in sorted(paths.items()):
+        try:
+            d = measure_board(path)
+        except Exception as exc:                             # noqa: BLE001
+            failed.append(name)
+            print('  %-30s FAILED: %r' % (name, exc))
+            continue
+        if d is None:
+            failed.append(name)
+            print('  %-30s FAILED: no board outline' % name)
+            continue
+        rows.append((name, d))
+
+    nc2_boards = [n for n, d in rows if d['tht_obstructing'] == 0]
+    nc2_bad = []
+    for n, d in rows:
+        if d['tht_obstructing']:
+            continue
+        for basis in BASES:
+            arm = d['arms'].get(basis)
+            if not arm:
+                continue
+            ref = arm['none']['charged_area_mm2']
+            for c in ('tht', 'courtyard'):
+                if arm[c]['charged_area_mm2'] != ref:
+                    nc2_bad.append({'board': n, 'basis': basis, 'currency': c,
+                                    'none': ref,
+                                    'got': arm[c]['charged_area_mm2']})
+    sha = subprocess.run(['git', 'rev-parse', 'HEAD'], cwd=ROOT,
+                         capture_output=True, text=True).stdout.strip()
+    doc = {
+        'engine_sha': sha,
+        'preregistration': PREREGISTRATION,
+        'basis': {'clearance': CLEARANCE,
+                  'board_edge_clearance': BOARD_EDGE_CLEARANCE,
+                  'board_edge_clearance_sensitivity': EDGE_SENSITIVITY,
+                  'corpus': 'run_utils.corpus_boards() -- the git-TRACKED set',
+                  'n_boards': len(rows)},
+        'control': {'nc2_boards': nc2_boards, 'nc2_mismatches': nc2_bad},
+        'confound': {
+            'courtyard_sides_drawn': sum(d['courtyard_sides_drawn']
+                                         for _n, d in rows),
+            'courtyard_sides_differ': sum(d['courtyard_sides_differ']
+                                          for _n, d in rows)},
+        'boards': {n: d for n, d in rows},
+    }
+    doc['headline'] = headline(rows)
+    doc['verdict'] = apply_rule(doc)
+    return doc, rows, failed
+
+
+DIFF_KEYS = ('utilisation', 'fits_by_area', 'charged_area_mm2',
+             'far_charge_mm2', 'binding_side')
+
+
+def _diff(before, after):
+    b = json.load(open(run_utils.evidence(before, 'the BEFORE run'),
+                       encoding='utf-8'))
+    a = json.load(open(run_utils.evidence(after, 'the AFTER run'),
+                       encoding='utf-8'))
+    moved = 0
+    for board in sorted(set(b['boards']) | set(a['boards'])):
+        if board not in b['boards'] or board not in a['boards']:
+            print('  %-30s %s' % (board, 'ADDED' if board in a['boards']
+                                  else 'REMOVED'))
+            moved += 1
+            continue
+        for basis in BASES:
+            ba = b['boards'][board]['arms'].get(basis)
+            aa = a['boards'][board]['arms'].get(basis)
+            if (ba is None) != (aa is None):
+                print('  %-30s %-20s basis appeared/vanished' % (board, basis))
+                moved += 1
+                continue
+            if ba is None:
+                continue
+            for c in CURRENCIES:
+                for k in DIFF_KEYS:
+                    x, y = ba[c].get(k), aa[c].get(k)
+                    if x != y:
+                        print('  %-30s %-28s %r -> %r'
+                              % (board, '%s.%s.%s' % (basis, c, k), x, y))
+                        moved += 1
+    for k in ('selected', 'bound_by'):
+        if b['verdict'].get(k) != a['verdict'].get(k):
+            print('  VERDICT %s: %r -> %r'
+                  % (k, b['verdict'].get(k), a['verdict'].get(k)))
+            moved += 1
+    print('\n%d value(s) moved' % moved)
+    if b.get('engine_sha') != a.get('engine_sha'):
+        print('engine %s -> %s' % (b.get('engine_sha'), a.get('engine_sha')))
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--table', default='control,census,charge,headline,verdict',
+                    help='comma-separated: %s' % ', '.join(TABLES))
+    ap.add_argument('--boards', nargs='*', help='basenames to restrict to')
+    ap.add_argument('--out', help='write the figures as json')
+    ap.add_argument('--diff', nargs=2, metavar=('BEFORE', 'AFTER'))
+    args = ap.parse_args()
+
+    if args.diff:
+        return _diff(*args.diff)
+
+    paths = boards(args.boards)
+    if paths is None:
+        print('SKIP: git could not name the tracked corpus')
+        return SKIP_EXIT
+    if not paths:
+        print('no tracked board matched %r' % (args.boards,))
+        return 2
+
+    doc, rows, failed = build(paths)
+
+    # REFUSE rather than print a clean page over nothing.
+    if failed or not rows:
+        print('\nREFUSING to report: %d of %d board(s) did not measure (%s).'
+              % (len(failed), len(failed) + len(rows),
+                 ', '.join(failed[:6]) or 'none measured'))
+        return 2
+
+    wanted = [t.strip() for t in args.table.split(',') if t.strip()]
+    for t in wanted:
+        if t not in TABLES:
+            print('unknown table %r; have %s' % (t, ', '.join(TABLES)))
+            return 2
+
+    nc1 = sum(len(r['mismatches']) for _n, d in rows for r in d['control']
+              if 'mismatches' in r)
+    nc2 = len(doc['control']['nc2_mismatches'])
+    if 'control' in wanted or nc1 or nc2:
+        table_control(doc, rows)
+    if nc1 or nc2:
+        print('\nREFUSING to report: the negative control did not reproduce '
+              '(NC1 %d mismatch(es), NC2 %d). Every table below would be a '
+              'page of numbers about a harness, not about the engine.'
+              % (nc1, nc2))
+        return 2
+
+    for t in wanted:
+        if t == 'control':
+            continue
+        TABLES[t](doc, rows)
+
+    if args.out:
+        with open(args.out, 'w', encoding='utf-8') as f:
+            json.dump(doc, f, indent=1, sort_keys=True)
+        print('\nwrote %s' % args.out)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/measure_878_far_face_area.py
+++ b/tests/measure_878_far_face_area.py
@@ -782,8 +782,25 @@ def build(paths):
                                     'got': arm[c]['charged_area_mm2']})
     sha = subprocess.run(['git', 'rev-parse', 'HEAD'], cwd=ROOT,
                          capture_output=True, text=True).stdout.strip()
+    # A BARE HEAD SHA IS A LIE whenever a run is recorded alongside its own
+    # change, which is the normal case: the numbers come from the working
+    # tree, the sha names its parent. The first recording of this file said
+    # `c487e00f`, a commit at which `grow_board` emitted no obstruction dict
+    # at all -- checking it out and re-running would mismatch on every
+    # through-hole board. So the dirty flag ships beside the sha, and it names
+    # the files that were modified.
+    _dirty = subprocess.run(
+        ['git', 'status', '--porcelain', '--', 'py_placer', 'py_router',
+         'py_tools', 'tests'],
+        cwd=ROOT, capture_output=True, text=True).stdout.strip()
+    engine_dirty = sorted(ln[3:] for ln in _dirty.splitlines() if ln[3:])
     doc = {
         'engine_sha': sha,
+        # True when the numbers above came from a tree that did NOT match
+        # `engine_sha`. A reader who checks that commit out and re-runs will
+        # not reproduce them, and this is what says so.
+        'engine_tree_dirty': bool(engine_dirty),
+        'engine_tree_dirty_files': engine_dirty,
         'preregistration': PREREGISTRATION,
         'basis': {'clearance': CLEARANCE,
                   'board_edge_clearance': BOARD_EDGE_CLEARANCE,
@@ -825,8 +842,9 @@ KEEP_PER_BOARD = ('census_sides', 'parts_charged', 'tht_obstructing',
 
 def compact(doc):
     """The committed shape: the deciding cells, not the whole record."""
-    out = {k: doc[k] for k in ('engine_sha', 'preregistration', 'basis',
-                               'confound', 'headline', 'post_hoc',
+    out = {k: doc[k] for k in ('engine_sha', 'engine_tree_dirty',
+                               'engine_tree_dirty_files', 'preregistration',
+                               'basis', 'confound', 'headline', 'post_hoc',
                                'verdict')}
     out['control'] = {
         'nc1_rows': sum(1 for b in doc['boards'].values()
@@ -946,6 +964,31 @@ def main():
         TABLES[t](doc, rows)
 
     if args.out:
+        # THE NOTARY IS NOT REGENERABLE. `--out` is the prescribed fix for any
+        # red in the gate, so if it also rewrote `preregistration` then moving
+        # a threshold after seeing the numbers would be repaired by the very
+        # command the failure message prints -- and the block would be a
+        # comment with extra steps. So: if the target file already carries a
+        # pre-registration and this module's differs, REFUSE, and name the
+        # keys. Changing a pre-registered threshold is a decision that has to
+        # be taken deliberately, by deleting the file or editing it by hand,
+        # never as a side effect of re-recording numbers.
+        prior = None
+        if os.path.isfile(args.out):
+            try:
+                with open(args.out, encoding='utf-8') as f:
+                    prior = json.load(f).get('preregistration')
+            except Exception:                                # noqa: BLE001
+                prior = None
+        if prior is not None and prior != PREREGISTRATION:
+            moved = sorted(k for k in set(prior) | set(PREREGISTRATION)
+                           if prior.get(k) != PREREGISTRATION.get(k))
+            print('\nREFUSING to write %s: it carries a pre-registration that '
+                  'differs from this module on %s.' % (args.out, moved))
+            print('Re-recording NUMBERS must not re-notarise the RULE that '
+                  'chose them. Edit the file by hand, deliberately, if the '
+                  'pre-registration is genuinely meant to change.')
+            return 2
         with open(args.out, 'w', encoding='utf-8') as f:
             json.dump(compact(doc), f, indent=1, sort_keys=True)
         print('\nwrote %s' % args.out)

--- a/tests/measure_878_far_face_area.py
+++ b/tests/measure_878_far_face_area.py
@@ -29,10 +29,11 @@ the public reader, not from `quench._through_pad_bounds_local`.
 
 TWO NEGATIVE CONTROLS, and a failure of either REFUSES the whole report:
 
-  NC1  currency `none` must reproduce `options.grow_board` EXACTLY -- eight
-       fields per (board, basis), not just the answer. This is what proves the
-       harness measures the engine and not itself. A report whose control did
-       not reproduce is a page of numbers about nothing.
+  NC1  the arm the ENGINE implements must reproduce `options.grow_board`
+       EXACTLY -- nine fields per (board, basis), not just the answer. This is
+       what proves the harness measures the engine and not itself, and since
+       #878 landed it also pins WHICH currency ships. A report whose control
+       did not reproduce is a page of numbers about nothing.
   NC2  a board carrying NO drilled pad must be bit-identical under all three
        currencies on every basis. If a currency moves one of those, the harness
        is charging something other than the far face and every cell is suspect.
@@ -220,11 +221,21 @@ def _board_geometry(pcb, path):
 
 
 def _per_side(geom, currency, *, bare_far=False):
-    """`per_side` under one currency. `none` reproduces options.py:245-246."""
+    """The POPULATION and OBSTRUCTION dicts under one currency.
+
+    `pop` is each part once on its own face -- what `options.py:245-246` has
+    always built, identical under every currency. `per` adds the far-face
+    charge this currency says a drilled part presents. They are returned
+    separately because the engine keeps them separately (#878), and a control
+    that compared one against the other would report a mismatch on every board
+    carrying a through-hole part.
+    """
     per = {'F.Cu': 0.0, 'B.Cu': 0.0}
+    pop = {'F.Cu': 0.0, 'B.Cu': 0.0}
     near_total = far_total = 0.0
     for r in geom['rows']:
         per[r['own']] += r['near']
+        pop[r['own']] += r['near']
         near_total += r['near']
         if currency == 'none' or not r['has_tht']:
             continue
@@ -244,7 +255,7 @@ def _per_side(geom, currency, *, bare_far=False):
             raise ValueError(currency)
         per[r['far']] += add
         far_total += add
-    return per, near_total, far_total
+    return per, pop, near_total, far_total
 
 
 def _usable(bounds, edge):
@@ -253,7 +264,8 @@ def _usable(bounds, edge):
 
 
 def _arm(geom, currency, basis, *, edge=BOARD_EDGE_CLEARANCE, bare_far=False):
-    per, near_total, far_total = _per_side(geom, currency, bare_far=bare_far)
+    per, pop, near_total, far_total = _per_side(geom, currency,
+                                                bare_far=bare_far)
     usable = _usable(geom['bounds'], edge)
     busiest = max(per.values()) if per else 0.0
     one_face = basis != 'busiest'
@@ -264,7 +276,11 @@ def _arm(geom, currency, basis, *, edge=BOARD_EDGE_CLEARANCE, bare_far=False):
         'charged_area_mm2': round(charged, 2),
         'utilisation': round(util, 4),
         'fits_by_area': charged <= usable,
-        'part_area_by_side_mm2': {k: round(v, 2) for k, v in sorted(per.items())},
+        # The engine's two dicts, kept apart for the same reason it keeps them
+        # apart: one is the population, one is the obstruction.
+        'part_area_by_side_mm2': {k: round(v, 2) for k, v in sorted(pop.items())},
+        'obstructed_area_by_side_mm2': {k: round(v, 2)
+                                        for k, v in sorted(per.items())},
         'busiest_side_area_mm2': round(busiest, 2),
         'near_charge_mm2': round(near_total, 2),
         'far_charge_mm2': round(far_total, 2),
@@ -280,23 +296,59 @@ def _arm(geom, currency, basis, *, edge=BOARD_EDGE_CLEARANCE, bare_far=False):
 
 # --- the negative controls ---------------------------------------------------
 
-#: The eight fields NC1 compares. Chosen to pin the CHAIN, not just the answer:
+#: The currency the shipping engine implements. NC1 compares
+#: `options.grow_board` against THIS, not against a fixed `none`.
+#:
+#: Before #878 it was `none`, and NC1 read "the harness reproduces the engine".
+#: After, it reads "the harness and the engine agree about which currency
+#: SHIPS" -- strictly more, and still a proof the harness is not measuring
+#: itself, because the harness computes every arm without consulting
+#: `grow_board` at all.
+ENGINE_CURRENCY = 'tht'
+
+
+def _engine_shaped_arm(geom, basis):
+    """The arm the ENGINE actually computes, which is not one of the study arms.
+
+    The distinction is the whole of #878's post-hoc finding, so it is modelled
+    rather than asserted. The engine charges the far face into `obstructed`
+    ALWAYS -- the dict does not depend on the basis -- and then takes
+    `max(obstructed)` on the busiest basis but `sum(per_side)` on the one-face
+    one, because that sum is defined as each part exactly once.
+
+    The study arms deliberately do the other thing on the one-face basis
+    (`sum(obstructed)`), which is what measured the double count. So a control
+    comparing the engine to a study arm would report a mismatch on every board
+    with a through-hole part -- as it did, before this function existed.
+    """
+    a = _arm(geom, ENGINE_CURRENCY, basis)
+    if basis != 'busiest':
+        pop = _arm(geom, 'none', basis)
+        a = dict(a)
+        for k in ('charged_area_mm2', 'utilisation', 'fits_by_area',
+                  'binding_side'):
+            a[k] = pop[k]
+    return a
+
+
+#: The nine fields NC1 compares. Chosen to pin the CHAIN, not just the answer:
 #: each one fails for a different reason.
 NC1_FIELDS = ('charged_area_mm2', 'utilisation', 'fits_by_area',
               'busiest_side_area_mm2', 'part_area_by_side_mm2',
+              'obstructed_area_by_side_mm2',
               'containers_excluded', 'extent_from_courtyard',
               'extent_from_pad_bbox')
 
 
 def _control_row(pcb, path, geom, basis, declared):
-    """currency `none` against the real engine, eight fields."""
+    """The arm the engine implements (`ENGINE_ARM`) against the real engine."""
     eng = O.grow_board(pcb, path, clearance=CLEARANCE,
                        board_edge_clearance=BOARD_EDGE_CLEARANCE,
                        assembly_sides=declared)
     if not eng.get('ran'):
         return {'basis': basis, 'skipped': eng.get('reason', 'did not run')}
     m = eng['measured']
-    mine = _arm(geom, 'none', basis)
+    mine = _engine_shaped_arm(geom, basis)
     mine_extra = {
         'containers_excluded': [r for _a, r in sorted(geom['containers'],
                                                       reverse=True)],
@@ -575,7 +627,7 @@ def headline(rows):
 # --- tables ------------------------------------------------------------------
 
 def table_control(doc, rows):
-    print('\n== control: currency `none` against the engine, %d fields =='
+    print('\n== control: the engine-shaped arm against the engine, %d fields =='
           % len(NC1_FIELDS))
     n = bad = 0
     for name, d in rows:

--- a/tests/mutate_553.py
+++ b/tests/mutate_553.py
@@ -248,6 +248,12 @@ ROWS = [
      (T553,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_554.py
+++ b/tests/mutate_554.py
@@ -336,6 +336,12 @@ ROWS = [
      (T554,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_554.py
+++ b/tests/mutate_554.py
@@ -307,9 +307,18 @@ ROWS = [
     # The relocation's own disclosure replaced by the SELECTOR's. It still reads
     # like a disclosure and still says NOT MEASURED -- about a different
     # experiment. This is the shape a laundered claim actually takes.
+    # RE-ANCHORED (#877). `d3a3f47d` ("#554: the routed A/B ran, and it is
+    # UNDERPOWERED with the incumbent ahead") REWORDED the claim -- the A/B it
+    # said did not exist has since been run -- so the quote matched nothing.
+    # The mutation is unchanged: make the claim name a DIFFERENT experiment
+    # than the one it reports, which is what the gate has to catch.
     ('efficacy-names-the-wrong-experiment', 'r',
-     "NO_EFFICACY_CLAIM = (\n    'NOT MEASURED: no paired routed A/B of relocate-on vs relocate-off exists, '\n",
-     "NO_EFFICACY_CLAIM = (\n    'NOT MEASURED: no paired routed A/B of pins vs diagnosis exists. '\n",
+     "NO_EFFICACY_CLAIM = (\n"
+     "    'UNDERPOWERED, AND THE INCUMBENT WON. The paired routed A/B of relocate-on '\n"
+     "    'vs relocate-off HAS now been run (tests/stress/block_relocation_study.py): '\n",
+     "NO_EFFICACY_CLAIM = (\n"
+     "    'UNDERPOWERED, AND THE INCUMBENT WON. The paired routed A/B of pins '\n"
+     "    'vs diagnosis HAS now been run (tests/stress/block_relocation_study.py): '\n",
      (T554, T554S), 'KILLED'),
 
     # ---- an expected survivor, recorded rather than deleted -----------------

--- a/tests/mutate_619.py
+++ b/tests/mutate_619.py
@@ -161,6 +161,12 @@ ROWS = [
                     'layer rule, so the two values are equal on every fixture)'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def run(tests):
     env = dict(os.environ, PYTHONDONTWRITEBYTECODE='1')

--- a/tests/mutate_620.py
+++ b/tests/mutate_620.py
@@ -407,6 +407,12 @@ ROWS = [
      (T756, T370), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _head():
     p = subprocess.run(['git', 'rev-parse', 'HEAD'], capture_output=True,

--- a/tests/mutate_698.py
+++ b/tests/mutate_698.py
@@ -354,6 +354,12 @@ ROWS = [
      (T698,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),

--- a/tests/mutate_702.py
+++ b/tests/mutate_702.py
@@ -132,13 +132,21 @@ ROWS = [
     # ---- per-ENTRY indexing -------------------------------------------------
     # The whole point of _IntentTerm: aggregate a rule's entries to one scalar
     # per ref and a part hops between two keep-outs at 1.0 -> 1.0.
+    # RE-ANCHORED (#877), and so are the five rows below it. `c7bef8d9` ("#698
+    # prep: the declared-claim measurement leaves the state that enforces it")
+    # moved this gate out of the state class into the module-level
+    # `intent_spec` / `build_zone_spec` / `intent_term_values`, so every anchor
+    # here lost its `self.` and four to eight columns of indent. The CODE is
+    # unchanged and every mutation below is the one it always was; only the
+    # quotation moved. Eight of this battery's 22 rows had been asserting
+    # nothing since that commit, which is what #877 measured.
     ('keepout-terms-collapse-to-one-per-ref', 'q',
-     "        return zones + tuple(\n"
-     "            _IntentTerm('keepout', str(k.get('name') or '<unnamed>'),\n"
-     "                        None, 0.0, False, k)\n"
-     "            for k in kos)\n",
-     "        return zones + (_IntentTerm('keepout', 'all', None, 0.0,\n"
-     "                                    False, kos[0]),)\n",
+     "    return zones + tuple(\n"
+     "        _IntentTerm('keepout', str(k.get('name') or '<unnamed>'),\n"
+     "                    None, 0.0, False, k)\n"
+     "        for k in kos)\n",
+     "    return zones + (_IntentTerm('keepout', 'all', None, 0.0,\n"
+     "                                False, kos[0]),)\n",
      (T702,), 'KILLED'),
 
     # The keep-out slice must stay LIVE, or #701's census lift is defeated:
@@ -147,35 +155,42 @@ ROWS = [
     # the census went lifted=49 -> lifted=0 on arm Q's fixture, and the
     # verdict degraded from
     # `keepout_blocks` to `no_movable_neighbour`.
+    # The REPLACEMENT is re-spelled too, and deliberately: the old one reached
+    # for `self.keepouts`, the whole board's list, which the free function does
+    # not have. Flattening `keepouts_for.values()` is the same mutation -- hand
+    # the ref every keep-out instead of its own live slice, so removing one
+    # entry from `keepouts_for[ref]` changes nothing and the census lift goes
+    # invisible. Widening it to anything else would be a different experiment.
     ('the-keepout-slice-stops-honouring-the-lift', 'q',
-     "        kos = self.keepouts_for.get(ref, ())\n",
-     "        kos = (self.keepouts if self.keepouts_for.get(ref) else ())\n",
+     "    kos = keepouts_for.get(ref, ())\n",
+     "    kos = (tuple(k for _v in keepouts_for.values() for k in _v)\n"
+     "           if keepouts_for.get(ref) else ())\n",
      (T702,), 'KILLED'),
 
     # ---- what the terms MEASURE --------------------------------------------
     ('the-keepout-test-forgets-the-through-hole-rect', 'q',
-     "                out.append(_fp.keepout_hit(t.entry, rects))\n",
-     "                out.append(_fp.keepout_hit(t.entry, (rects[0],)))\n",
+     "            out.append(_fp.keepout_hit(t.entry, rects))\n",
+     "            out.append(_fp.keepout_hit(t.entry, (rects[0],)))\n",
      (T702, T701P), 'KILLED'),
 
     ('the-anchor-branch-is-never-taken', 'q',
-     "                        _anchor = not any(\n"
-     "                            _fp.zone_fits_courtyard(\n"
-     "                                _z['rect'], _p.rect(0.0, 0.0, _r), _tol)\n"
-     "                            for _r in (_p.rot % 360, (_p.rot + 90) % 360))\n",
-     "                        _anchor = False\n",
+     "                _anchor = not any(\n"
+     "                    _fp.zone_fits_courtyard(\n"
+     "                        _z['rect'], _p.rect(0.0, 0.0, _r), _tol)\n"
+     "                    for _r in (_p.rot % 360, (_p.rot + 90) % 360))\n",
+     "                _anchor = False\n",
      (T702,), 'KILLED'),
 
     ('the-zone-tolerance-is-ignored', 'q',
-     "                    _tol = float(_z['tolerance_mm'])\n",
-     "                    _tol = 0.0\n",
+     "            _tol = float(_z['tolerance_mm'])\n",
+     "            _tol = 0.0\n",
      (T702,), 'KILLED'),
 
     ('the-exclusive-zone-term-is-dropped', 'q',
-     "                        _terms.append(_IntentTerm(\n"
-     "                            'zone_exclusive', _z['name'], tuple(_z['rect']),\n"
-     "                            legality.EPS, False, None))\n",
-     "                        pass\n",
+     "                _terms.append(_IntentTerm(\n"
+     "                    'zone_exclusive', _z['name'], tuple(_z['rect']),\n"
+     "                    legality.EPS, False, None))\n",
+     "                pass\n",
      (T702,), 'KILLED'),
 
     # ---- the shared measurement, which the GRADE also calls -----------------
@@ -238,9 +253,19 @@ ROWS = [
      (T702,), 'SURVIVED'),
 
     # ---- inertness ----------------------------------------------------------
+    # RE-ANCHORED (#877). This is the one row whose old anchor names code
+    # `c7bef8d9` DELETED rather than moved: the state no longer guards the
+    # build on "something was declared", it builds unconditionally and lets
+    # `_intent_active` be False. The claim is unchanged -- CONSTRUCTING the
+    # gate when nothing is declared is harmless -- so it is re-pointed at the
+    # early-out that now expresses it, in `build_zone_spec`. Removing that
+    # early-out builds the (empty) spec anyway, which is exactly what the old
+    # `if True:` did, and it must still SURVIVE.
     ('the-gate-is-built-even-with-no-intent', 'q',
-     "        if self.intent_zones or self.keepouts_for:\n",
-     "        if True:\n",
+     "    if not zones:\n"
+     "        return spec\n",
+     "    if False:\n"
+     "        return spec\n",
      (T702,), 'SURVIVED'),
 
     # ---- expected survivors, recorded rather than deleted -------------------
@@ -249,9 +274,9 @@ ROWS = [
     # `intent_ok` returns True on `if not spec`. Recorded so it becomes a
     # detector the day the guard starts meaning something else.
     ('the-active-flag-ignores-whether-anything-bound', 'q',
-     "            self._intent_active = bool(self._intent_spec\n"
-     "                                       or self.keepouts_for)\n",
-     "            self._intent_active = True\n",
+     "        self._intent_active = bool(self._intent_spec"
+     " or self.keepouts_for)\n",
+     "        self._intent_active = True\n",
      (T702,), 'SURVIVED'),
 
     # MEASURED KILLED, and I had expected SURVIVED. Arm A asserts

--- a/tests/mutate_702.py
+++ b/tests/mutate_702.py
@@ -333,6 +333,12 @@ ROWS = [
      (T702,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),

--- a/tests/mutate_702.py
+++ b/tests/mutate_702.py
@@ -43,10 +43,15 @@ start reports nothing at all.
 THE MEASURED TABLE IS IN THE HEADER OF `test_702_quench_intent_gate.py`, FROM
 THE RUN -- never predicted here and never edited afterwards to match.
 
-RE-RUN at 939fec4f, after #877 re-anchored eight of these rows: **22 rows, 18
-killed, 4 survived, 0 broken, 1 disagreeing.** Before it, the same 22 rows were
+RE-RUN at e59e8cf9, after #877 re-anchored eight of these rows: **22 rows, 19
+killed, 3 survived, 0 broken, 1 disagreeing.** Before it, the same 22 rows were
 14 usable and 8 BROKEN -- 8 of this battery's rows had asserted nothing since
 `c7bef8d9`, which is the worst case #877 measured.
+
+(An intermediate run at 939fec4f read 18 killed / 4 survived / 3 disagreeing.
+That is not this table: two rows were still wrong at that commit -- the keepout
+row's first re-anchor was inert, and the active-flag row had not been re-graded
+-- and both are described below. The number above is the shipped table's.)
 
 Two things that run found, both recorded rather than tidied away:
 
@@ -59,10 +64,12 @@ Two things that run found, both recorded rather than tidied away:
     is the one disagreement left, and it is NOT from #877's work: the row, its
     target (`floorplan.py`) and its witness are byte-identical to
     upstream/main, so its verdict is deterministic and predates this branch.
-    It was invisible because the battery already exited non-zero on the eight
-    BROKEN rows, so nobody read past them. Left standing as a real finding
-    about this gate's coverage, to be fixed on its own terms rather than
-    folded into an anchor pass.
+    It is a COVERAGE REGRESSION, not a wrong expectation -- the table in
+    `test_702_quench_intent_gate.py` records this row as KILLED when it was
+    last measured, so the gate went quiet in between. It was invisible because
+    the battery already exited non-zero on the eight BROKEN rows, so nobody
+    read past them. Left standing as a real finding, to be fixed on its own
+    terms rather than folded into an anchor pass.
 """
 from __future__ import annotations
 

--- a/tests/mutate_702.py
+++ b/tests/mutate_702.py
@@ -42,6 +42,27 @@ start reports nothing at all.
 
 THE MEASURED TABLE IS IN THE HEADER OF `test_702_quench_intent_gate.py`, FROM
 THE RUN -- never predicted here and never edited afterwards to match.
+
+RE-RUN at 939fec4f, after #877 re-anchored eight of these rows: **22 rows, 18
+killed, 4 survived, 0 broken, 1 disagreeing.** Before it, the same 22 rows were
+14 usable and 8 BROKEN -- 8 of this battery's rows had asserted nothing since
+`c7bef8d9`, which is the worst case #877 measured.
+
+Two things that run found, both recorded rather than tidied away:
+
+  * `the-active-flag-ignores-whether-anything-bound` was recorded SURVIVED and
+    now KILLS. The gate got stronger while the row could not fire: `test_702`
+    has since grown two arms that assert `_intent_active` itself rather than
+    its consequences. Re-graded KILLED, with the arms named at the row.
+
+  * `the-crossed-claim-check-never-fires` SURVIVES and is expected KILLED. It
+    is the one disagreement left, and it is NOT from #877's work: the row, its
+    target (`floorplan.py`) and its witness are byte-identical to
+    upstream/main, so its verdict is deterministic and predates this branch.
+    It was invisible because the battery already exited non-zero on the eight
+    BROKEN rows, so nobody read past them. Left standing as a real finding
+    about this gate's coverage, to be fixed on its own terms rather than
+    folded into an anchor pass.
 """
 from __future__ import annotations
 
@@ -155,16 +176,26 @@ ROWS = [
     # the census went lifted=49 -> lifted=0 on arm Q's fixture, and the
     # verdict degraded from
     # `keepout_blocks` to `no_movable_neighbour`.
-    # The REPLACEMENT is re-spelled too, and deliberately: the old one reached
-    # for `self.keepouts`, the whole board's list, which the free function does
-    # not have. Flattening `keepouts_for.values()` is the same mutation -- hand
-    # the ref every keep-out instead of its own live slice, so removing one
-    # entry from `keepouts_for[ref]` changes nothing and the census lift goes
-    # invisible. Widening it to anything else would be a different experiment.
+    # RE-ANCHORED TO THE CALL SITE (#877), and the first re-anchor here was
+    # WRONG -- recorded because the run caught it and the row is the reason the
+    # run exists. `c7bef8d9` left the free `intent_spec` no `self.keepouts` to
+    # reach for, so the first attempt flattened `keepouts_for.values()`
+    # instead. MEASURED: SURVIVED, expected KILLED. On this fixture one ref
+    # holds every keep-out, so the flattened union EQUALS that ref's own slice
+    # and the mutation is a no-op -- a re-anchor that had quietly stopped
+    # expressing the claim, which is exactly the failure #877 is about.
+    #
+    # `self.keepouts` is still there (quench.py:892); it is the CALLER that has
+    # it now. Mutating the call site reproduces the original edit exactly --
+    # hand the ref every keep-out on the board whenever it has any, so removing
+    # one entry from `keepouts_for[ref]` changes nothing and #701's census lift
+    # goes invisible.
     ('the-keepout-slice-stops-honouring-the-lift', 'q',
-     "    kos = keepouts_for.get(ref, ())\n",
-     "    kos = (tuple(k for _v in keepouts_for.values() for k in _v)\n"
-     "           if keepouts_for.get(ref) else ())\n",
+     "        return intent_spec(self._intent_spec, self.keepouts_for, ref)\n",
+     "        return intent_spec(\n"
+     "            self._intent_spec,\n"
+     "            {ref: self.keepouts} if self.keepouts_for.get(ref) else {},\n"
+     "            ref)\n",
      (T702,), 'KILLED'),
 
     # ---- what the terms MEASURE --------------------------------------------
@@ -268,16 +299,28 @@ ROWS = [
      "        return spec\n",
      (T702,), 'SURVIVED'),
 
-    # ---- expected survivors, recorded rather than deleted -------------------
-    # `_intent_active` is what candidate_valid guards on; flipping it ON with
-    # an empty spec changes nothing, because every lookup misses and
-    # `intent_ok` returns True on `if not spec`. Recorded so it becomes a
-    # detector the day the guard starts meaning something else.
+    # RE-ANCHORED AND RE-GRADED (#877). The anchor was a two-line wrap that
+    # `c7bef8d9` reflowed onto one line.
+    #
+    # It was recorded SURVIVED, with the reasoning that flipping the flag ON
+    # with an empty spec changes nothing: every lookup misses and `intent_ok`
+    # returns True on `if not spec`. MEASURED NOW: KILLED. The gate got
+    # stronger while the row could not fire -- `test_702` has since grown two
+    # arms that assert the FLAG rather than its consequences, and both fail:
+    #
+    #     FAIL a state with no intent binds nothing --
+    #          _intent_active False, _intent_spec empty
+    #     FAIL a no-intent quench never calls the gate --
+    #          the intent gate was reached with no intent
+    #
+    # Graded KILLED, from the run. The old expectation is kept in this comment
+    # rather than overwritten, because "the day the guard starts meaning
+    # something else" is the day this row was written for, and it arrived.
     ('the-active-flag-ignores-whether-anything-bound', 'q',
      "        self._intent_active = bool(self._intent_spec"
      " or self.keepouts_for)\n",
      "        self._intent_active = True\n",
-     (T702,), 'SURVIVED'),
+     (T702,), 'KILLED'),
 
     # MEASURED KILLED, and I had expected SURVIVED. Arm A asserts
     # `by_site['candidate_valid'] > 0`, so the tally is load-bearing after all:

--- a/tests/mutate_703.py
+++ b/tests/mutate_703.py
@@ -78,10 +78,18 @@ _TIE_SCAN = (
     "            j += 1\n"
     "        avg = (i + j) / 2.0 + 1\n")
 
+# DISAMBIGUATED (#877). `89bd8a29` ("#789: the arithmetic -- Kendall tau-b in
+# rank_stats, and its self-test") added `board_tau` as a near-copy of
+# `board_rho`, so this block occurs TWICE. `replace(..., 1)` would still have
+# hit the `board_rho` copy -- it is first in the file -- but only by luck of
+# ordering, and the battery's own exactly-once check reported BROKEN. The
+# trailing line is board_rho's alone (`board_tau` tests both columns in one
+# `or`), so the quote names the site the row is about.
 _DROP_NULL = (
     "        if p is None or d is None:\n"
     "            dropped += 1\n"
-    "            continue\n")
+    "            continue\n"
+    "        if isinstance(p, float) and p != p:\n")
 
 _MAPPING_GUARD = (
     "    if not isinstance(rhos_by_board, Mapping):\n"
@@ -181,9 +189,18 @@ ROWS = [
      (T703,), 'KILLED'),
 
     # ---- the formatter that cannot emit a bare rho -------------------------
+    # DISAMBIGUATED (#877), with `fmt-rho-hides-a-missing-span` below. `fmt_tau`
+    # is a near-copy of `fmt_rho` and carries the same two `span` lines, so both
+    # rows quoted a string that occurs TWICE. The `rho=n/a` prefix belongs to
+    # `fmt_rho` alone and names the function each row is about; the mutations
+    # are unchanged.
     ('fmt-rho-drops-the-LOO-span', 'rs',
+     "        return f'rho=n/a [{reason or \"not measurable\"}' + (\n"
+     "            f', K={k}]' if k is not None else ']')\n"
      "    span = (f'LOO {fmt(lo, 0)}..{fmt(hi, 0)}' if lo == lo and hi == hi\n"
      "            else 'LOO not computed')\n",
+     "        return f'rho=n/a [{reason or \"not measurable\"}' + (\n"
+     "            f', K={k}]' if k is not None else ']')\n"
      "    span = ''\n",
      (T703,), 'KILLED'),
 
@@ -201,7 +218,8 @@ ROWS = [
     ('board-rho-coerces-a-null-to-zero', 'rs',
      _DROP_NULL,
      "        if p is None or d is None:\n"
-     "            p, d = (p or 0), (d or 0)\n",
+     "            p, d = (p or 0), (d or 0)\n"
+     "        if isinstance(p, float) and p != p:\n",
      (T703,), 'KILLED'),
 
     # ---- the anti-pooling guard, EXECUTED --------------------------------
@@ -236,7 +254,13 @@ ROWS = [
 
     # ---- renderings that misreport their own scope -------------------------
     ('fmt-rho-hides-a-missing-span', 'rs',
+     "        return f'rho=n/a [{reason or \"not measurable\"}' + (\n"
+     "            f', K={k}]' if k is not None else ']')\n"
+     "    span = (f'LOO {fmt(lo, 0)}..{fmt(hi, 0)}' if lo == lo and hi == hi\n"
      "            else 'LOO not computed')\n",
+     "        return f'rho=n/a [{reason or \"not measurable\"}' + (\n"
+     "            f', K={k}]' if k is not None else ']')\n"
+     "    span = (f'LOO {fmt(lo, 0)}..{fmt(hi, 0)}' if lo == lo and hi == hi\n"
      "            else '')\n",
      (T703,), 'KILLED'),
 

--- a/tests/mutate_703.py
+++ b/tests/mutate_703.py
@@ -328,6 +328,12 @@ ROWS = [
      (T703,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _uncache(path):
     """Delete the target's cached bytecode. MEASURED HAZARD, not hygiene.

--- a/tests/mutate_705_792_794.py
+++ b/tests/mutate_705_792_794.py
@@ -294,6 +294,12 @@ ROWS = [
      (T792P,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),

--- a/tests/mutate_708.py
+++ b/tests/mutate_708.py
@@ -250,6 +250,12 @@ ROWS = [
      (T_SNAP, T_RESEAT), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _uncache(path):
     """Delete the target's cached bytecode. MEASURED HAZARD, not hygiene --

--- a/tests/mutate_711.py
+++ b/tests/mutate_711.py
@@ -225,6 +225,12 @@ ROWS = [
      (T706,), KILLED),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _clear_pycache():
     """Delete every `__pycache__` under the repo.

--- a/tests/mutate_713_census.py
+++ b/tests/mutate_713_census.py
@@ -154,11 +154,11 @@ for label, rel, old, new, why in ROWS:
         # RAW BYTES for the restore, decoded text for the match (#877).
         # Writing without `newline=''` translates every '\n' to os.linesep, so
         # on Windows one run rewrote the whole target in CRLF and left it
-        # permanently "modified" -- which then tripped a dirty-tree refusal on
-        # the next run. `.gitattributes` pins `*.py text eol=lf`, so that was a
-        # real corruption, not a preference. `mutate_711.py:296-321` has the
-        # same pair and records the other half: matching a multi-line anchor
-        # against a RAW decode silently found nothing in three rows.
+        # modified in `git status`. `.gitattributes` pins `*.py text eol=lf`,
+        # so that is a real corruption, not a preference -- and this battery
+        # has NO dirty-tree refusal to notice it. `mutate_711.py` has the same
+        # raw/decoded pair and records the other half: matching a multi-line
+        # anchor against a RAW decode silently found nothing in three rows.
         raw = open(path, 'rb').read()
         with open(path, encoding='utf-8') as f:
             original = f.read()

--- a/tests/mutate_713_census.py
+++ b/tests/mutate_713_census.py
@@ -15,6 +15,20 @@ import shutil
 import subprocess
 import sys
 
+# This battery's runner is at MODULE SCOPE, so `import mutate_713_census`
+# RUNS THE GATE AND REWRITES ENGINE FILES. #877 was filed after a census did
+# exactly that to six batteries, rewrote 13 files under py_router/ and
+# py_placer/, and then reported numbers measured against its own damage.
+# Refusing the import outright, rather than hiding the runner behind
+# `if __name__`, keeps the reason visible and names the API that answers the
+# question the importer actually had.
+if __name__ != '__main__':                                 # pragma: no cover
+    raise ImportError(
+        'tests/mutate_713_census.py is a SCRIPT, not a module: importing it '
+        'runs the battery and rewrites engine files in place. To read its '
+        'rows, use tests/mutation_anchors.resolve_static(path), which parses '
+        'the file instead of executing it.')
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 GATE = os.path.join(ROOT, 'tests', 'test_713_wallclock_census.py')
 
@@ -84,6 +98,12 @@ ROWS = [
      'rather than discovered later'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 #: Rows that MUST survive, with the reason. A recorded expected survivor is a
 #: stated limit of the gate; an unrecorded one is a hole nobody looked at.
@@ -131,6 +151,15 @@ for label, rel, old, new, why in ROWS:
             broken += 1
             continue
     else:
+        # RAW BYTES for the restore, decoded text for the match (#877).
+        # Writing without `newline=''` translates every '\n' to os.linesep, so
+        # on Windows one run rewrote the whole target in CRLF and left it
+        # permanently "modified" -- which then tripped a dirty-tree refusal on
+        # the next run. `.gitattributes` pins `*.py text eol=lf`, so that was a
+        # real corruption, not a preference. `mutate_711.py:296-321` has the
+        # same pair and records the other half: matching a multi-line anchor
+        # against a RAW decode silently found nothing in three rows.
+        raw = open(path, 'rb').read()
         with open(path, encoding='utf-8') as f:
             original = f.read()
         if original.count(old) != 1:
@@ -139,7 +168,7 @@ for label, rel, old, new, why in ROWS:
             broken += 1
             continue
     try:
-        with open(path, 'w', encoding='utf-8') as f:
+        with open(path, 'w', encoding='utf-8', newline='') as f:
             f.write(new if created else original.replace(old, new))
         _clear_pyc()
         rc, out = run_gate()
@@ -147,8 +176,7 @@ for label, rel, old, new, why in ROWS:
         if created:
             os.unlink(path)
         else:
-            with open(path, 'w', encoding='utf-8') as f:
-                f.write(original)
+            open(path, 'wb').write(raw)      # byte-exact, from what was read
         _clear_pyc()
     expected = label in EXPECTED_SURVIVORS
     if rc != 0:

--- a/tests/mutate_713_phase1.py
+++ b/tests/mutate_713_phase1.py
@@ -192,10 +192,11 @@ for label, rel, old, new, why in ROWS:
     path = os.path.join(ROOT, rel)
     # RAW BYTES for the restore, decoded text for the match (#877). Writing
     # without `newline=''` translates every '\n' to os.linesep, so on Windows
-    # one run rewrote the whole target in CRLF and left it permanently
-    # "modified". `.gitattributes` pins `*.py text eol=lf`, so that was a real
-    # corruption. `mutate_711.py:296-321` records the other half: matching a
-    # multi-line anchor against a RAW decode silently found nothing.
+    # one run rewrote the whole target in CRLF and left it modified in `git
+    # status`. `.gitattributes` pins `*.py text eol=lf`, so that is a real
+    # corruption -- and this battery has NO dirty-tree refusal to notice it.
+    # `mutate_711.py` records the other half: matching a multi-line anchor
+    # against a RAW decode silently found nothing.
     raw = open(path, 'rb').read()
     with open(path, encoding='utf-8') as f:
         original = f.read()

--- a/tests/mutate_713_phase1.py
+++ b/tests/mutate_713_phase1.py
@@ -20,6 +20,20 @@ import shutil
 import subprocess
 import sys
 
+# This battery's runner is at MODULE SCOPE, so `import mutate_713_phase1`
+# RUNS THE GATE AND REWRITES ENGINE FILES. #877 was filed after a census did
+# exactly that to six batteries, rewrote 13 files under py_router/ and
+# py_placer/, and then reported numbers measured against its own damage.
+# Refusing the import outright, rather than hiding the runner behind
+# `if __name__`, keeps the reason visible and names the API that answers the
+# question the importer actually had.
+if __name__ != '__main__':                                 # pragma: no cover
+    raise ImportError(
+        'tests/mutate_713_phase1.py is a SCRIPT, not a module: importing it '
+        'runs the battery and rewrites engine files in place. To read its '
+        'rows, use tests/mutation_anchors.resolve_static(path), which parses '
+        'the file instead of executing it.')
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 GATE = os.path.join(ROOT, 'tests', 'test_713_refill_status.py')
 
@@ -140,6 +154,12 @@ ROWS = [
      'an absent verdict must not be reported as a fact about the board'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _clear_pyc():
     for base, dirs, _ in os.walk(ROOT):
@@ -170,6 +190,13 @@ print(f"baseline: gate passes clean ({out.strip().splitlines()[-1]})\n")
 killed = survived = broken = 0
 for label, rel, old, new, why in ROWS:
     path = os.path.join(ROOT, rel)
+    # RAW BYTES for the restore, decoded text for the match (#877). Writing
+    # without `newline=''` translates every '\n' to os.linesep, so on Windows
+    # one run rewrote the whole target in CRLF and left it permanently
+    # "modified". `.gitattributes` pins `*.py text eol=lf`, so that was a real
+    # corruption. `mutate_711.py:296-321` records the other half: matching a
+    # multi-line anchor against a RAW decode silently found nothing.
+    raw = open(path, 'rb').read()
     with open(path, encoding='utf-8') as f:
         original = f.read()
     if original.count(old) != 1:
@@ -178,13 +205,12 @@ for label, rel, old, new, why in ROWS:
         broken += 1
         continue
     try:
-        with open(path, 'w', encoding='utf-8') as f:
+        with open(path, 'w', encoding='utf-8', newline='') as f:
             f.write(original.replace(old, new))
         _clear_pyc()
         rc, out = run_gate()
     finally:
-        with open(path, 'w', encoding='utf-8') as f:
-            f.write(original)
+        open(path, 'wb').write(raw)          # byte-exact, from what was read
         _clear_pyc()
     if rc != 0:
         killed += 1

--- a/tests/mutate_714.py
+++ b/tests/mutate_714.py
@@ -282,6 +282,12 @@ ROWS = [
      (PERT,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths), cwd=_ROOT)

--- a/tests/mutate_726.py
+++ b/tests/mutate_726.py
@@ -209,7 +209,12 @@ ROWS = [
 # rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
 # witnesses have been paid for; this is the one second (#877).
 from mutation_anchors import preflight   # noqa: E402
-preflight(__file__)
+# `repo_wide=True` because THIS battery's own check was the strictest in the
+# tree: `verify_anchors` below also refuses an anchor that occurs in another
+# tracked file, the prose trap its docstring describes. `preflight` handles
+# `--verify-anchors` itself, so without this the shared check would have
+# SHADOWED the stricter one and quietly dropped that column.
+preflight(__file__, repo_wide=True)
 
 
 def _uncache(path):

--- a/tests/mutate_726.py
+++ b/tests/mutate_726.py
@@ -205,6 +205,12 @@ ROWS = [
      (T_SYNC,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _uncache(path):
     """Delete the target's cached bytecode. MEASURED HAZARD, not hygiene.

--- a/tests/mutate_730.py
+++ b/tests/mutate_730.py
@@ -69,13 +69,17 @@ _VIA_GATE = """        if override_holes and override_hole_gap(
 _CONN_GATE = """        if override_holes and override_hole_gap(
                 net_id, sx, sy, ex, ey) < hw - 1e-4:
             return False"""
-# RE-ANCHORED (#877), with the three site-E rows that share this quote.
-# `b02761b7` ("legality: the board's own copper-to-hole floor, and the review
-# its tripwire asked for (#761)") replaced `defaults.NPTH_TO_TRACK_CLEARANCE`
-# with the board-resolved local `_npth_floor` and reflowed the two lines into
-# one. The REPLACEMENTS below are re-spelled to `_npth_floor` as well, so each
-# row still changes exactly ONE thing: reverting to the raw default would drop
-# the board floor too, which is a second mutation and a different experiment.
+# RE-ANCHORED (#877). `b02761b7` ("legality: the board's own copper-to-hole
+# floor, and the review its tripwire asked for (#761)") replaced
+# `defaults.NPTH_TO_TRACK_CLEARANCE` with the board-resolved local
+# `_npth_floor` and reflowed the two lines into one, staling this quote and the
+# three site-E rows that inline their own copy of it.
+#
+# Where the mutation lands AT that line, the replacement says `_npth_floor`
+# too, so the row still changes exactly one thing -- naming the raw default
+# there would drop the board floor as well, which is a second mutation. The
+# one exception is `site-E-reverted-to-the-hoist`, whose edit lands at the TOP
+# of `__init__` where `_npth_floor` is not yet bound; see the note on that row.
 _E_BLOCK = """                    _lc = ((getattr(p, 'local_clearance', 0.0) or 0.0)
                            if copper_holes else 0.0)
                     npth_grow = max(0.0, max(_npth_floor, _lc) - clearance)"""
@@ -224,7 +228,16 @@ ROWS = [
        "'s pad requirements\n",
        '        self.max_floor = 0.0    # upper bound on this part'
        "'s pad requirements\n"
-       '        npth_grow = max(0.0, _npth_floor - clearance)\n'),
+       # NOT `_npth_floor`: this line is hoisted to the TOP of `__init__`
+       # (legality.py:2090) and `_npth_floor` is a local of that same function
+       # bound sixteen lines later, at :2105. Naming it here makes every
+       # `PartPads` construction raise UnboundLocalError, so the row reports
+       # its expected KILLED for an exception rather than for the floor -- a
+       # green tally measuring nothing, which is #877's own defect. The flat
+       # default is also what the pre-#730 hoist actually said, so this is the
+       # faithful revert as well as the working one.
+       '        npth_grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE'
+       ' - clearance)\n'),
       (_E_BLOCK, '                    pass')],
      None, (T730,), 'KILLED'),
     ('site-E-loses-the-fab-floor', 'leg',

--- a/tests/mutate_730.py
+++ b/tests/mutate_730.py
@@ -253,6 +253,12 @@ ROWS = [
      (T730,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_730.py
+++ b/tests/mutate_730.py
@@ -69,10 +69,16 @@ _VIA_GATE = """        if override_holes and override_hole_gap(
 _CONN_GATE = """        if override_holes and override_hole_gap(
                 net_id, sx, sy, ex, ey) < hw - 1e-4:
             return False"""
+# RE-ANCHORED (#877), with the three site-E rows that share this quote.
+# `b02761b7` ("legality: the board's own copper-to-hole floor, and the review
+# its tripwire asked for (#761)") replaced `defaults.NPTH_TO_TRACK_CLEARANCE`
+# with the board-resolved local `_npth_floor` and reflowed the two lines into
+# one. The REPLACEMENTS below are re-spelled to `_npth_floor` as well, so each
+# row still changes exactly ONE thing: reverting to the raw default would drop
+# the board floor too, which is a second mutation and a different experiment.
 _E_BLOCK = """                    _lc = ((getattr(p, 'local_clearance', 0.0) or 0.0)
                            if copper_holes else 0.0)
-                    npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,
-                                             _lc) - clearance)"""
+                    npth_grow = max(0.0, max(_npth_floor, _lc) - clearance)"""
 
 # (name, target, old, new, tests, expect)
 ROWS = [
@@ -218,18 +224,17 @@ ROWS = [
        "'s pad requirements\n",
        '        self.max_floor = 0.0    # upper bound on this part'
        "'s pad requirements\n"
-       '        npth_grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE'
-       ' - clearance)\n'),
+       '        npth_grow = max(0.0, _npth_floor - clearance)\n'),
       (_E_BLOCK, '                    pass')],
      None, (T730,), 'KILLED'),
     ('site-E-loses-the-fab-floor', 'leg',
-     '                    npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,\n'
-     '                                             _lc) - clearance)',
+     '                    npth_grow = max(0.0, max(_npth_floor, _lc)'
+     ' - clearance)',
      '                    npth_grow = max(0.0, _lc - clearance)',
      (T730,), 'KILLED'),
     ('site-E-threshold-at-clearance', 'leg',
-     '                    npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,\n'
-     '                                             _lc) - clearance)',
+     '                    npth_grow = max(0.0, max(_npth_floor, _lc)'
+     ' - clearance)',
      '                    npth_grow = max(0.0, max(clearance, _lc) - clearance)',
      (T730,), 'KILLED'),
     ('site-E-silk-gate-dropped', 'leg',
@@ -240,9 +245,9 @@ ROWS = [
     # an exact re-spelling of `max`. Recorded so nobody reads its survival as
     # a coverage hole.
     ('site-E-max-respelled-as-a-conditional', 'leg',
-     '                    npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,\n'
-     '                                             _lc) - clearance)',
-     '                    _f = defaults.NPTH_TO_TRACK_CLEARANCE\n'
+     '                    npth_grow = max(0.0, max(_npth_floor, _lc)'
+     ' - clearance)',
+     '                    _f = _npth_floor\n'
      '                    npth_grow = max(0.0, (_lc if _lc > _f else _f)\n'
      '                                    - clearance)',
      (T730,), 'SURVIVED'),

--- a/tests/mutate_735.py
+++ b/tests/mutate_735.py
@@ -217,6 +217,12 @@ ROWS = [
      (T735, TDRUC), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_746.py
+++ b/tests/mutate_746.py
@@ -139,6 +139,12 @@ GUI_ROWS = [
      "    via_resolved = result['via_resolved']"),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 BATTERIES = {
     'engine': (ENGINE, ENGINE_TEST, ENGINE_ROWS),
     'gui': (GUI, GUI_TEST, GUI_ROWS),

--- a/tests/mutate_747.py
+++ b/tests/mutate_747.py
@@ -329,6 +329,12 @@ ROWS = [
      (T747, T736, T746, T775), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_747.py
+++ b/tests/mutate_747.py
@@ -144,10 +144,15 @@ ROWS = [
      '                        radius=None,',
      (T747, T725), 'KILLED'),
 
+    # RE-ANCHORED (#877). `f1bfee4d` ("#779: the seed half of the via
+    # disclosure grades seed BARRELS") reformatted the `_register_via(...)`
+    # call: the statement no longer closes on this line, so the trailing `))`
+    # became `)` and the anchor matched nothing. Dropping the keep-out
+    # carry-over is still the mutation.
     ('drop-keepout-carry-over', 'fc',
      """                        radius=None if rec is None else rec[1],
-                        keepout=t[3]))""",
-     """                        radius=0.0 if rec is None else rec[1]))""",
+                        keepout=t[3])""",
+     """                        radius=0.0 if rec is None else rec[1])""",
      (T747,), 'KILLED'),
 
     # ---- the registrar: the match --------------------------------------

--- a/tests/mutate_750.py
+++ b/tests/mutate_750.py
@@ -180,6 +180,12 @@ ROWS = [
      'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_756.py
+++ b/tests/mutate_756.py
@@ -303,6 +303,12 @@ ROWS = [
      (T756, T370), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_760.py
+++ b/tests/mutate_760.py
@@ -22,6 +22,20 @@ Run it after touching either site:
 import os
 import subprocess
 import sys
+
+# This battery's runner is at MODULE SCOPE, so `import mutate_760` REWRITES
+# ENGINE FILES. #877 was filed after a census did exactly that to six batteries
+# and rewrote 13 files under py_router/ and py_placer/ -- then reported numbers
+# measured against its own damage. Refusing the import outright, rather than
+# hiding the runner behind `if __name__`, keeps the reason visible and points
+# at the API that answers the question the importer actually had.
+if __name__ != '__main__':                                 # pragma: no cover
+    raise ImportError(
+        'tests/mutate_760.py is a SCRIPT, not a module: importing it runs the '
+        'battery and rewrites engine files in place. To read its rows, use '
+        'tests/mutation_anchors.resolve_static(path), which parses the file '
+        'instead of executing it.')
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SER = os.path.join(ROOT, 'py_router/single_ended_routing.py')
 PCM = os.path.join(ROOT, 'py_router/pcb_modification.py')
@@ -61,11 +75,35 @@ ROWS = [
    "                hd >= npth_clr + w / 2.0 - 1e-4 and\n"
    "                edge_clears(x1, y1, x2, y2, w))"),
 ]
+
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
 killed = surv = broken = 0
+
+# A dirty target would be RESTORED to its committed text, silently destroying
+# uncommitted work. Every other battery refuses; this one did not (#877).
+_dirty = subprocess.run(
+    ['git', 'status', '--porcelain', '--'] + sorted({r[1] for r in ROWS}),
+    cwd=ROOT, capture_output=True, text=True).stdout.strip()
+if _dirty:
+    print('REFUSED: the files this battery rewrites have uncommitted changes.\n'
+          'Restoring them writes the COMMITTED text back over your work.\n'
+          + _dirty)
+    sys.exit(2)
+
 for row in ROWS:
     name, path, old, new = row[:4]
     nth = row[4] if len(row) > 4 else None
-    orig = open(path).read()
+    # RAW BYTES for the restore, decoded text for the match (#877). This was
+    # the worst of the four: no encoding AND no newline on either side, so it
+    # round-tripped every target through the locale codec (cp1252 on Windows)
+    # and translated every '\n' to os.linesep. `.gitattributes` pins `*.py text
+    # eol=lf`, so a single run left every target permanently "modified".
+    raw = open(path, 'rb').read()
+    orig = raw.decode('utf-8').replace('\r\n', '\n')
     if nth is not None:            # replace the Nth occurrence only
         parts = orig.split(old)
         if len(parts) - 1 < nth + 1:
@@ -77,7 +115,7 @@ for row in ROWS:
             print(f'  BROKEN {name}: anchor count {orig.count(old)}')
             broken += 1; continue
         mut = orig.replace(old, new)
-    open(path, 'w').write(mut)
+    open(path, 'w', encoding='utf-8', newline='').write(mut)
     try:
         r = subprocess.run([sys.executable, TEST], capture_output=True, text=True,
                            cwd=ROOT, timeout=600)
@@ -90,6 +128,6 @@ for row in ROWS:
             print(f'  SURVIVED {name}')
             surv += 1
     finally:
-        open(path, 'w').write(orig)
+        open(path, 'wb').write(raw)          # byte-exact, from what was read
 print(f'\n{killed} killed, {surv} SURVIVED, {broken} broken')
 sys.exit(1 if surv or broken else 0)

--- a/tests/mutate_761.py
+++ b/tests/mutate_761.py
@@ -216,6 +216,12 @@ ROWS = [
      (T761,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_768.py
+++ b/tests/mutate_768.py
@@ -105,8 +105,18 @@ _DISCLOSE = """                    if _capped:
 
 _HOLE_KW = "                hole_clearance=_hc,\n"
 
-_GUI_CEILING = ("                netclass_ceiling="
-                "fanout_config.get('clearance_ceiling'),\n")
+# RE-ANCHORED (#877), with the five other GUI rows below. `1c044399` ("#530
+# decision 2: --clearance sets the Default class; --clearance-ceiling caps every
+# class") renamed the shared key `clearance_ceiling` -> `placement_clearance_
+# ceiling`, keeping the old spelling as a two-line `.get(new, .get(old))`
+# fallback, and replaced `self.clearance_check.GetValue()` with
+# `self._ceiling_on()`. Six of this battery's 31 rows quoted the one-line forms
+# and had matched nothing since. The mutations are unchanged.
+_GUI_CEILING = (
+    "                netclass_ceiling=fanout_config.get("
+    "'placement_clearance_ceiling',\n"
+    "                                                   fanout_config.get("
+    "'clearance_ceiling')),\n")
 
 # RE-ANCHORED (#780). The predicate grew a second shape -- a FANOUT step
 # that switches the inline cap pass on runs the same pass -- so the old
@@ -250,18 +260,18 @@ ROWS = [
     # back on the OMITTED one. Found by a parity review measuring the value,
     # after two string-count assertions passed it.
     ('gui-gate-is-fix-drc-settings', 'gui',
-     "netclass_ceiling=fanout_config.get('clearance_ceiling'),",
-     "netclass_ceiling=(fanout_config.get('clearance')\n"
+     _GUI_CEILING,
+     "                netclass_ceiling=(fanout_config.get('clearance')\n"
      "                                  if fanout_config.get("
-     "'fix_drc_settings', True) else None),",
+     "'fix_drc_settings', True) else None),\n",
      (T768, TDLG), 'KILLED'),
     # THE SECOND CUT'S DEFECT, found by an adversarial review: the RESOLVED base
     # is already min(Default class, override), so handing it over as a ceiling
     # caps a class BETWEEN the two down to the Default. Measured 22 cap
     # clearance violations against main's 2 at the default dialog config.
     ('gui-ceiling-is-the-resolved-base', 'gui',
-     "netclass_ceiling=fanout_config.get('clearance_ceiling'),",
-     "netclass_ceiling=fanout_config.get('clearance'),",
+     _GUI_CEILING,
+     "                netclass_ceiling=fanout_config.get('clearance'),\n",
      (TDLG,), 'KILLED'),
     # RE-ANCHORED AND RE-GRADED (#780). The inline cap config gained the
     # same pair of lines at a DEEPER indent, and 12 spaces + the text is a
@@ -275,14 +285,20 @@ ROWS = [
     # driving run_cap_optimization. Both are fixed in the same commit
     # range; T772 is added because it drives the step end to end.
     ('gui-standalone-cfg-drops-the-key', 'gui',
-     "            'clearance_ceiling': shared.get('clearance_ceiling'),\n"
+     "            'clearance_ceiling': shared.get("
+     "'placement_clearance_ceiling',\n"
+     "                                            shared.get("
+     "'clearance_ceiling')),\n"
      "            'fix_drc_settings': shared.get('fix_drc_settings', True),\n",
      "            'fix_drc_settings': shared.get('fix_drc_settings', True),\n",
      (T768, TDLG, T772), 'KILLED'),
     # #780's own half of the same defect, on the INLINE dict. Its only
     # behavioural killer is TDLG's section 2, which drives _run_bga_fanout.
     ('gui-inline-cfg-drops-the-key', 'gui',
-     "                'clearance_ceiling': shared.get('clearance_ceiling'),\n",
+     "                'clearance_ceiling': shared.get("
+     "'placement_clearance_ceiling',\n"
+     "                                                shared.get("
+     "'clearance_ceiling')),\n",
      '',
      (TDLG,), 'KILLED'),
     ('fanout-tab-exports-the-RESOLVED-clearance-as-the-ceiling', 'swig',
@@ -295,7 +311,7 @@ ROWS = [
     # That is the runner behaving exactly as designed.
     ('fanout-tab-stops-exporting-the-override', 'swig',
      "                # what the pass must price at.\n"
-     "                'clamp_netclasses': self.clearance_check.GetValue(),\n",
+     "                'clamp_netclasses': self._ceiling_on(),\n",
      '',
      (T768, TDLG), 'KILLED'),
     # #768's plan-executor half: an OMITTED --clearance must not inherit the

--- a/tests/mutate_768.py
+++ b/tests/mutate_768.py
@@ -333,6 +333,12 @@ ROWS = [
      (T768,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_775.py
+++ b/tests/mutate_775.py
@@ -190,6 +190,12 @@ ROWS = [
      (T775,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_779.py
+++ b/tests/mutate_779.py
@@ -158,6 +158,12 @@ ROWS = [
      (T779,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],

--- a/tests/mutate_789.py
+++ b/tests/mutate_789.py
@@ -130,6 +130,12 @@ ROWS = [
      (T_HARNESS,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def run(tests):
     for t in tests:

--- a/tests/mutate_797.py
+++ b/tests/mutate_797.py
@@ -338,6 +338,12 @@ ROWS = [
 
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _uncache(path):
     """Delete the target's cached bytecode. MEASURED HAZARD, not hygiene --

--- a/tests/mutate_799.py
+++ b/tests/mutate_799.py
@@ -194,9 +194,13 @@ ROWS = [
      "    violations = list(validate_intent(intent)) + list(block_problems)\n",
      (T793, T799), 'KILLED'),
 
+    # RE-ANCHORED (#877). `a22a968a` ("#705: grade the decoupling cap to the
+    # PIN") EXTENDED `_NON_RULE_SEVERITIES`, so this line no longer closes the
+    # frozenset with `})` and the quote matched nothing. Dropping
+    # `keepout_allow_unresolved` from the registry is still the mutation.
     ('the-rule-name-is-not-registered', 'fp',
-     "    'intent_zone_in_keepout', 'keepout_allow_unresolved'})\n",
-     "    'intent_zone_in_keepout'})\n",
+     "    'intent_zone_in_keepout', 'keepout_allow_unresolved',\n",
+     "    'intent_zone_in_keepout',\n",
      (T549S,), 'KILLED'),
 
     # ---- the board_score prerequisite --------------------------------------

--- a/tests/mutate_799.py
+++ b/tests/mutate_799.py
@@ -210,6 +210,12 @@ ROWS = [
      (TBS,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),

--- a/tests/mutate_826.py
+++ b/tests/mutate_826.py
@@ -170,6 +170,12 @@ ROWS = [
      (T_PF,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _uncache(path):
     """Delete the target's cached bytecode. MEASURED HAZARD, not hygiene."""

--- a/tests/mutate_829.py
+++ b/tests/mutate_829.py
@@ -233,6 +233,12 @@ ROWS = [
      (TREF, T550), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),

--- a/tests/mutate_829.py
+++ b/tests/mutate_829.py
@@ -194,12 +194,16 @@ ROWS = [
     # Drop the "did the pose actually change?" qualifier and the backstop
     # refuses a write in which nothing moved -- which is exactly
     # `perturb._all_at_current`, and its dose-0 CONTROL board.
+    # RE-ANCHORED (#877). `68d9af16` ("#714: placement.writer can mirror a
+    # footprint to the other face") EXTENDED this disjunction with `side_change`
+    # and a comment block, so the closing paren the anchor quoted moved and the
+    # row matched nothing. Rather than quote thirteen lines to reach the new
+    # paren -- which would go stale again on the next term -- the mutation now
+    # neutralises the FIRST disjunct, making the whole `or` chain true. Same
+    # claim, same verdict: the writer stops refusing a zero-move write.
     ('the-writer-refuses-a-zero-move-write', 'wr',
-     "                and (abs(new_x - float(at_match.group(1))) > _POSE_EPS\n"
-     "                     or abs(new_y - float(at_match.group(2))) > _POSE_EPS\n"
-     "                     or abs((new_rot - old_rot + 180) % 360 - 180) "
-     "> _POSE_EPS)\n",
-     "                and True\n",
+     "                and (abs(new_x - float(at_match.group(1))) > _POSE_EPS\n",
+     "                and (True\n",
      (T829,), 'KILLED'),
 
     # Compare the fingerprint against the OUTPUT file instead of the in-memory

--- a/tests/mutate_830.py
+++ b/tests/mutate_830.py
@@ -205,6 +205,12 @@ ROWS = [
      (T830,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),

--- a/tests/mutate_834_835.py
+++ b/tests/mutate_834_835.py
@@ -217,10 +217,18 @@ ROWS = [
      'SURVIVED'),
 
     # ---- the reconciliation ---------------------------------------------
+    # The mutation is on the ADMISSION TEST only. `b31adcea` turned the
+    # comprehension into a loop where `shared` feeds two consumers -- the
+    # filter AND the charged rect -- so mutating `shared` would also inflate
+    # every admitted neighbour's box, and a kill could no longer be attributed
+    # to the one-sided test the row is named for. Mutating the `if` keeps the
+    # rect identical on both arms, which is what the comprehension's
+    # `_geom[g.ref].rect` did.
     ('routability-keeps-its-one-sided-side-test', 'rou',
-     """        shared = own_sides & g.sides""",
-     """        shared = (g.sides if footprint_side(fp) in g.sides
-                  else frozenset())""",
+     """        if not shared:
+            continue""",
+     """        if footprint_side(fp) not in g.sides:
+            continue""",
      (T835,), 'KILLED'),
 
     ('routability-goes-back-to-double-charging', 'rou',

--- a/tests/mutate_834_835.py
+++ b/tests/mutate_834_835.py
@@ -321,6 +321,12 @@ ROWS = [
      'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     out = subprocess.run(['git', 'status', '--porcelain', '--'] + list(paths),

--- a/tests/mutate_834_835.py
+++ b/tests/mutate_834_835.py
@@ -149,13 +149,19 @@ ROWS = [
      'SURVIVED'),
 
     # ---- #835: the escape ledger ----------------------------------------
+    # RE-ANCHORED (#877), with the six rows below it. This battery is not in
+    # #877's table at all -- 7 of its 22 rows had gone stale and nobody had
+    # measured it. Three causes, all of them later work on the same code:
+    # `b31adcea` (#848, charge a neighbour the sides it SHARES) turned two
+    # comprehensions into loops and moved `oth` out of the branch that used it,
+    # `398d8052` (#862) added kwargs to the ledger call, and `fa594fd1` (#850)
+    # renamed `own` to `geom` in `assign_faces`. Every mutation below is the
+    # one it always was, re-quoted against the code as it now stands.
     ('the-side-filter-goes-away', 'esc',
      """        if own is not None:
-            oth = sides.get(other)
             if oth is not None and not (own & oth):
                 continue""",
      """        if False:
-            oth = sides.get(other)
             if oth is not None and not (own & oth):
                 continue""",
      (T835,), 'KILLED'),
@@ -201,9 +207,9 @@ ROWS = [
 
     ('the-sides-map-is-not-threaded-into-the-ledger', 'esc',
      """                       sides=sides, containers=containers,
-                       obstruction_rects=orects)""",
+                       obstruction_rects=orects,""",
      """                       sides=None, containers=containers,
-                       obstruction_rects=orects)""",
+                       obstruction_rects=orects,""",
      (T835,),
      # Inert by construction: `part_escape` builds its own map when given
      # None. Recorded so that if the fallback is ever removed -- making the
@@ -212,12 +218,9 @@ ROWS = [
 
     # ---- the reconciliation ---------------------------------------------
     ('routability-keeps-its-one-sided-side-test', 'rou',
-     """    neighbors = [(g.ref, _geom[g.ref].rect) for g in _graded
-                 if g.ref != ref and (own_sides & g.sides)
-                 and g.ref not in _containers and g.ref in _geom]""",
-     """    neighbors = [(g.ref, _geom[g.ref].rect) for g in _graded
-                 if g.ref != ref and (footprint_side(fp) in g.sides)
-                 and g.ref not in _containers and g.ref in _geom]""",
+     """        shared = own_sides & g.sides""",
+     """        shared = (g.sides if footprint_side(fp) in g.sides
+                  else frozenset())""",
      (T835,), 'KILLED'),
 
     ('routability-goes-back-to-double-charging', 'rou',
@@ -240,15 +243,16 @@ ROWS = [
     # going back to billing routing for assembly margin: the deficit GROWS,
     # so every "is there a deficit" arm is satisfied harder.
     ('routability-goes-back-to-the-courtyard', 'rou',
-     """    neighbors = [(g.ref, _geom[g.ref].rect) for g in _graded""",
-     """    neighbors = [(g.ref, g.rect) for g in _graded""",
+     """        neighbors.append((g.ref, rect_on_sides(_geom[g.ref], shared)))""",
+     """        neighbors.append((g.ref, g.rect))""",
      (T835,), 'KILLED'),
 
     # #841, the other direction. `escape` charged the bbox of pad CENTRES, so
     # this is the exact code that shipped before -- and the per-board table is
     # what has to catch it.
     ('escape-neighbour-goes-back-to-pad-centres', 'esc',
-     """        obstacles.append((other, g.rect if g is not None else _part_rect(ofp)))""",
+     """        obstacles.append((other, _rect_on_sides(g, shared)
+                          if g is not None else _part_rect(ofp)))""",
      """        obstacles.append((other, _part_rect(ofp)))""",
      (T835,), 'KILLED'),
 
@@ -258,7 +262,7 @@ ROWS = [
     # every deficit number goes green DOWNWARD, which is why the demand arm
     # exists to kill it.
     ('escape-face-assignment-forgets-the-pad-edge', 'esc',
-     """        box = None if own is None else _pad_box(own, pad)""",
+     """        box = None if geom is None else _pad_box(geom, pad)""",
      """        box = None""",
      (T835,), 'KILLED'),
 
@@ -308,8 +312,8 @@ ROWS = [
      (T841,), 'KILLED'),
 
     ('routability-stops-exempting-containers', 'rou',
-     """                 and g.ref not in _containers and g.ref in _geom]""",
-     """                 and g.ref not in () and g.ref in _geom]""",
+     """        if g.ref == ref or g.ref in _containers or g.ref not in _geom:""",
+     """        if g.ref == ref or g.ref in () or g.ref not in _geom:""",
      (T835,),
      # Expected SURVIVED on the reasoning that only `escape` is asserted on;
      # measured KILLED, because `test_face_lane_ledger_side_test_is_symmetric`

--- a/tests/mutate_837.py
+++ b/tests/mutate_837.py
@@ -390,9 +390,15 @@ def main(argv=None):
     rows = [r for r in ROWS if not a.row or r[0] in set(a.row)]
     # RAW BYTES for the restore, decoded text for the match (#877). Every write
     # below lacked `newline=''`, so on Windows a single run rewrote all five
-    # targets in CRLF and left them permanently "modified" -- which then
-    # tripped THIS battery's own dirty-tree refusal on the next run.
-    # `.gitattributes` pins `*.py text eol=lf`, so that was a real corruption.
+    # targets in CRLF. `.gitattributes` pins `*.py text eol=lf`, so that is a
+    # real corruption of the working tree, and `git status --porcelain` shows
+    # all five as modified afterwards.
+    #
+    # It does NOT trip this battery's own refusal, which is `git diff --quiet`
+    # (:267): that applies the `text eol=lf` clean filter and reports a pure
+    # CRLF rewrite as CLEAN. So the damage was silent to the one guard that
+    # might have caught it -- worse than the first draft of this comment
+    # claimed, not better.
     raws = {k: io.open(v, 'rb').read() for k, v in TARGETS.items()}
     originals = {k: v.decode('utf-8').replace('\r\n', '\n')
                  for k, v in raws.items()}
@@ -400,9 +406,18 @@ def main(argv=None):
     try:
         for name, target, old, new, tests, expect in rows:
             src = originals[target]
-            # The count, checked BEFORE the write. This battery had none: its
-            # only protection was the pre-flight, so a stale anchor here was
-            # the silent false KILLED #877 describes rather than a BROKEN.
+            # The count, checked BEFORE the write. This battery had none --
+            # every other one counts here -- so its ONLY protection was the
+            # pre-flight at the top of main(). Belt and braces, not a live
+            # bug: with the pre-flight in place this branch is unreachable.
+            #
+            # What a stale anchor here would produce is SURVIVED, not KILLED:
+            # `replace` of an absent needle is a no-op, the witnesses pass, and
+            # `_run` reports not-killed. Of the 26 rows, 24 expect KILLED and
+            # would print `BAD SURVIVED` and exit 1; only the 2 that expect
+            # SURVIVED would pass silently. #877's title says such a row
+            # "reports KILLED", and that direction is wrong -- `mutate_702`'s
+            # own docstring has it right.
             n = src.count(old)
             if n != 1:
                 print(f"  BROKEN    {name}  (anchor matched {n} times)")

--- a/tests/mutate_837.py
+++ b/tests/mutate_837.py
@@ -237,7 +237,7 @@ ROWS = [
 
     # ------------------------------------------------- disclosed SURVIVORS
     # Every tracked board's footprints are on F.Cu or B.Cu, so reading the raw
-    # layer string and calling `footprint_side` agree on all 23. The helper is
+    # layer string and calling `footprint_side` agree on all 22. The helper is
     # used because the partition must not be ABLE to grow a third key that
     # `max()` would rank against the other two -- an invariant no corpus board
     # can exercise, which is exactly why it is stated here rather than left as
@@ -248,7 +248,7 @@ ROWS = [
      (CAP, CEN), 'SURVIVED'),
 
     # `ctx.parts` (the graded-part population) and the census's pad-bearing
-    # refs agree on every tracked board -- measured, 0 disagreements over 23.
+    # refs agree on every tracked board -- measured, 0 disagreements over 22.
     # They are NOT the same set by construction: `QuenchState` admits a
     # zero-pad footprint that draws a courtyard, and the census excludes it.
     # No corpus board carries one, so this row cannot be killed without a

--- a/tests/mutate_837.py
+++ b/tests/mutate_837.py
@@ -257,6 +257,12 @@ ROWS = [
      (CEN,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths), cwd=_ROOT)
@@ -382,17 +388,31 @@ def main(argv=None):
     print(f"baseline: {why}")
 
     rows = [r for r in ROWS if not a.row or r[0] in set(a.row)]
-    originals = {k: io.open(v, encoding='utf-8').read()
-                 for k, v in TARGETS.items()}
+    # RAW BYTES for the restore, decoded text for the match (#877). Every write
+    # below lacked `newline=''`, so on Windows a single run rewrote all five
+    # targets in CRLF and left them permanently "modified" -- which then
+    # tripped THIS battery's own dirty-tree refusal on the next run.
+    # `.gitattributes` pins `*.py text eol=lf`, so that was a real corruption.
+    raws = {k: io.open(v, 'rb').read() for k, v in TARGETS.items()}
+    originals = {k: v.decode('utf-8').replace('\r\n', '\n')
+                 for k, v in raws.items()}
     wrong = broken = 0
     try:
         for name, target, old, new, tests, expect in rows:
             src = originals[target]
+            # The count, checked BEFORE the write. This battery had none: its
+            # only protection was the pre-flight, so a stale anchor here was
+            # the silent false KILLED #877 describes rather than a BROKEN.
+            n = src.count(old)
+            if n != 1:
+                print(f"  BROKEN    {name}  (anchor matched {n} times)")
+                broken += 1
+                continue
             _drop_pyc()
-            io.open(TARGETS[target], 'w', encoding='utf-8').write(
+            io.open(TARGETS[target], 'w', encoding='utf-8', newline='').write(
                 src.replace(old, new, 1))
             killed, why = _run(tests)
-            io.open(TARGETS[target], 'w', encoding='utf-8').write(src)
+            io.open(TARGETS[target], 'wb').write(raws[target])
             _drop_pyc()
             got = 'KILLED' if killed else 'SURVIVED'
             mark = 'ok ' if got == expect else 'BAD'
@@ -401,7 +421,7 @@ def main(argv=None):
             print(f"  {mark} {got:9} {name}  ({why})")
     finally:
         for k, v in TARGETS.items():
-            io.open(v, 'w', encoding='utf-8').write(originals[k])
+            io.open(v, 'wb').write(raws[k])   # byte-exact, from what was read
         _drop_pyc()
 
     killed = sum(1 for r in rows if r[5] == 'KILLED')

--- a/tests/mutate_837.py
+++ b/tests/mutate_837.py
@@ -51,8 +51,14 @@ CEN = os.path.join(_TESTS, 'test_837_assembly_sides.py')
 CAP = os.path.join(_TESTS, 'test_capacity_options.py')
 SCH = os.path.join(_TESTS, 'test_549_floorplan_schema.py')
 CLI = os.path.join(_TESTS, 'test_549_floorplan_cli.py')
+#: #878. The corpus-level witness: it re-RUNS the far-face sweep and its NC1
+#: compares `grow_board` against the arm the engine is supposed to implement,
+#: on nine fields per (board, basis) over every tracked board. A per-board
+#: assertion can miss a charge that moves one board it does not look at; this
+#: cannot.
+FFC = os.path.join(_TESTS, 'test_878_far_face_currency.py')
 
-BASELINE = (CEN, CAP, SCH, CLI)
+BASELINE = (CEN, CAP, SCH, CLI, FFC)
 
 ROWS = [
     # ------------------------------------------------- the census's two rules
@@ -186,6 +192,48 @@ ROWS = [
      "            'assembly_sides': _cen['sides'],\n",
      "            'assembly_sides': 'F',\n",
      (CEN,), 'KILLED'),
+
+    # ----------------------------------------------- #878, the far face
+    # The charge itself. Without it `grow_board` is back to charging a
+    # through-hole part to its footprint layer only, which is the defect.
+    ('the-far-face-charge-goes-away', 'op',
+     "        far = _far_face_area(fp, clearance)\n",
+     "        far = 0.0\n",
+     (CAP, FFC), 'KILLED'),
+
+    # WHICH dict the verdict rests on. This row restores the exact pre-#878
+    # behaviour while leaving the far charge computed and reported, so a gate
+    # that only checks `far_face_area_mm2` is non-zero cannot kill it -- the
+    # number is still right, it has just stopped reaching the answer.
+    ('the-busiest-side-reads-the-population-charge', 'op',
+     "    busiest = max(obstructed.values()) if obstructed else 0.0\n",
+     "    busiest = max(per_side.values()) if per_side else 0.0\n",
+     (CAP, FFC), 'KILLED'),
+
+    # The half that is easy to get wrong in the OTHER direction: charging the
+    # leads into the one-face sum, where each part is meant to appear exactly
+    # once. Measured, this double-charges 10 of the 15 one-face boards.
+    # Shares its anchor with the two #837 rows above -- the anchor must match
+    # its TARGET once, not be unique across rows.
+    ('the-one-face-charge-double-counts-the-leads', 'op',
+     "    charged = sum(per_side.values()) if one_face else busiest\n",
+     "    charged = sum(obstructed.values()) if one_face else busiest\n",
+     (CAP, FFC), 'KILLED'),
+
+    # The far charge landing on the near face: the total is unchanged and
+    # `far_face_area_mm2` still reports the right number, so only an arm that
+    # compares the two per-side dicts can see it.
+    ('the-far-face-charge-lands-on-the-near-face', 'op',
+     "            other = 'F.Cu' if layer == 'B.Cu' else 'B.Cu'\n",
+     "            other = layer\n",
+     (CAP, FFC), 'KILLED'),
+
+    # Commensurability: the near charge is grown by `clearance` on each axis,
+    # so a far charge that is not is a smaller number added to the same sum.
+    ('the-far-face-charge-omits-the-clearance', 'op',
+     "    return (tx1 - tx0 + clearance) * (ty1 - ty0 + clearance)\n",
+     "    return (tx1 - tx0) * (ty1 - ty0)\n",
+     (CAP, FFC), 'KILLED'),
 
     # ------------------------------------------------- disclosed SURVIVORS
     # Every tracked board's footprints are on F.Cu or B.Cu, so reading the raw
@@ -413,7 +461,7 @@ def main(argv=None):
             #
             # What a stale anchor here would produce is SURVIVED, not KILLED:
             # `replace` of an absent needle is a no-op, the witnesses pass, and
-            # `_run` reports not-killed. Of the 26 rows, 24 expect KILLED and
+            # `_run` reports not-killed. Of the 31 rows, 29 expect KILLED and
             # would print `BAD SURVIVED` and exit 1; only the 2 that expect
             # SURVIVED would pass silently. #877's title says such a row
             # "reports KILLED", and that direction is wrong -- `mutate_702`'s

--- a/tests/mutate_846.py
+++ b/tests/mutate_846.py
@@ -207,6 +207,12 @@ ROWS = [
      (T652,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _head():
     p = subprocess.run(['git', 'rev-parse', 'HEAD'], capture_output=True,

--- a/tests/mutate_847.py
+++ b/tests/mutate_847.py
@@ -266,6 +266,12 @@ ROWS = [
      (T847,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     out = subprocess.run(['git', 'status', '--porcelain', '--'] + list(paths),

--- a/tests/mutate_849.py
+++ b/tests/mutate_849.py
@@ -147,6 +147,12 @@ ROWS = [
      (T_849,), 'SURVIVED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 #: `run_all.py`'s self-skip code. A test that exits 77 asserted NOTHING, so
 #: reading it as a kill is exactly the "most flattering possible bug" this

--- a/tests/mutate_850_848.py
+++ b/tests/mutate_850_848.py
@@ -331,6 +331,12 @@ ROWS = [
      (T848,), 'KILLED'),
 ]
 
+# Every anchor must match its target exactly once BEFORE anything is
+# rewritten. A stale anchor otherwise reports BROKEN mid-run, after the
+# witnesses have been paid for; this is the one second (#877).
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
 
 def _git_clean(paths):
     out = subprocess.run(['git', 'status', '--porcelain', '--'] + list(paths),

--- a/tests/mutation_anchors.py
+++ b/tests/mutation_anchors.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""Do the mutation batteries' anchors still match the code they quote? (#877)
+
+A mutation row is applied with `src.replace(old, new, 1)`. When `old` no longer
+occurs in the target the row mutates NOTHING, and whatever the runner prints
+next is about a tree it never changed. Every battery here does catch that --
+each counts the anchor and reports BROKEN rather than a kill -- but it catches
+it *during* the run, after the witnesses have been paid for. #877's own words:
+
+    a stale anchor reports BROKEN 50 minutes into a run rather than in one
+    second before it -- mutate_847.py:67-73
+
+This module is the one second. It answers a single question -- *does this
+anchor match its target exactly once?* -- for two callers that must not drift
+apart:
+
+  * each `tests/mutate_*.py`, from `--verify-anchors`, over the rows it already
+    holds in memory (`verify`); and
+  * `tests/test_718_static_test_hygiene.py`, over every battery in the tree,
+    without importing any of them (`resolve_static` -> `verify`).
+
+**Static resolution is not an optimisation, it is the only safe way.**
+`mutate_713_census.py`, `mutate_713_phase1.py` and `mutate_760.py` run their
+runner at module scope, so IMPORTING one mutates the tree. #877 was filed after
+a census did exactly that and rewrote 13 engine files under `py_router/` and
+`py_placer/` -- and reported inflated numbers measured against its own damage.
+Nothing here imports a battery; everything is `ast`.
+
+Two distinctions this draws that a plain `count(old) != 1` does not:
+
+  * **STALE (0 matches) is not AMBIGUOUS (>1).** A stale anchor guards nothing.
+    A 2-match anchor still mutates -- whichever site comes first -- so it is a
+    row whose subject is decided by file order rather than by the row. Both
+    deserve fixing; they are not the same finding, and #877 reported three
+    ambiguous rows in `mutate_703.py` as stale.
+
+  * **Targets are read with UNIVERSAL NEWLINES.** `mutate_711.py:296-321`
+    records why: matching a multi-line anchor against a raw byte decode
+    "silently found NOTHING in three rows".
+
+    python3 tests/mutation_anchors.py               # census over every battery
+    python3 tests/mutation_anchors.py --verbose     # every anchor, one a line
+    python3 tests/mutation_anchors.py --battery mutate_702.py
+"""
+import argparse
+import ast
+import os
+import sys
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(TESTS_DIR)
+
+#: `_fold` could not decide. Distinct from None, which several row layouts use
+#: as a MEANINGFUL value (`old is None` means "create this file", not "unknown").
+UNKNOWN = object()
+
+STALE = 'STALE'
+AMBIGUOUS = 'AMBIGUOUS'
+MISSING_TARGET = 'MISSING_TARGET'
+
+
+class Anchor(object):
+    """One `old` string, and the file it is supposed to occur in exactly once.
+
+    `nth` is `mutate_760.py`'s optional occurrence selector, which replaces the
+    Nth match instead of the first, so its requirement is "at least nth+1
+    matches" rather than "exactly one".
+
+    `old is None` marks `mutate_713_census.py`'s create-this-file row, which
+    carries no anchor at all and must not be graded as one.
+    """
+
+    __slots__ = ('battery', 'row', 'target', 'old', 'nth', 'edit')
+
+    def __init__(self, battery, row, target, old, nth=None, edit=0):
+        self.battery = battery
+        self.row = row
+        self.target = target
+        self.old = old
+        self.nth = nth
+        self.edit = edit
+
+    @property
+    def label(self):
+        return self.row if self.edit == 0 else '%s[%d]' % (self.row, self.edit)
+
+    def __repr__(self):                                    # pragma: no cover
+        return '<Anchor %s %s -> %s>' % (
+            self.battery, self.label, os.path.basename(self.target))
+
+
+class Problem(object):
+    __slots__ = ('anchor', 'kind', 'count', 'detail')
+
+    def __init__(self, anchor, kind, count, detail=''):
+        self.anchor = anchor
+        self.kind = kind
+        self.count = count
+        self.detail = detail
+
+    def __str__(self):
+        return '%s: %s %s -- matched %d time(s) in %s%s' % (
+            self.anchor.battery, self.kind, self.anchor.label, self.count,
+            os.path.relpath(self.anchor.target, ROOT).replace(os.sep, '/'),
+            ('  ' + self.detail) if self.detail else '')
+
+
+# --------------------------------------------------------------------------
+# constant folding
+# --------------------------------------------------------------------------
+
+def _dotted(node):
+    """'os.path.join' for the Attribute/Name chain in a Call's func, else ''."""
+    parts = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if not isinstance(node, ast.Name):
+        return ''
+    parts.append(node.id)
+    return '.'.join(reversed(parts))
+
+
+def _fold(node, env):
+    """The value of `node`, or UNKNOWN.
+
+    Deliberately narrow: string literals, implicit and explicit concatenation,
+    module-level names, and the `os.path` calls every battery builds its target
+    constants with. An f-string is UNKNOWN rather than guessed -- an anchor
+    whose text this cannot reproduce EXACTLY must be refused, not approximated,
+    or the census grades a string the battery will never apply.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        return env.get(node.id, UNKNOWN)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _fold(node.left, env)
+        right = _fold(node.right, env)
+        if isinstance(left, str) and isinstance(right, str):
+            return left + right
+        return UNKNOWN
+    if isinstance(node, ast.Call):
+        fn = _dotted(node.func)
+        if fn not in ('os.path.join', 'os.path.dirname', 'os.path.abspath'):
+            return UNKNOWN
+        args = [_fold(a, env) for a in node.args]
+        if not args or not all(isinstance(a, str) for a in args):
+            return UNKNOWN
+        if fn == 'os.path.join':
+            return os.path.join(*args)
+        if fn == 'os.path.dirname':
+            return os.path.dirname(args[0])
+        return os.path.abspath(args[0])
+    if isinstance(node, (ast.Tuple, ast.List)):
+        return [_fold(e, env) for e in node.elts]
+    if isinstance(node, ast.Dict):
+        out = {}
+        for k, v in zip(node.keys, node.values):
+            key = _fold(k, env)
+            if isinstance(key, str):
+                out[key] = _fold(v, env)
+        return out
+    return UNKNOWN
+
+
+def _module_env(tree, path):
+    """Module-level names a battery's tables are built from.
+
+    Walks top-level assignments in order, so a constant may be defined in terms
+    of an earlier one -- which is how every battery spells its paths
+    (`_ROOT = os.path.dirname(_TESTS)`).
+    """
+    env = {'__file__': os.path.abspath(path)}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        value = _fold(node.value, env)
+        for tgt in node.targets:
+            if isinstance(tgt, ast.Name):
+                env[tgt.id] = value
+    return env
+
+
+# --------------------------------------------------------------------------
+# table discovery
+# --------------------------------------------------------------------------
+
+def _is_row_table(value):
+    """A list of tuples whose first element is a string: a mutation table.
+
+    Every battery's table is one, and nothing else at module scope in these
+    files is. Empty lists are rejected -- a table that resolved to nothing is
+    a parse failure wearing a clean result.
+    """
+    if not isinstance(value, list) or not value:
+        return False
+    for row in value:
+        if not isinstance(row, list) or len(row) < 3:
+            return False
+        if not isinstance(row[0], str):
+            return False
+    return True
+
+
+def _tables(tree, env):
+    """[(variable name, rows)] for every module-level mutation table."""
+    out = []
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for tgt in node.targets:
+            if not isinstance(tgt, ast.Name):
+                continue
+            value = env.get(tgt.id, UNKNOWN)
+            if _is_row_table(value):
+                out.append((tgt.id, value))
+    return out
+
+
+def _battery_dict_targets(tree, env):
+    """`mutate_746.py`'s `BATTERIES = {'engine': (ENGINE, TEST, ENGINE_ROWS)}`.
+
+    Maps a table's VARIABLE NAME to the source path in the same tuple. Read off
+    the AST rather than the folded value because the association is by name --
+    two tables of equal content would be indistinguishable once folded.
+    """
+    out = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value,
+                                                              ast.Dict):
+            continue
+        for val in node.value.values:
+            if not isinstance(val, (ast.Tuple, ast.List)):
+                continue
+            names = [e.id for e in val.elts if isinstance(e, ast.Name)]
+            paths = [env.get(n) for n in names]
+            table = None
+            src = None
+            for name, resolved in zip(names, paths):
+                if _is_row_table(resolved):
+                    table = name
+                elif isinstance(resolved, str) and src is None:
+                    src = resolved
+            if table and src:
+                out[table] = src
+    return out
+
+
+def _abs_target(value, env, must_exist=True):
+    """An absolute path from a row's target slot, else None.
+
+    Handles both spellings: an already-absolute constant (`mutate_760.py`) and
+    a repo-relative string (`mutate_713_*.py`).
+
+    `must_exist` is False for a CREATE row, whose whole point is a file that is
+    not there yet (`mutate_713_census.py`'s "a NEW file with a clock,
+    registered nowhere"). Requiring the file unconditionally made that battery
+    report UNRESOLVED -- a resolver refusing the one row that is behaving
+    exactly as designed.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    path = value if os.path.isabs(value) else os.path.join(ROOT, value)
+    if must_exist and not os.path.isfile(path):
+        return None
+    if not must_exist and not value.endswith('.py'):
+        return None
+    return path
+
+
+def _edits(old, new):
+    """[(old, ...)] for a row, expanding the list-valued multi-edit form.
+
+    14 batteries let `old` be a list of `(old, new)` pairs with `new` None
+    (`mutate_554.py:78-83`). Each pair is its own anchor: one of them going
+    stale breaks the row exactly as a scalar anchor would, and #877's census
+    counted the ROW rather than the pair.
+    """
+    if isinstance(old, list):
+        out = []
+        for pair in old:
+            if isinstance(pair, list) and pair and isinstance(pair[0], str):
+                out.append(pair[0])
+            else:
+                out.append(UNKNOWN)
+        return out
+    return [old]
+
+
+def resolve_static(path):
+    """(anchors, unresolved_reason) for one `tests/mutate_*.py`, without import.
+
+    `unresolved_reason` is a string when the file could not be read as a
+    battery at all; the caller must treat that as a failure, never as "no
+    anchors". A resolver that answers cleanly for a file it did not understand
+    is the same bug this module exists to catch.
+    """
+    battery = os.path.basename(path)
+    try:
+        with open(path, encoding='utf-8') as fh:
+            src = fh.read()
+    except OSError as exc:                                 # pragma: no cover
+        return [], 'cannot read: %s' % exc
+    try:
+        tree = ast.parse(src, battery)
+    except SyntaxError as exc:                             # pragma: no cover
+        return [], 'cannot parse: %s' % exc
+
+    env = _module_env(tree, path)
+    tables = _tables(tree, env)
+    if not tables:
+        return [], 'no mutation table found'
+
+    targets_map = env.get('TARGETS')
+    if not isinstance(targets_map, dict):
+        targets_map = {}
+    by_table = _battery_dict_targets(tree, env)
+
+    #: The single-target fallback: a battery with one engine file names it
+    #: ENGINE (`mutate_750.py:46`). Only consulted when the row itself carries
+    #: no target, so it cannot mask a per-row path.
+    lone = _abs_target(env.get('ENGINE'), env)
+
+    anchors = []
+    for table_name, rows in tables:
+        table_target = by_table.get(table_name) or lone
+        for row in rows:
+            name = row[0]
+            slot = row[1]
+
+            # Layout A: row[1] keys the TARGETS dict.
+            if isinstance(slot, str) and slot in targets_map:
+                target = _abs_target(targets_map[slot], env)
+                old, new = row[2], row[3] if len(row) > 3 else None
+                nth = None
+            else:
+                # A CREATE row (`old is None`) names a file that does not exist
+                # yet; every other row's target must be a real file, or a typo
+                # would silently resolve and grade as stale.
+                creates = len(row) > 2 and row[2] is None
+                explicit = _abs_target(slot, env, must_exist=not creates)
+                if explicit is not None:
+                    # Layouts D and E: row[1] IS the path.
+                    target = explicit
+                    old = row[2]
+                    new = row[3] if len(row) > 3 else None
+                    nth = row[4] if len(row) > 4 and isinstance(
+                        row[4], int) and not isinstance(row[4], bool) else None
+                else:
+                    # Layouts B and C: no per-row target; row[1] is the anchor.
+                    target = table_target
+                    old, new = slot, row[2]
+                    nth = None
+
+            if target is None:
+                return [], ('row %r in %s names no resolvable target'
+                            % (name, table_name))
+
+            for i, one in enumerate(_edits(old, new)):
+                if one is UNKNOWN:
+                    return [], ('row %r in %s has an anchor this cannot '
+                                'reproduce exactly' % (name, table_name))
+                if one is not None and not isinstance(one, str):
+                    return [], ('row %r in %s has a non-string anchor'
+                                % (name, table_name))
+                anchors.append(Anchor(battery, name, target, one, nth,
+                                      0 if not isinstance(old, list) else i))
+    return anchors, None
+
+
+# --------------------------------------------------------------------------
+# verification
+# --------------------------------------------------------------------------
+
+def _read_target(path, cache):
+    """The target's text with UNIVERSAL NEWLINES, which is what the batteries
+    match against (`mutate_711.py:296-305`). Reading it any other way makes
+    every multi-line anchor stale on a CRLF checkout."""
+    if path not in cache:
+        with open(path, encoding='utf-8', errors='replace') as fh:
+            cache[path] = fh.read()
+    return cache[path]
+
+
+def verify(anchors, repo_wide=False):
+    """Every problem among `anchors`, worst first within each battery.
+
+    Returns a list, never raises on a bad anchor: the caller decides whether a
+    problem is fatal, and a run that stops at the first one hides the rest.
+    """
+    problems = []
+    cache = {}
+    for a in anchors:
+        if a.old is None:
+            # `mutate_713_census.py`'s create-this-file row. It carries no
+            # anchor; grading it as one invents a finding.
+            continue
+        if not os.path.isfile(a.target):
+            problems.append(Problem(a, MISSING_TARGET, 0,
+                                    'target does not exist'))
+            continue
+        n = _read_target(a.target, cache).count(a.old)
+        if a.nth is not None:
+            if n < a.nth + 1:
+                problems.append(Problem(
+                    a, STALE, n,
+                    'needs occurrence %d, so at least %d match(es)'
+                    % (a.nth, a.nth + 1)))
+            continue
+        if n == 0:
+            problems.append(Problem(a, STALE, 0,
+                                    'the row mutates nothing'))
+        elif n > 1:
+            problems.append(Problem(
+                a, AMBIGUOUS, n,
+                'replace(..., 1) takes whichever comes first in the file'))
+    if repo_wide:
+        problems.extend(_prose_problems(anchors))
+    return problems
+
+
+def _prose_problems(anchors):
+    """Anchors that also occur in another tracked file.
+
+    `mutate_726.py:248-280`'s check, kept: a comment quoting code has satisfied
+    a grep-shaped test in this repo before, and a battery that mutates a
+    comment reports SURVIVED for a mutation that changed nothing executable.
+    """
+    import subprocess
+    out = subprocess.run(['git', 'ls-files', '*.py', '*.md'], cwd=ROOT,
+                         capture_output=True, text=True).stdout.split()
+    texts = {}
+    for rel in out:
+        path = os.path.join(ROOT, rel)
+        try:
+            with open(path, encoding='utf-8', errors='replace') as fh:
+                texts[os.path.abspath(path)] = fh.read()
+        except OSError:                                    # pragma: no cover
+            continue
+    problems = []
+    for a in anchors:
+        if a.old is None:
+            continue
+        battery_path = os.path.abspath(os.path.join(TESTS_DIR, a.battery))
+        others = [p for p, text in texts.items()
+                  if p not in (os.path.abspath(a.target), battery_path)
+                  and a.old in text]
+        if others:
+            problems.append(Problem(
+                a, 'PROSE', len(others),
+                'also in ' + ', '.join(
+                    os.path.relpath(p, ROOT).replace(os.sep, '/')
+                    for p in sorted(others)[:3])))
+    return problems
+
+
+def batteries():
+    """Every `tests/mutate_*.py`, sorted. The corpus both callers run over."""
+    names = sorted(n for n in os.listdir(TESTS_DIR)
+                   if n.startswith('mutate_') and n.endswith('.py'))
+    return [os.path.join(TESTS_DIR, n) for n in names]
+
+
+def census():
+    """[(battery, anchors, problems, unresolved_reason)] over the whole tree."""
+    out = []
+    for path in batteries():
+        anchors, reason = resolve_static(path)
+        problems = [] if reason else verify(anchors)
+        out.append((os.path.basename(path), anchors, problems, reason))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--battery', help='census one file, by basename')
+    ap.add_argument('--verbose', action='store_true',
+                    help='print every anchor, not only the problems')
+    ap.add_argument('--repo-wide', action='store_true',
+                    help="also report anchors that occur in another tracked "
+                         "file, which may be prose rather than code")
+    args = ap.parse_args()
+
+    rows = census()
+    if args.battery:
+        rows = [r for r in rows if r[0] == args.battery]
+        if not rows:
+            print('no battery named %r' % args.battery, file=sys.stderr)
+            return 2
+
+    total = stale = ambiguous = missing = unresolved = 0
+    print('%-26s %6s %6s %6s %6s' % ('battery', 'rows', 'STALE', 'AMBIG',
+                                     'UNRES'))
+    for name, anchors, problems, reason in rows:
+        if args.repo_wide and not reason:
+            problems = verify(anchors, repo_wide=True)
+        n_stale = sum(1 for p in problems if p.kind == STALE)
+        n_amb = sum(1 for p in problems if p.kind == AMBIGUOUS)
+        n_missing = sum(1 for p in problems if p.kind == MISSING_TARGET)
+        total += len(anchors)
+        stale += n_stale
+        ambiguous += n_amb
+        missing += n_missing
+        if reason:
+            unresolved += 1
+        print('%-26s %6s %6s %6s %6s' % (
+            name, len(anchors) if not reason else '-', n_stale, n_amb,
+            'YES' if reason else ''))
+        if reason:
+            print('    UNRESOLVED: %s' % reason)
+        for p in problems:
+            print('    %s' % p)
+        if args.verbose and not reason:
+            for a in anchors:
+                print('      %-52s %s' % (
+                    a.label,
+                    os.path.relpath(a.target, ROOT).replace(os.sep, '/')))
+
+    print('\n%d battery(s), %d anchor(s): %d stale, %d ambiguous, %d missing '
+          'target, %d unresolved' % (len(rows), total, stale, ambiguous,
+                                     missing, unresolved))
+    return 1 if (stale or missing or unresolved) else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutation_anchors.py
+++ b/tests/mutation_anchors.py
@@ -566,6 +566,47 @@ def _prose_problems(anchors):
     return problems
 
 
+def preflight(path, repo_wide=False):
+    """Refuse to mutate anything until every anchor in `path` matches once.
+
+    ONE line at the top of a battery, right after its table:
+
+        from mutation_anchors import preflight
+        preflight(__file__)
+
+    and it also IS the battery's `--verify-anchors`: the flag is handled here
+    and stripped from `sys.argv` before the battery's own argparse sees it, so
+    no battery needs a flag, a help string or a branch of its own. That matters
+    because the alternative was a 38th hand-rolled copy in each of 37 files,
+    each free to drift -- which is how only 5 of them had the check at all.
+
+    Exits 2 on a bad anchor, matching the batteries' existing refusal code, so
+    a stale anchor stops the run in ONE SECOND rather than reporting BROKEN
+    after the witnesses have been paid for. With `--verify-anchors` it reports
+    and exits either way, mutating nothing.
+    """
+    only = '--verify-anchors' in sys.argv
+    if only:
+        sys.argv = [a for a in sys.argv if a != '--verify-anchors']
+    name = os.path.basename(path)
+    anchors, reason = resolve_static(path)
+    if reason:
+        print('%s: ANCHORS UNRESOLVED -- %s' % (name, reason), file=sys.stderr)
+        raise SystemExit(2)
+    problems = verify(anchors, repo_wide=repo_wide)
+    for p in problems:
+        print('  %s' % p, file=sys.stderr)
+    if problems:
+        print('%s: %d of %d anchor(s) do not match exactly once. Re-anchor '
+              'them before running -- a stale row mutates nothing and every '
+              'gate it names passes for free (#877).'
+              % (name, len(problems), len(anchors)), file=sys.stderr)
+        raise SystemExit(2)
+    if only:
+        print('%s: all %d anchor(s) match exactly once' % (name, len(anchors)))
+        raise SystemExit(0)
+
+
 def batteries():
     """Every `tests/mutate_*.py`, sorted. The corpus both callers run over."""
     names = sorted(n for n in os.listdir(TESTS_DIR)

--- a/tests/mutation_anchors.py
+++ b/tests/mutation_anchors.py
@@ -60,6 +60,34 @@ Distinctions a plain `count(old) != 1` does not draw:
     python3 tests/mutation_anchors.py               # census over every battery
     python3 tests/mutation_anchors.py --verbose     # every anchor, one a line
     python3 tests/mutation_anchors.py --battery mutate_702.py
+
+MEASURED at 0aff32c0, before the re-anchoring pass: 37 batteries, 831 anchors,
+**29 stale, 3 ambiguous, 0 unresolved**, across 9 batteries. After it: 0, 0, 0.
+
+An anchor matching exactly once does NOT establish that the row still means
+what its name says -- this branch's own `mutate_702` keepout row proved that,
+matching cleanly while mutating nothing. So every battery whose rows changed
+was RUN, not merely re-censused:
+
+    battery            rows  killed  survived  broken  disagreeing
+    mutate_702           22      19         3       0            1
+    mutate_703           29      27         2       0            0
+    mutate_554           30      26         4       0            0
+    mutate_730           28      25         3       0            0
+    mutate_747           22      20         2       0            0
+    mutate_768           31      31         0       0            0
+    mutate_799           22      18         4       0            0
+    mutate_829           23      22         1       0            0
+    mutate_834_835       22      18         4       0            0
+    -----------------------------------------------------------------
+    total               229     206        23       0            1
+
+Every survivor is a declared, expected one. The single disagreement is
+`mutate_702`'s `the-crossed-claim-check-never-fires`, which is byte-identical
+to upstream/main and predates this work -- disclosed at that row rather than
+re-graded. Each run also left the tree byte-identical, checked with BOTH `git
+status --porcelain` and `git diff --stat`, because a pure CRLF flip shows in
+the first and not the second.
 """
 import argparse
 import ast

--- a/tests/mutation_anchors.py
+++ b/tests/mutation_anchors.py
@@ -4,39 +4,55 @@
 A mutation row is applied with `src.replace(old, new, 1)`. When `old` no longer
 occurs in the target the row mutates NOTHING, and whatever the runner prints
 next is about a tree it never changed. Every battery here does catch that --
-each counts the anchor and reports BROKEN rather than a kill -- but it catches
-it *during* the run, after the witnesses have been paid for. #877's own words:
+each counts the anchor and reports BROKEN, and every one exits non-zero -- but
+it catches it DURING the run, after the witnesses have been paid for. #877's
+own citation:
 
     a stale anchor reports BROKEN 50 minutes into a run rather than in one
     second before it -- mutate_847.py:67-73
 
 This module is the one second. It answers a single question -- *does this
-anchor match its target exactly once?* -- for two callers that must not drift
-apart:
+anchor match its target exactly once?* -- and it is meant to be the ONLY
+implementation of that question in the tree, for two callers:
 
   * each `tests/mutate_*.py`, from `--verify-anchors`, over the rows it already
     holds in memory (`verify`); and
-  * `tests/test_718_static_test_hygiene.py`, over every battery in the tree,
-    without importing any of them (`resolve_static` -> `verify`).
+  * `tests/test_718_static_test_hygiene.py`, over every battery, without
+    importing any of them (`resolve_static` -> `verify`).
+
+The second caller exists today; the batteries are converted in the same PR.
+Until that lands, the five hand-rolled `--verify-anchors` implementations
+(`mutate_714`, `726`, `837`, `847`, `850_848`) are still the shipped state, and
+`mutate_726.py:248-280`'s is STRICTER than this module's default -- its prose
+check is always on, where here it needs `--repo-wide`.
 
 **Static resolution is not an optimisation, it is the only safe way.**
 `mutate_713_census.py`, `mutate_713_phase1.py` and `mutate_760.py` run their
 runner at module scope, so IMPORTING one mutates the tree. #877 was filed after
-a census did exactly that and rewrote 13 engine files under `py_router/` and
-`py_placer/` -- and reported inflated numbers measured against its own damage.
-Nothing here imports a battery; everything is `ast`.
+a census did exactly that, rewrote 13 engine files under `py_router/` and
+`py_placer/`, and reported numbers inflated by its own damage. Nothing here
+imports a battery; everything is `ast`.
 
-Two distinctions this draws that a plain `count(old) != 1` does not:
+Distinctions a plain `count(old) != 1` does not draw:
 
   * **STALE (0 matches) is not AMBIGUOUS (>1).** A stale anchor guards nothing.
-    A 2-match anchor still mutates -- whichever site comes first -- so it is a
-    row whose subject is decided by file order rather than by the row. Both
-    deserve fixing; they are not the same finding, and #877 reported three
-    ambiguous rows in `mutate_703.py` as stale.
+    A 2-match anchor still mutates -- whichever site comes first -- so the row's
+    subject is decided by file order rather than by the row. Both fail; they are
+    not the same finding, and #877 reported `mutate_703.py`'s three ambiguous
+    rows as stale.
 
-  * **Targets are read with UNIVERSAL NEWLINES.** `mutate_711.py:296-321`
-    records why: matching a multi-line anchor against a raw byte decode
-    "silently found NOTHING in three rows".
+  * **NEWLINE_SENSITIVE**: the anchor's verdict changes with how the target is
+    read. This module reads universal-newline, and so does `mutate_711.py`
+    (`:296-305`), whose comment records that matching a raw byte decode
+    "silently found NOTHING in three rows". But 18 batteries read their target
+    with `newline=''`, so on a CRLF checkout the census and the battery would
+    disagree. Dormant on this tree -- `.gitattributes` pins `*.py text eol=lf`
+    -- and free to keep.
+
+  * A **create row** (`old is None`, `mutate_713_census.py`'s "a NEW file with
+    a clock, registered nowhere") carries no anchor, but it is not unchecked:
+    the battery reports BROKEN when the file it means to create already exists
+    (`mutate_713_census.py:129-132`), and that is what is graded here.
 
     python3 tests/mutation_anchors.py               # census over every battery
     python3 tests/mutation_anchors.py --verbose     # every anchor, one a line
@@ -45,6 +61,7 @@ Two distinctions this draws that a plain `count(old) != 1` does not:
 import argparse
 import ast
 import os
+import re
 import sys
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -57,32 +74,48 @@ UNKNOWN = object()
 STALE = 'STALE'
 AMBIGUOUS = 'AMBIGUOUS'
 MISSING_TARGET = 'MISSING_TARGET'
+NEWLINE_SENSITIVE = 'NEWLINE_SENSITIVE'
+CREATE_EXISTS = 'CREATE_EXISTS'
+PROSE = 'PROSE'
+
+#: Names a battery gives a mutation table. A module-level binding matching this
+#: MUST resolve to a table or the whole battery is reported UNRESOLVED -- see
+#: `_tables`, and the defect that motivated it.
+_TABLE_NAME_RE = re.compile(r'^(ROWS|[A-Z_]*_ROWS)$')
 
 
 class Anchor(object):
-    """One `old` string, and the file it is supposed to occur in exactly once.
+    """One `old` string, and the file it must occur in exactly once.
 
-    `nth` is `mutate_760.py`'s optional occurrence selector, which replaces the
-    Nth match instead of the first, so its requirement is "at least nth+1
-    matches" rather than "exactly one".
+    `nth` is the optional occurrence selector `mutate_760.py:65-79` implements
+    (`row[4]`), which replaces the Nth match instead of the first -- so its
+    requirement is "at least nth+1 matches", not "exactly one". No row uses it
+    today; the form is supported because the battery accepts it.
 
-    `old is None` marks `mutate_713_census.py`'s create-this-file row, which
-    carries no anchor at all and must not be graded as one.
+    `old is None` marks a create-this-file row, which has no anchor.
     """
 
-    __slots__ = ('battery', 'row', 'target', 'old', 'nth', 'edit')
+    __slots__ = ('battery', 'row', 'target', 'old', 'nth', 'edit', 'multi')
 
-    def __init__(self, battery, row, target, old, nth=None, edit=0):
+    def __init__(self, battery, row, target, old, nth=None, edit=0,
+                 multi=False):
         self.battery = battery
         self.row = row
         self.target = target
         self.old = old
         self.nth = nth
         self.edit = edit
+        self.multi = multi
 
     @property
     def label(self):
-        return self.row if self.edit == 0 else '%s[%d]' % (self.row, self.edit)
+        """`name[i]` for every edit of a multi-edit row, INCLUDING edit 0.
+
+        Suppressing `[0]` made a stale first pair print as a bare row name,
+        indistinguishable from a stale scalar row -- so the reader could not
+        tell which of the row's edits to fix.
+        """
+        return '%s[%d]' % (self.row, self.edit) if self.multi else self.row
 
     def __repr__(self):                                    # pragma: no cover
         return '<Anchor %s %s -> %s>' % (
@@ -99,10 +132,17 @@ class Problem(object):
         self.detail = detail
 
     def __str__(self):
-        return '%s: %s %s -- matched %d time(s) in %s%s' % (
-            self.anchor.battery, self.kind, self.anchor.label, self.count,
-            os.path.relpath(self.anchor.target, ROOT).replace(os.sep, '/'),
-            ('  ' + self.detail) if self.detail else '')
+        rel = os.path.relpath(self.anchor.target, ROOT).replace(os.sep, '/')
+        if self.kind in (PROSE, CREATE_EXISTS):
+            # `count` is not an occurrence count for these, and rendering it as
+            # one printed "matched 458 time(s) in <the wrong file>".
+            head = '%s: %s %s' % (self.anchor.battery, self.kind,
+                                  self.anchor.label)
+        else:
+            head = '%s: %s %s -- matched %d time(s) in %s' % (
+                self.anchor.battery, self.kind, self.anchor.label,
+                self.count, rel)
+        return head + (('  ' + self.detail) if self.detail else '')
 
 
 # --------------------------------------------------------------------------
@@ -164,21 +204,34 @@ def _fold(node, env):
     return UNKNOWN
 
 
+def _assignments(tree):
+    """(name, value_node) for each module-level binding, in source order.
+
+    `ast.AnnAssign` is included: `ROWS: List[Row] = [...]` binds exactly as
+    `ROWS = [...]` does, and skipping it made a whole table invisible while the
+    battery still reported clean.
+    """
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name):
+                    yield tgt.id, node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            if isinstance(node.target, ast.Name):
+                yield node.target.id, node.value
+
+
 def _module_env(tree, path):
     """Module-level names a battery's tables are built from.
 
-    Walks top-level assignments in order, so a constant may be defined in terms
-    of an earlier one -- which is how every battery spells its paths
-    (`_ROOT = os.path.dirname(_TESTS)`).
+    In source order, so a constant may be defined in terms of an earlier one --
+    which is how every battery spells its paths (`_ROOT =
+    os.path.dirname(_TESTS)`). A rebound name keeps its LAST value, as Python
+    would.
     """
     env = {'__file__': os.path.abspath(path)}
-    for node in tree.body:
-        if not isinstance(node, ast.Assign):
-            continue
-        value = _fold(node.value, env)
-        for tgt in node.targets:
-            if isinstance(tgt, ast.Name):
-                env[tgt.id] = value
+    for name, value_node in _assignments(tree):
+        env[name] = _fold(value_node, env)
     return env
 
 
@@ -187,11 +240,11 @@ def _module_env(tree, path):
 # --------------------------------------------------------------------------
 
 def _is_row_table(value):
-    """A list of tuples whose first element is a string: a mutation table.
+    """A non-empty list of tuples whose first element is a string.
 
-    Every battery's table is one, and nothing else at module scope in these
-    files is. Empty lists are rejected -- a table that resolved to nothing is
-    a parse failure wearing a clean result.
+    Every battery's table is one and nothing else at module scope is. Empty
+    lists are rejected: a table that resolved to nothing is a parse failure
+    wearing a clean result.
     """
     if not isinstance(value, list) or not value:
         return False
@@ -204,18 +257,36 @@ def _is_row_table(value):
 
 
 def _tables(tree, env):
-    """[(variable name, rows)] for every module-level mutation table."""
-    out = []
-    for node in tree.body:
-        if not isinstance(node, ast.Assign):
+    """([(name, rows)], reason) for the module-level mutation tables.
+
+    Two rules, and the second is the one that matters:
+
+    * a binding whose value IS a row table is a table; and
+    * a binding whose NAME declares one (`ROWS`, `*_ROWS`) and whose value is
+      not a row table makes the whole battery UNRESOLVED.
+
+    Without the second rule a table this cannot fold -- rows built by a helper
+    call, say -- simply vanished, and the battery still printed a clean line
+    for the tables that did resolve. A resolver that answers cleanly for a file
+    it did not understand is the bug this module exists to catch.
+
+    Names are collected ONCE each. Iterating assignment NODES counted a table
+    rebound at module scope twice over, silently doubling its anchors.
+    """
+    seen, out = set(), []
+    for name, _node in _assignments(tree):
+        if name in seen:
             continue
-        for tgt in node.targets:
-            if not isinstance(tgt, ast.Name):
-                continue
-            value = env.get(tgt.id, UNKNOWN)
-            if _is_row_table(value):
-                out.append((tgt.id, value))
-    return out
+        seen.add(name)
+        value = env.get(name, UNKNOWN)
+        if _is_row_table(value):
+            out.append((name, value))
+        elif _TABLE_NAME_RE.match(name):
+            return [], ('%s is named like a mutation table but did not '
+                        'resolve to one' % name)
+    if not out:
+        return [], 'no mutation table found'
+    return out, None
 
 
 def _battery_dict_targets(tree, env):
@@ -224,77 +295,105 @@ def _battery_dict_targets(tree, env):
     Maps a table's VARIABLE NAME to the source path in the same tuple. Read off
     the AST rather than the folded value because the association is by name --
     two tables of equal content would be indistinguishable once folded.
+
+    The path goes through `_abs_target` like every other. Returning `env`'s raw
+    value made a relative constant resolve against the PROCESS CWD, so the same
+    battery answered differently depending on where it was run from.
     """
     out = {}
-    for node in tree.body:
-        if not isinstance(node, ast.Assign) or not isinstance(node.value,
-                                                              ast.Dict):
+    for _name, node in _assignments(tree):
+        if not isinstance(node, ast.Dict):
             continue
-        for val in node.value.values:
+        for val in node.values:
             if not isinstance(val, (ast.Tuple, ast.List)):
                 continue
             names = [e.id for e in val.elts if isinstance(e, ast.Name)]
-            paths = [env.get(n) for n in names]
-            table = None
-            src = None
-            for name, resolved in zip(names, paths):
+            table = src = None
+            for elt_name in names:
+                resolved = env.get(elt_name)
                 if _is_row_table(resolved):
-                    table = name
-                elif isinstance(resolved, str) and src is None:
-                    src = resolved
+                    table = elt_name
+                elif src is None:
+                    src = _abs_target(resolved)
             if table and src:
                 out[table] = src
     return out
 
 
-def _abs_target(value, env, must_exist=True):
+def _abs_target(value, must_exist=True):
     """An absolute path from a row's target slot, else None.
 
     Handles both spellings: an already-absolute constant (`mutate_760.py`) and
-    a repo-relative string (`mutate_713_*.py`).
+    a repo-relative string (`mutate_713_*.py`). Relative paths resolve against
+    the REPO ROOT, never the process CWD.
 
     `must_exist` is False for a CREATE row, whose whole point is a file that is
-    not there yet (`mutate_713_census.py`'s "a NEW file with a clock,
-    registered nowhere"). Requiring the file unconditionally made that battery
-    report UNRESOLVED -- a resolver refusing the one row that is behaving
-    exactly as designed.
+    not there yet.
     """
     if not isinstance(value, str) or not value:
         return None
     path = value if os.path.isabs(value) else os.path.join(ROOT, value)
-    if must_exist and not os.path.isfile(path):
-        return None
-    if not must_exist and not value.endswith('.py'):
-        return None
-    return path
+    if must_exist:
+        return path if os.path.isfile(path) else None
+    return path if value.endswith('.py') else None
 
 
-def _edits(old, new):
-    """[(old, ...)] for a row, expanding the list-valued multi-edit form.
+def _edits(old):
+    """The `old` of each edit in a row, expanding the list-valued form.
 
     14 batteries let `old` be a list of `(old, new)` pairs with `new` None
-    (`mutate_554.py:78-83`). Each pair is its own anchor: one of them going
-    stale breaks the row exactly as a scalar anchor would, and #877's census
-    counted the ROW rather than the pair.
+    (`mutate_554.py:78-83`); `mutate_553.py:301-310` applies them as
+    `for o, nw in edits`, so element 0 of each pair is the anchor. Each pair is
+    its own anchor -- one going stale breaks the row exactly as a scalar anchor
+    would, and #877's census counted the ROW rather than the pair.
     """
     if isinstance(old, list):
-        out = []
-        for pair in old:
-            if isinstance(pair, list) and pair and isinstance(pair[0], str):
-                out.append(pair[0])
-            else:
-                out.append(UNKNOWN)
-        return out
-    return [old]
+        return [pair[0] if isinstance(pair, list) and pair else UNKNOWN
+                for pair in old], True
+    return [old], False
+
+
+def _layout(rows, targets_map, table_target, table_name):
+    """(layout, reason) for one table: 'key', 'path' or 'lone'.
+
+    Decided ONCE for the whole table, from ALL its rows, because a table is
+    homogeneous and a per-row guess is not safe. Trying `_abs_target(row[1])`
+    per row meant a single row whose `old` happened to be a repo-relative path
+    to a real file was read as a target -- grading that row's NEW text against
+    the file its OLD text named, and reporting a false STALE. A false stale
+    costs exactly what a missed one does.
+
+    When both readings are viable the table is REFUSED, not guessed. No
+    battery in the tree is ambiguous today; one that becomes so must be read by
+    someone rather than resolved by a coin flip.
+    """
+    def creates(row):
+        return len(row) > 2 and row[2] is None
+
+    key = bool(targets_map) and all(
+        isinstance(r[1], str) and r[1] in targets_map for r in rows)
+    if key:
+        return 'key', None
+
+    path = all(_abs_target(r[1], must_exist=not creates(r)) is not None
+               for r in rows)
+    if path and table_target is not None:
+        return None, ('%s can be read two ways -- every row[1] names a real '
+                      'file AND the table has a target of its own' % table_name)
+    if path:
+        return 'path', None
+    if table_target is not None:
+        return 'lone', None
+    return None, ('%s names no target: row[1] is not a TARGETS key, not a '
+                  'resolvable path, and the table has no target of its own'
+                  % table_name)
 
 
 def resolve_static(path):
     """(anchors, unresolved_reason) for one `tests/mutate_*.py`, without import.
 
     `unresolved_reason` is a string when the file could not be read as a
-    battery at all; the caller must treat that as a failure, never as "no
-    anchors". A resolver that answers cleanly for a file it did not understand
-    is the same bug this module exists to catch.
+    battery; the caller must treat that as a failure, never as "no anchors".
     """
     battery = os.path.basename(path)
     try:
@@ -308,9 +407,9 @@ def resolve_static(path):
         return [], 'cannot parse: %s' % exc
 
     env = _module_env(tree, path)
-    tables = _tables(tree, env)
-    if not tables:
-        return [], 'no mutation table found'
+    tables, reason = _tables(tree, env)
+    if reason:
+        return [], reason
 
     targets_map = env.get('TARGETS')
     if not isinstance(targets_map, dict):
@@ -318,54 +417,45 @@ def resolve_static(path):
     by_table = _battery_dict_targets(tree, env)
 
     #: The single-target fallback: a battery with one engine file names it
-    #: ENGINE (`mutate_750.py:46`). Only consulted when the row itself carries
-    #: no target, so it cannot mask a per-row path.
-    lone = _abs_target(env.get('ENGINE'), env)
+    #: ENGINE (`mutate_750.py:46`).
+    lone = _abs_target(env.get('ENGINE'))
 
     anchors = []
     for table_name, rows in tables:
         table_target = by_table.get(table_name) or lone
-        for row in rows:
-            name = row[0]
-            slot = row[1]
+        layout, reason = _layout(rows, targets_map, table_target, table_name)
+        if reason:
+            return [], reason
 
-            # Layout A: row[1] keys the TARGETS dict.
-            if isinstance(slot, str) and slot in targets_map:
-                target = _abs_target(targets_map[slot], env)
-                old, new = row[2], row[3] if len(row) > 3 else None
-                nth = None
-            else:
-                # A CREATE row (`old is None`) names a file that does not exist
-                # yet; every other row's target must be a real file, or a typo
-                # would silently resolve and grade as stale.
+        for row in rows:
+            name, slot = row[0], row[1]
+            nth = None
+            if layout == 'key':
+                target = _abs_target(targets_map[slot])
+                old = row[2]
+            elif layout == 'path':
                 creates = len(row) > 2 and row[2] is None
-                explicit = _abs_target(slot, env, must_exist=not creates)
-                if explicit is not None:
-                    # Layouts D and E: row[1] IS the path.
-                    target = explicit
-                    old = row[2]
-                    new = row[3] if len(row) > 3 else None
-                    nth = row[4] if len(row) > 4 and isinstance(
-                        row[4], int) and not isinstance(row[4], bool) else None
-                else:
-                    # Layouts B and C: no per-row target; row[1] is the anchor.
-                    target = table_target
-                    old, new = slot, row[2]
-                    nth = None
+                target = _abs_target(slot, must_exist=not creates)
+                old = row[2] if len(row) > 2 else UNKNOWN
+                nth = (row[4] if len(row) > 4 and isinstance(row[4], int)
+                       and not isinstance(row[4], bool) else None)
+            else:
+                target, old = table_target, slot
 
             if target is None:
                 return [], ('row %r in %s names no resolvable target'
                             % (name, table_name))
 
-            for i, one in enumerate(_edits(old, new)):
+            olds, multi = _edits(old)
+            for i, one in enumerate(olds):
                 if one is UNKNOWN:
                     return [], ('row %r in %s has an anchor this cannot '
                                 'reproduce exactly' % (name, table_name))
                 if one is not None and not isinstance(one, str):
                     return [], ('row %r in %s has a non-string anchor'
                                 % (name, table_name))
-                anchors.append(Anchor(battery, name, target, one, nth,
-                                      0 if not isinstance(old, list) else i))
+                anchors.append(Anchor(battery, name, target, one, nth, i,
+                                      multi))
     return anchors, None
 
 
@@ -374,33 +464,54 @@ def resolve_static(path):
 # --------------------------------------------------------------------------
 
 def _read_target(path, cache):
-    """The target's text with UNIVERSAL NEWLINES, which is what the batteries
-    match against (`mutate_711.py:296-305`). Reading it any other way makes
-    every multi-line anchor stale on a CRLF checkout."""
+    """(universal_newline_text, as_written_text) for a target.
+
+    Both, because the batteries disagree about which they match against: this
+    module and `mutate_711.py` read universal-newline, while 18 batteries read
+    with `newline=''`. On an LF checkout the two are identical; on a CRLF one
+    they are not, and an anchor whose count differs between them is a verdict
+    that depends on the checkout rather than on the code.
+    """
     if path not in cache:
-        with open(path, encoding='utf-8', errors='replace') as fh:
-            cache[path] = fh.read()
+        with open(path, 'rb') as fh:
+            raw = fh.read().decode('utf-8', 'replace')
+        cache[path] = (raw.replace('\r\n', '\n'), raw)
     return cache[path]
 
 
 def verify(anchors, repo_wide=False):
-    """Every problem among `anchors`, worst first within each battery.
+    """Every problem among `anchors`.
 
-    Returns a list, never raises on a bad anchor: the caller decides whether a
-    problem is fatal, and a run that stops at the first one hides the rest.
+    Returns a list and never raises: the caller decides what is fatal, and a
+    run that stops at the first problem hides the rest.
     """
     problems = []
     cache = {}
     for a in anchors:
         if a.old is None:
-            # `mutate_713_census.py`'s create-this-file row. It carries no
-            # anchor; grading it as one invents a finding.
+            # A create row has no anchor, but it is not unchecked: the battery
+            # refuses when the file it means to create is already there
+            # (`mutate_713_census.py:129-132`).
+            if os.path.exists(a.target):
+                problems.append(Problem(
+                    a, CREATE_EXISTS, 0,
+                    'the row creates %s, which already exists -- the battery '
+                    'reports BROKEN'
+                    % os.path.relpath(a.target, ROOT).replace(os.sep, '/')))
             continue
         if not os.path.isfile(a.target):
             problems.append(Problem(a, MISSING_TARGET, 0,
                                     'target does not exist'))
             continue
-        n = _read_target(a.target, cache).count(a.old)
+        text, as_written = _read_target(a.target, cache)
+        n = text.count(a.old)
+        if n != as_written.count(a.old):
+            problems.append(Problem(
+                a, NEWLINE_SENSITIVE, n,
+                'as-written count is %d -- the verdict depends on how the '
+                'target is read, and the batteries disagree about that'
+                % as_written.count(a.old)))
+            continue
         if a.nth is not None:
             if n < a.nth + 1:
                 problems.append(Problem(
@@ -409,8 +520,7 @@ def verify(anchors, repo_wide=False):
                     % (a.nth, a.nth + 1)))
             continue
         if n == 0:
-            problems.append(Problem(a, STALE, 0,
-                                    'the row mutates nothing'))
+            problems.append(Problem(a, STALE, 0, 'the row mutates nothing'))
         elif n > 1:
             problems.append(Problem(
                 a, AMBIGUOUS, n,
@@ -428,10 +538,10 @@ def _prose_problems(anchors):
     comment reports SURVIVED for a mutation that changed nothing executable.
     """
     import subprocess
-    out = subprocess.run(['git', 'ls-files', '*.py', '*.md'], cwd=ROOT,
-                         capture_output=True, text=True).stdout.split()
+    listed = subprocess.run(['git', 'ls-files', '*.py', '*.md'], cwd=ROOT,
+                            capture_output=True, text=True).stdout.split()
     texts = {}
-    for rel in out:
+    for rel in listed:
         path = os.path.join(ROOT, rel)
         try:
             with open(path, encoding='utf-8', errors='replace') as fh:
@@ -443,15 +553,16 @@ def _prose_problems(anchors):
         if a.old is None:
             continue
         battery_path = os.path.abspath(os.path.join(TESTS_DIR, a.battery))
-        others = [p for p, text in texts.items()
-                  if p not in (os.path.abspath(a.target), battery_path)
-                  and a.old in text]
+        others = sorted(p for p, text in texts.items()
+                        if p not in (os.path.abspath(a.target), battery_path)
+                        and a.old in text)
         if others:
             problems.append(Problem(
-                a, 'PROSE', len(others),
-                'also in ' + ', '.join(
-                    os.path.relpath(p, ROOT).replace(os.sep, '/')
-                    for p in sorted(others)[:3])))
+                a, PROSE, len(others),
+                'also in %d other tracked file(s): %s' % (
+                    len(others),
+                    ', '.join(os.path.relpath(p, ROOT).replace(os.sep, '/')
+                              for p in others[:3]))))
     return problems
 
 
@@ -462,12 +573,12 @@ def batteries():
     return [os.path.join(TESTS_DIR, n) for n in names]
 
 
-def census():
+def census(repo_wide=False):
     """[(battery, anchors, problems, unresolved_reason)] over the whole tree."""
     out = []
     for path in batteries():
         anchors, reason = resolve_static(path)
-        problems = [] if reason else verify(anchors)
+        problems = [] if reason else verify(anchors, repo_wide=repo_wide)
         out.append((os.path.basename(path), anchors, problems, reason))
     return out
 
@@ -478,34 +589,31 @@ def main():
     ap.add_argument('--verbose', action='store_true',
                     help='print every anchor, not only the problems')
     ap.add_argument('--repo-wide', action='store_true',
-                    help="also report anchors that occur in another tracked "
-                         "file, which may be prose rather than code")
+                    help='also report anchors that occur in another tracked '
+                         'file, which may be prose rather than code')
     args = ap.parse_args()
 
-    rows = census()
+    rows = census(repo_wide=args.repo_wide)
     if args.battery:
         rows = [r for r in rows if r[0] == args.battery]
         if not rows:
             print('no battery named %r' % args.battery, file=sys.stderr)
             return 2
 
-    total = stale = ambiguous = missing = unresolved = 0
+    total = unresolved = 0
+    kinds = {}
     print('%-26s %6s %6s %6s %6s' % ('battery', 'rows', 'STALE', 'AMBIG',
                                      'UNRES'))
     for name, anchors, problems, reason in rows:
-        if args.repo_wide and not reason:
-            problems = verify(anchors, repo_wide=True)
-        n_stale = sum(1 for p in problems if p.kind == STALE)
-        n_amb = sum(1 for p in problems if p.kind == AMBIGUOUS)
-        n_missing = sum(1 for p in problems if p.kind == MISSING_TARGET)
         total += len(anchors)
-        stale += n_stale
-        ambiguous += n_amb
-        missing += n_missing
         if reason:
             unresolved += 1
+        for p in problems:
+            kinds[p.kind] = kinds.get(p.kind, 0) + 1
         print('%-26s %6s %6s %6s %6s' % (
-            name, len(anchors) if not reason else '-', n_stale, n_amb,
+            name, len(anchors) if not reason else '-',
+            sum(1 for p in problems if p.kind == STALE),
+            sum(1 for p in problems if p.kind == AMBIGUOUS),
             'YES' if reason else ''))
         if reason:
             print('    UNRESOLVED: %s' % reason)
@@ -517,10 +625,14 @@ def main():
                     a.label,
                     os.path.relpath(a.target, ROOT).replace(os.sep, '/')))
 
-    print('\n%d battery(s), %d anchor(s): %d stale, %d ambiguous, %d missing '
-          'target, %d unresolved' % (len(rows), total, stale, ambiguous,
-                                     missing, unresolved))
-    return 1 if (stale or missing or unresolved) else 0
+    summary = ', '.join('%d %s' % (kinds[k], k.lower())
+                        for k in sorted(kinds)) or 'no problems'
+    print('\n%d battery(s), %d anchor(s): %s, %d unresolved'
+          % (len(rows), total, summary, unresolved))
+    # EVERY problem kind fails, not only STALE. The exit code and the #718 gate
+    # must agree about what is wrong, or the one-second check reports green
+    # while the suite goes red on the same rows.
+    return 1 if (kinds or unresolved) else 0
 
 
 if __name__ == '__main__':

--- a/tests/mutation_anchors.py
+++ b/tests/mutation_anchors.py
@@ -20,11 +20,14 @@ implementation of that question in the tree, for two callers:
   * `tests/test_718_static_test_hygiene.py`, over every battery, without
     importing any of them (`resolve_static` -> `verify`).
 
-The second caller exists today; the batteries are converted in the same PR.
-Until that lands, the five hand-rolled `--verify-anchors` implementations
-(`mutate_714`, `726`, `837`, `847`, `850_848`) are still the shipped state, and
-`mutate_726.py:248-280`'s is STRICTER than this module's default -- its prose
-check is always on, where here it needs `--repo-wide`.
+Both callers exist. Every battery calls `preflight`, which also HANDLES
+`--verify-anchors` and strips it from `sys.argv`, so the five hand-rolled
+implementations that predate this (`mutate_714`, `726`, `837`, `847`,
+`850_848`) are no longer what answers that flag. One of them was STRICTER than
+this module's default -- `mutate_726`'s also refuses an anchor occurring in
+another tracked file, the prose trap -- so that battery passes
+`repo_wide=True`. A shared check that silently weakened a battery's own would
+be this module's defect in miniature.
 
 **Static resolution is not an optimisation, it is the only safe way.**
 `mutate_713_census.py`, `mutate_713_phase1.py` and `mutate_760.py` run their
@@ -42,8 +45,8 @@ Distinctions a plain `count(old) != 1` does not draw:
     rows as stale.
 
   * **NEWLINE_SENSITIVE**: the anchor's verdict changes with how the target is
-    read. This module reads universal-newline, and so does `mutate_711.py`
-    (`:296-305`), whose comment records that matching a raw byte decode
+    read. This module reads universal-newline, and so does `mutate_711.py`,
+    whose comment records that matching a raw byte decode
     "silently found NOTHING in three rows". But 18 batteries read their target
     with `newline=''`, so on a CRLF checkout the census and the battery would
     disagree. Dormant on this tree -- `.gitattributes` pins `*.py text eol=lf`
@@ -52,7 +55,7 @@ Distinctions a plain `count(old) != 1` does not draw:
   * A **create row** (`old is None`, `mutate_713_census.py`'s "a NEW file with
     a clock, registered nowhere") carries no anchor, but it is not unchecked:
     the battery reports BROKEN when the file it means to create already exists
-    (`mutate_713_census.py:129-132`), and that is what is graded here.
+    (`mutate_713_census.py's create-exists check`), and that is what is graded here.
 
     python3 tests/mutation_anchors.py               # census over every battery
     python3 tests/mutation_anchors.py --verbose     # every anchor, one a line
@@ -87,10 +90,10 @@ _TABLE_NAME_RE = re.compile(r'^(ROWS|[A-Z_]*_ROWS)$')
 class Anchor(object):
     """One `old` string, and the file it must occur in exactly once.
 
-    `nth` is the optional occurrence selector `mutate_760.py:65-79` implements
-    (`row[4]`), which replaces the Nth match instead of the first -- so its
-    requirement is "at least nth+1 matches", not "exactly one". No row uses it
-    today; the form is supported because the battery accepts it.
+    `nth` is the optional occurrence selector `mutate_760.py` implements as a
+    fifth row element, which replaces the Nth match instead of the first -- so
+    its requirement is "at least nth+1 matches", not "exactly one". No row uses
+    it today; the form is supported because that battery accepts it.
 
     `old is None` marks a create-this-file row, which has no anchor.
     """
@@ -256,6 +259,24 @@ def _is_row_table(value):
     return True
 
 
+def _looks_like_a_table(node):
+    """SYNTACTICALLY a mutation table: a non-empty list/tuple of tuples.
+
+    The name test alone was not enough. A second table called `GUI_TABLE`,
+    `ROWS2` or `MUTATIONS` -- or one built by a comprehension -- fell through
+    both arms of `_tables` and VANISHED, and the battery reported clean about
+    rows nobody checked. Shape catches what the name misses, and a table this
+    can see but not fold is exactly the case that must refuse rather than
+    disappear.
+    """
+    if isinstance(node, (ast.ListComp, ast.GeneratorExp)):
+        return True
+    if not isinstance(node, (ast.List, ast.Tuple)) or not node.elts:
+        return False
+    return all(isinstance(e, (ast.Tuple, ast.List, ast.Call, ast.Starred))
+               for e in node.elts)
+
+
 def _tables(tree, env):
     """([(name, rows)], reason) for the module-level mutation tables.
 
@@ -274,16 +295,16 @@ def _tables(tree, env):
     rebound at module scope twice over, silently doubling its anchors.
     """
     seen, out = set(), []
-    for name, _node in _assignments(tree):
+    for name, node in _assignments(tree):
         if name in seen:
             continue
         seen.add(name)
         value = env.get(name, UNKNOWN)
         if _is_row_table(value):
             out.append((name, value))
-        elif _TABLE_NAME_RE.match(name):
-            return [], ('%s is named like a mutation table but did not '
-                        'resolve to one' % name)
+        elif _TABLE_NAME_RE.match(name) or _looks_like_a_table(node):
+            return [], ('%s is shaped or named like a mutation table but did '
+                        'not resolve to one' % name)
     if not out:
         return [], 'no mutation table found'
     return out, None
@@ -342,7 +363,7 @@ def _edits(old):
     """The `old` of each edit in a row, expanding the list-valued form.
 
     14 batteries let `old` be a list of `(old, new)` pairs with `new` None
-    (`mutate_554.py:78-83`); `mutate_553.py:301-310` applies them as
+    (`mutate_554.py:78-83`); `mutate_553.py's edit loop` applies them as
     `for o, nw in edits`, so element 0 of each pair is the anchor. Each pair is
     its own anchor -- one going stale breaks the row exactly as a scalar anchor
     would, and #877's census counted the ROW rather than the pair.
@@ -491,7 +512,7 @@ def verify(anchors, repo_wide=False):
         if a.old is None:
             # A create row has no anchor, but it is not unchecked: the battery
             # refuses when the file it means to create is already there
-            # (`mutate_713_census.py:129-132`).
+            # (`mutate_713_census.py's create-exists check`).
             if os.path.exists(a.target):
                 problems.append(Problem(
                     a, CREATE_EXISTS, 0,
@@ -533,13 +554,21 @@ def verify(anchors, repo_wide=False):
 def _prose_problems(anchors):
     """Anchors that also occur in another tracked file.
 
-    `mutate_726.py:248-280`'s check, kept: a comment quoting code has satisfied
+    `mutate_726.py's verify_anchors`'s check, kept: a comment quoting code has satisfied
     a grep-shaped test in this repo before, and a battery that mutates a
     comment reports SURVIVED for a mutation that changed nothing executable.
     """
     import subprocess
-    listed = subprocess.run(['git', 'ls-files', '*.py', '*.md'], cwd=ROOT,
-                            capture_output=True, text=True).stdout.split()
+    r = subprocess.run(['git', 'ls-files', '*.py', '*.md'], cwd=ROOT,
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        # Zero tracked files would mean zero prose problems and a clean
+        # report -- the same shape as the defect this module polices. Refuse
+        # instead of answering from an empty list.
+        raise RuntimeError(
+            'git ls-files failed (%d), so the prose check has no corpus and '
+            'cannot answer: %s' % (r.returncode, (r.stderr or '').strip()))
+    listed = r.stdout.split()
     texts = {}
     for rel in listed:
         path = os.path.join(ROOT, rel)

--- a/tests/test_456_side_and_outline.py
+++ b/tests/test_456_side_and_outline.py
@@ -460,7 +460,7 @@ def test_far_side_box_is_not_transposed_on_a_rotated_footprint():
     2.54 x 13.97 where the truth is 3.81 x 12.70, under-blocking 1.27mm on the
     far side. The box must be projected through the pad's local tilt, exactly as
     placement/utility.compute_footprint_bbox_local does."""
-    from placement.quench import _through_pad_bounds_local
+    from placement.legality import through_pad_bounds_local
     board = os.path.join(KICAD_FILES, 'kit-dev-coldfire-xilinx_5213.kicad_pcb')
     if not os.path.exists(board):
         return
@@ -470,7 +470,7 @@ def test_far_side_box_is_not_transposed_on_a_rotated_footprint():
         drilled = [p for p in fp.pads if (p.drill or 0) > 0]
         if not drilled:
             continue
-        b = _through_pad_bounds_local(fp)
+        b = through_pad_bounds_local(fp)
         xs, ys = [], []
         for p in drilled:
             sx, sy = p.size_x, p.size_y
@@ -491,7 +491,7 @@ def test_far_side_box_sits_on_the_hole_not_offset_from_it():
     hole_x/hole_y BEFORE shifting global_x/global_y to the copper centre. The
     old code 'corrected' by (hole - global), which is MINUS the offset, landing
     the box a full offset on the wrong side."""
-    from placement.quench import _through_pad_bounds_local
+    from placement.legality import through_pad_bounds_local
 
     class _P:
         shape = 'circle'
@@ -507,7 +507,7 @@ def test_far_side_box_sits_on_the_hole_not_offset_from_it():
         rotation = 0.0
         pads = [_P()]
 
-    b = _through_pad_bounds_local(_F())
+    b = through_pad_bounds_local(_F())
     cx, cy = (b[0] + b[2]) / 2.0, (b[1] + b[3]) / 2.0
     assert abs(cx) < 1e-9 and abs(cy) < 1e-9,         f"far-side box centred at ({cx}, {cy}); the hole is at the local origin"
 

--- a/tests/test_702_quench_intent_gate.py
+++ b/tests/test_702_quench_intent_gate.py
@@ -21,26 +21,46 @@ mutations in `tests/mutate_702.py` are killed only by a `by_site` assertion.
 MEASURED MUTATION TABLE, from `python3 tests/mutate_702.py`. The edits are in
 that file; these are the verdicts, recorded FROM THE RUN and not predicted:
 
-    22 rows: 19 killed, 3 survived, 0 broken, 0 disagreeing with expectation
+RE-MEASURED after #877 re-anchored eight of the rows, which had been asserting
+nothing since `c7bef8d9`:
 
-    the two survivors, recorded rather than deleted:
+    22 rows: 19 killed, 3 survived, 0 broken, 1 disagreeing with expectation
+
+The totals are unchanged from the previous recording; the MEMBERSHIP is not,
+and both moves are findings rather than noise.
+
+    the survivors, recorded rather than deleted:
       the-gate-is-built-even-with-no-intent      building an empty spec on a
                                                 board that declares nothing is
                                                 indistinguishable from not
                                                 building one -- every lookup
                                                 misses and `intent_ok` returns
-                                                on `if not spec`.
-      the-active-flag-ignores-whether-anything-bound
-                                                same reason, one level up: the
-                                                flag only guards work that is
-                                                already a no-op on an empty
-                                                spec. Kept as a detector for
-                                                the day the guard means more.
+                                                on `if not spec`. (#877
+                                                re-pointed this row at
+                                                `build_zone_spec`'s early-out,
+                                                which is where that claim now
+                                                lives.)
       the-swallow-test-ignores-the-tolerance    no arm builds a zone whose
                                                 tolerance band reaches outside
                                                 its keep-out; the row is here
                                                 so the guard exists the day one
                                                 does.
+      the-crossed-claim-check-never-fires       EXPECTS KILLED. See below.
+
+    the-active-flag-ignores-whether-anything-bound now KILLS, and was recorded
+    above as a survivor "kept as a detector for the day the guard means more".
+    That day arrived: this file has since grown two arms asserting the FLAG
+    rather than its consequences, and the mutation fails both. Re-graded in
+    `mutate_702.py`.
+
+    the-crossed-claim-check-never-fires is the one DISAGREEMENT, and it is a
+    coverage regression in THIS FILE, not in #877's work: the row, its target
+    (`floorplan.py`) and this gate are all byte-identical to the commit the
+    branch forked from, and the table above records it as KILLED when it was
+    last measured. It went quiet in between, and nobody could see it because
+    the battery was already exiting non-zero on the eight BROKEN rows. Left
+    standing as a real finding, to be fixed on its own terms rather than folded
+    into an anchor pass.
 
 Three rows exist because a mutation caught THIS FILE, not the engine:
 `the-incumbent-is-read-at-the-SEED-pose` survived until arm C was written at

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -925,6 +925,108 @@ def test_every_committed_baseline_is_declared():
           f'{len(_BASELINE_UNGATED)} ungated with a stated reason')
 
 
+#: Batteries whose row table `mutation_anchors.resolve_static` cannot read.
+#:
+#: Declared with the reason and held in BOTH directions, like `_WK_DEPENDENT`
+#: above: an entry that no longer applies is as much a defect as a missing one,
+#: because a stale exemption is indistinguishable from a gate that still covers
+#: the file. Empty today -- all 37 resolve -- and it exists so that a battery
+#: written in a shape the resolver has never seen fails LOUDLY here instead of
+#: being counted as "no anchors, nothing to check".
+_UNRESOLVABLE = {}
+
+#: Every `tests/mutate_*.py` in the tree, pinned. A resolver that quietly stops
+#: finding batteries would otherwise report a clean sweep over nothing -- the
+#: exact shape of the defect #877 is about, reproduced in its own gate.
+_BATTERY_COUNT = 37
+
+#: A floor well under today's 831, not a target. Same purpose as
+#: `test_the_scanners_still_match_something`: prove the corpus is populated.
+_MIN_ANCHORS = 600
+
+
+def test_every_mutation_anchor_matches_exactly_once():
+    """A mutation row whose anchor no longer matches guards NOTHING (#877).
+
+    A row is applied with `src.replace(old, new, 1)`. When `old` has gone --
+    a rename, a reflow, a dedent -- the row rewrites nothing, and every gate it
+    names passes for a reason that has nothing to do with the claim next to it.
+
+    Every battery does detect this and reports BROKEN rather than a kill. What
+    it cannot do is detect it CHEAPLY: the check runs per row, mid-run, after
+    the witnesses have been paid for. #877 quotes `mutate_847.py`'s own words --
+    "a stale anchor reports BROKEN 50 minutes into a run rather than in one
+    second before it". This is the one second, and it is the only thing in the
+    tree that runs over ALL the batteries: they are deliberately not named
+    `test_*`, so `run_all.discover()` never collects them, and at the time #877
+    was filed 8 of the 37 had been red for months with nobody looking.
+
+    Measured at 0aff32c0, before the re-anchoring pass: 29 stale anchors and 3
+    ambiguous ones across 9 batteries, of 831. #877 reported 24, missing
+    `mutate_834_835.py`'s 7 entirely and counting `mutate_703.py`'s 3 ambiguous
+    rows as stale.
+
+    AMBIGUOUS (>1 match) fails here as well as STALE (0). It is a milder
+    defect -- the row still mutates -- but which of the matching sites it hits
+    is decided by their order in the file rather than by the row, so the row's
+    subject is not what its name says it is.
+    """
+    sys.path.insert(0, TESTS_DIR)
+    import mutation_anchors
+
+    paths = mutation_anchors.batteries()
+    assert len(paths) == _BATTERY_COUNT, (
+        f'expected {_BATTERY_COUNT} mutation batteries, found {len(paths)}. '
+        f'If a battery was added or removed, update _BATTERY_COUNT -- the pin '
+        f'is here so a scan that stops finding them cannot report a clean '
+        f'sweep over an empty corpus.')
+
+    problems, unresolved, total = [], {}, 0
+    for path in paths:
+        name = os.path.basename(path)
+        anchors, reason = mutation_anchors.resolve_static(path)
+        if reason:
+            unresolved[name] = reason
+            continue
+        total += len(anchors)
+        assert anchors, (
+            f'{name}: resolved to ZERO anchors and reported no reason. That '
+            f'is a resolver failure wearing a clean result -- the battery has '
+            f'rows.')
+        for p in mutation_anchors.verify(anchors):
+            problems.append(str(p))
+
+    undeclared = sorted(set(unresolved) - set(_UNRESOLVABLE))
+    assert not undeclared, (
+        'battery(s) whose row table could not be resolved:\n  '
+        + '\n  '.join(f'{n}: {unresolved[n]}' for n in undeclared)
+        + '\nAn unreadable table is not an empty one. Either teach '
+          'mutation_anchors the shape, or declare it in _UNRESOLVABLE with '
+          'the reason -- silence here means the battery is unchecked.')
+    departed = sorted(set(_UNRESOLVABLE) - set(unresolved))
+    assert not departed, (
+        '_UNRESOLVABLE names battery(s) that now resolve fine:\n  '
+        + '\n  '.join(departed)
+        + '\nDrop them. A stale exemption is indistinguishable from a gate '
+          'that still covers the file.')
+
+    assert total >= _MIN_ANCHORS, (
+        f'only {total} anchor(s) resolved across {len(paths)} batteries -- the '
+        f'resolver has stopped reading the tables, so a green result here '
+        f'means nothing')
+
+    assert not problems, (
+        f'mutation row(s) whose anchor does not match its target exactly '
+        f'once:\n  ' + '\n  '.join(problems)
+        + '\nSTALE means the row rewrites nothing and the gates it names pass '
+          'for free. AMBIGUOUS means replace(..., 1) picks a site by file '
+          'order rather than by the row. Re-anchor the row to the code as it '
+          'now stands, expressing the SAME mutation -- never widen it to '
+          'whatever is convenient to quote (#877).')
+    print(f'  PASS: {total} mutation anchor(s) across {len(paths)} batteries '
+          f'each match their target exactly once')
+
+
 TESTS = [
     test_wk_dependent_tests_are_declared,
     test_no_test_spawns_a_script_that_moved,
@@ -933,6 +1035,7 @@ TESTS = [
     test_no_test_is_defined_after_its_own_runner,
     test_every_test_is_registered_in_its_files_own_list,
     test_every_committed_baseline_is_declared,
+    test_every_mutation_anchor_matches_exactly_once,
 ]
 
 

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -612,6 +612,8 @@ _BASELINE_GATES = {
         'tests/test_799_feasibility_claims.py',
     'tests/831_fill_timing_census.json':
         'tests/test_831_fill_preflight_census.py',
+    'tests/878_far_face_currency.json':
+        'tests/test_878_far_face_currency.py',
     'tests/placement_ab_baseline.json': 'tests/test_placement_ab.py',
     'tests/placement_calibration_recovered.json':
         'tests/test_803_calibration_claims.py',
@@ -670,7 +672,7 @@ _UNGATED_BASELINE_COUNT = 7
 #: verbatim, because the print string has since been reworded and the counts
 #: have moved -- a "measured" line spliced from two versions is exactly what
 #: #879 is about.)
-_DECLARED_BASELINE_COUNT = 20
+_DECLARED_BASELINE_COUNT = 21
 
 #: Committed JSON/JSONL under `tests/` that is an INPUT, not a recorded
 #: measurement. Full-path regexes, each with its reason.

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -958,13 +958,32 @@ def test_every_mutation_anchor_matches_exactly_once():
     "a stale anchor reports BROKEN 50 minutes into a run rather than in one
     second before it". This is the one second, and it is the only thing in the
     tree that runs over ALL the batteries: they are deliberately not named
-    `test_*`, so `run_all.discover()` never collects them, and at the time #877
-    was filed 8 of the 37 had been red for months with nobody looking.
+    `test_*`, so `run_all.discover()` never collects them, and nothing else
+    does either.
+
+    HOW LONG THEY HAD BEEN RED, measured rather than guessed, because the first
+    draft of this docstring said "months" and that flattered the change: the
+    earliest staling commit is `b02761b7` (2026-08-26) and #877 was filed
+    2026-09-05, so the worst case is TEN DAYS and two batteries had been red
+    for one. The argument for this gate is not that the rot is ancient -- it is
+    that nothing in the tree could see it at all, so its age was never bounded
+    by anything but luck.
 
     Measured at 0aff32c0, before the re-anchoring pass: 29 stale anchors and 3
-    ambiguous ones across 9 batteries, of 831. #877 reported 24, missing
-    `mutate_834_835.py`'s 7 entirely and counting `mutate_703.py`'s 3 ambiguous
-    rows as stale.
+    ambiguous ones across 9 batteries, of 831 anchors in 822 rows.
+
+    #877 reported 24 of 581. Neither number reproduces, and the difference is
+    method, not drift -- both re-measure identically at the commit it cites:
+
+      * it MISSED `mutate_834_835.py` entirely, which has 7 (the third-worst);
+      * it counted `mutate_703.py`'s 3 rows as stale where they are AMBIGUOUS,
+        matching twice rather than never; and
+      * its denominators are SCALAR-ROW counts, so it dropped the 8 multi-edit
+        rows -- under its own rule the total should have read 814, not 581.
+
+    So 24 = 28 (stale scalar rows) - 7 (missed) + 3 (miscounted); the 29th
+    stale anchor is the second edit of a multi-edit row, which it could not
+    see.
 
     AMBIGUOUS (>1 match) fails here as well as STALE (0). It is a milder
     defect -- the row still mutates -- but which of the matching sites it hits

--- a/tests/test_837_assembly_sides.py
+++ b/tests/test_837_assembly_sides.py
@@ -447,9 +447,14 @@ def main():
     check("capacity: the undeclared run says the back area is credited free",
           'NOT MODELLED' in out_none
           and 'credited free' in out_none, out_none[-700:])
+    # #878 reworded the far-face half: the leads ARE charged now, so the
+    # sentence became "what the far charge is, and what still disagrees with
+    # it" rather than "it is not charged". The claim this arm makes is
+    # unchanged -- the declared run drops the back-area-credit half and keeps
+    # the far-face half -- so only the phrase it greps for moves.
     check("capacity: and the declared run drops that half, keeping the other",
           'NOT MODELLED' in out_f and 'credited free' not in out_f
-          and 'through-hole leads' in out_f, out_f[-700:])
+          and 'through-hole part is charged' in out_f, out_f[-700:])
 
     # An intent that declares NOTHING is not an intent that declares `both`.
     # They share an arithmetic and are different statements, and reading them

--- a/tests/test_877_mutation_anchors.py
+++ b/tests/test_877_mutation_anchors.py
@@ -17,7 +17,7 @@ reported a clean result for all five. They are kept as change detectors:
   3. a table bound twice at module scope, which was counted TWICE -- and an
      inflated anchor count is invisible against a floor;
   4. a create-this-file row aimed at a file that already exists, the one
-     condition `mutate_713_census.py:129-132` reports BROKEN for and the one
+     condition `mutate_713_census.py's create-exists check` reports BROKEN for and the one
      the first draft skipped outright;
   5. a table both layouts fit, which must be REFUSED rather than guessed; and
   6. a row whose `old` is itself a path to a real file, which was read as the
@@ -125,6 +125,34 @@ def test_a_helper_built_table_is_refused_not_dropped():
     print('  PASS: a helper-built table is named, not dropped')
 
 
+def test_an_unreadable_table_is_refused_whatever_it_is_called():
+    """The refusal must rest on SHAPE, not only on the name `*_ROWS`.
+
+    The first fix keyed only on the name, so a second table called `GUI_TABLE`,
+    `ROWS2` or `MUTATIONS` -- or one built by a comprehension -- still vanished
+    and the battery still reported clean. Each fixture below hides a row whose
+    anchor matches nothing, so a silent drop is a silent false pass.
+    """
+    bodies = {
+        'GUI_TABLE': 'GUI_TABLE = [_row(%r, %r, %r)]\n' % ('r2', GONE, 'y'),
+        'ROWS2': 'ROWS2 = [_row(%r, %r, %r)]\n' % ('r2', GONE, 'y'),
+        'MUTATIONS': ('MUTATIONS = [(n, %r, "y") for n in ("r2",)]\n' % GONE),
+    }
+    missed = []
+    for name, extra in bodies.items():
+        with _Fixture() as fx:
+            _a, reason, _p = fx.battery('mutate_probe_%s.py' % name.lower(), (
+                'def _row(a, b, c):\n    return (a, b, c)\n'
+                'ROWS = [(%r, %r, %r)]\n' % ('r1', UNIQUE, 'x')) + extra)
+        if reason is None:
+            missed.append(name)
+    assert not missed, (
+        f'a second, unreadable table named {missed} was dropped in silence. '
+        f'The guard must key on the SHAPE of the value -- a list of tuples '
+        f'that would not fold -- not only on the name matching *_ROWS.')
+    print('  PASS: an unreadable table is refused whatever it is called')
+
+
 def test_an_annotated_table_assignment_is_seen():
     """`ROWS: List[Row] = [...]` binds exactly as `ROWS = [...]` does.
 
@@ -170,12 +198,16 @@ def test_a_create_row_whose_file_exists_is_reported():
     """The one condition a create row can fail, graded rather than skipped.
 
     A create row carries no anchor, so skipping it looked right -- but
-    `mutate_713_census.py:129-132` reports BROKEN when the file it means to
+    `mutate_713_census.py's create-exists check` reports BROKEN when the file it means to
     create is already there. Skipping meant the row the resolver singles out
     for special handling was the one row it checked nothing about.
     """
     with _Fixture() as fx:
-        rel = os.path.relpath(fx.engine, ROOT).replace(os.sep, '/')
+        # ABSOLUTE, not repo-relative: `os.path.relpath` raises
+        # ValueError when TEMP and the repo are on different Windows
+        # drives, which turned this gate into an error on an ordinary
+        # C:-temp / D:-repo box. `_abs_target` takes either.
+        rel = fx.engine.replace(os.sep, '/')
         _a, reason, problems = fx.battery('mutate_probe_h.py', (
             'GATE = ENGINE_TEST\n'
             'ROWS = [(%r, %r, None, %r, %r)]\n'
@@ -196,7 +228,11 @@ def test_an_ambiguous_table_is_refused_not_guessed():
     read by a person.
     """
     with _Fixture() as fx:
-        rel = os.path.relpath(fx.engine, ROOT).replace(os.sep, '/')
+        # ABSOLUTE, not repo-relative: `os.path.relpath` raises
+        # ValueError when TEMP and the repo are on different Windows
+        # drives, which turned this gate into an error on an ordinary
+        # C:-temp / D:-repo box. `_abs_target` takes either.
+        rel = fx.engine.replace(os.sep, '/')
         _a, reason, _p = fx.battery('mutate_probe_i.py', (
             'ROWS = [(%r, %r, %r)]\n' % ('r', rel, 'x')))
     assert reason and 'two ways' in reason, (
@@ -287,6 +323,7 @@ def test_the_corpus_is_populated():
 
 TESTS = [
     test_a_helper_built_table_is_refused_not_dropped,
+    test_an_unreadable_table_is_refused_whatever_it_is_called,
     test_an_annotated_table_assignment_is_seen,
     test_a_table_bound_twice_is_counted_once,
     test_a_create_row_whose_file_exists_is_reported,

--- a/tests/test_877_mutation_anchors.py
+++ b/tests/test_877_mutation_anchors.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Does `tests/mutation_anchors.py` actually bite? (#877)
+
+The module exists to stop a mutation row asserting nothing. A checker that
+answers "no problems" for a battery it did not understand has the same defect
+it was written to find, one level up -- so every gate below is a battery-shaped
+file built to be WRONG in a specific way, and the assertion is that the
+resolver says so.
+
+Every case here was found by an adversarial review of the first draft, which
+reported a clean result for all five. They are kept as change detectors:
+
+  1. a second table whose rows a helper builds -- `_fold` cannot read it, and
+     the table used to VANISH while the battery still printed a clean line;
+  2. a table bound with an ANNOTATED assignment (`ROWS: List[Row] = [...]`),
+     which the first draft's `ast.Assign`-only walk did not see at all;
+  3. a table bound twice at module scope, which was counted TWICE -- and an
+     inflated anchor count is invisible against a floor;
+  4. a create-this-file row aimed at a file that already exists, the one
+     condition `mutate_713_census.py:129-132` reports BROKEN for and the one
+     the first draft skipped outright;
+  5. a table both layouts fit, which must be REFUSED rather than guessed; and
+  6. a row whose `old` is itself a path to a real file, which was read as the
+     row's TARGET -- grading the row's new text against the file its old text
+     named, and reporting a FALSE STALE. A false stale costs what a missed one
+     does.
+
+Nothing here reads a battery in the repo and nothing imports one: three run
+their runner at module scope, so importing them rewrites engine files. The
+fixtures are written into a temporary directory and handed to
+`resolve_static` as data, which is exactly how the #718 gate uses it.
+
+    python3 tests/test_877_mutation_anchors.py
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(TESTS_DIR)
+sys.path.insert(0, TESTS_DIR)
+
+import mutation_anchors as ma                                     # noqa: E402
+
+#: The stand-in engine every fixture battery mutates. Self-contained on
+#: purpose: a fixture anchored to a real repo file would go stale exactly the
+#: way the rows this module polices do, and then this gate would be testing
+#: its own rot instead of the resolver.
+ENGINE_TEXT = (
+    'def alpha():\n'
+    '    return 1\n'
+    '\n'
+    'def beta():\n'
+    '    return 2\n'
+    '\n'
+    'def gamma():\n'
+    '    return 2\n'
+)
+
+#: Occurs exactly once in ENGINE_TEXT.
+UNIQUE = 'def alpha():'
+#: Occurs exactly twice.
+TWICE = '    return 2\n'
+#: Occurs nowhere.
+GONE = 'def delta():'
+
+
+class _Fixture(object):
+    """A temporary directory holding an engine file and battery-shaped files."""
+
+    def __enter__(self):
+        self.dir = tempfile.mkdtemp(prefix='mut877_')
+        self.engine = os.path.join(self.dir, 'engine.py')
+        with open(self.engine, 'w', encoding='utf-8', newline='') as fh:
+            fh.write(ENGINE_TEXT)
+        return self
+
+    def __exit__(self, *exc):
+        shutil.rmtree(self.dir, ignore_errors=True)
+        return False
+
+    def battery(self, name, body, with_engine=True):
+        """Write a battery-shaped file and resolve it. Never imported.
+
+        `with_engine` mirrors a real distinction: `mutate_750.py` names its one
+        target `ENGINE`, and `mutate_713_census.py` / `mutate_760.py` name no
+        table-level target at all and carry the path in each row. A fixture
+        that always defined `ENGINE` could not express the second shape.
+        """
+        path = os.path.join(self.dir, name)
+        head = ('import os\n'
+                'ENGINE_TEST = %r\n'
+                'OTHER = %r\n' % (self.engine, self.engine))
+        if with_engine:
+            head += 'ENGINE = %r\n' % self.engine
+        with open(path, 'w', encoding='utf-8', newline='') as fh:
+            fh.write(head + body)
+        anchors, reason = ma.resolve_static(path)
+        problems = [] if reason else ma.verify(anchors)
+        return anchors, reason, problems
+
+
+def test_a_helper_built_table_is_refused_not_dropped():
+    """A table `_fold` cannot read must fail the battery, not disappear.
+
+    `resolve_static` returns as soon as ONE table resolves, so a second table
+    it could not fold was silently absent and the battery reported clean. The
+    name is the signal: a binding called `*_ROWS` that is not a row table means
+    the resolver has met a shape it does not know.
+    """
+    with _Fixture() as fx:
+        _a, reason, _p = fx.battery('mutate_probe_a.py', (
+            'def _row(a, b, c):\n    return (a, b, c)\n'
+            'ENGINE_ROWS = [(%r, %r, %r)]\n'
+            'GUI_ROWS = [_row(%r, %r, %r)]\n'
+            'BATTERIES = {"e": (ENGINE, ENGINE_TEST, ENGINE_ROWS),\n'
+            '             "g": (OTHER, ENGINE_TEST, GUI_ROWS)}\n'
+            % ('r1', UNIQUE, 'x', 'r2', GONE, 'y')))
+    assert reason and 'GUI_ROWS' in reason, (
+        f'a table built by a helper call resolved to {reason!r} -- it must '
+        f'name the table it could not read. A vanished table is a battery '
+        f'reporting clean about rows nobody checked.')
+    print('  PASS: a helper-built table is named, not dropped')
+
+
+def test_an_annotated_table_assignment_is_seen():
+    """`ROWS: List[Row] = [...]` binds exactly as `ROWS = [...]` does.
+
+    An `ast.Assign`-only walk skips `ast.AnnAssign`, so the whole table was
+    invisible -- and invisible reads as clean.
+    """
+    with _Fixture() as fx:
+        anchors, reason, problems = fx.battery('mutate_probe_d.py', (
+            'from typing import List, Tuple\n'
+            'ENGINE_ROWS = [(%r, %r, %r)]\n'
+            'GUI_ROWS: List[Tuple[str, str, str]] = [(%r, %r, %r)]\n'
+            'BATTERIES = {"e": (ENGINE, ENGINE_TEST, ENGINE_ROWS),\n'
+            '             "g": (OTHER, ENGINE_TEST, GUI_ROWS)}\n'
+            % ('r1', UNIQUE, 'x', 'r2', GONE, 'y')))
+    assert reason is None and len(anchors) == 2, (
+        f'an annotated table assignment resolved to {len(anchors)} anchor(s), '
+        f'reason={reason!r} -- both tables must be read')
+    assert [p.kind for p in problems] == [ma.STALE], (
+        f'the annotated table must still be GRADED, got '
+        f'{[p.kind for p in problems]}')
+    print('  PASS: an annotated table assignment is seen and graded')
+
+
+def test_a_table_bound_twice_is_counted_once():
+    """N assignments to one name are one table, at its LAST value.
+
+    Counting assignment NODES emitted every row once per binding. An inflated
+    anchor count is invisible against a floor, and it is the flattering
+    direction: more anchors, all passing.
+    """
+    with _Fixture() as fx:
+        anchors, reason, _p = fx.battery('mutate_probe_f.py', (
+            'ROWS = [(%r, %r, %r)]\n'
+            'ROWS = [(%r, %r, %r), (%r, %r, %r)]\n'
+            % ('a', UNIQUE, 'x', 'b', UNIQUE, 'y', 'c', UNIQUE, 'z')))
+    assert reason is None and [a.row for a in anchors] == ['b', 'c'], (
+        f'a rebound table resolved to {[a.row for a in anchors]} -- it must be '
+        f"the LAST binding's rows, once each")
+    print('  PASS: a table bound twice is counted once, at its last value')
+
+
+def test_a_create_row_whose_file_exists_is_reported():
+    """The one condition a create row can fail, graded rather than skipped.
+
+    A create row carries no anchor, so skipping it looked right -- but
+    `mutate_713_census.py:129-132` reports BROKEN when the file it means to
+    create is already there. Skipping meant the row the resolver singles out
+    for special handling was the one row it checked nothing about.
+    """
+    with _Fixture() as fx:
+        rel = os.path.relpath(fx.engine, ROOT).replace(os.sep, '/')
+        _a, reason, problems = fx.battery('mutate_probe_h.py', (
+            'GATE = ENGINE_TEST\n'
+            'ROWS = [(%r, %r, None, %r, %r)]\n'
+            % ('makes-an-existing-file', rel, 'body', 'why')),
+            with_engine=False)
+    assert reason is None and [p.kind for p in problems] == [ma.CREATE_EXISTS], (
+        f'a create row aimed at an existing file gave reason={reason!r}, '
+        f'problems={[p.kind for p in problems]} -- expected CREATE_EXISTS')
+    print('  PASS: a create row whose file already exists is reported')
+
+
+def test_an_ambiguous_table_is_refused_not_guessed():
+    """Two viable readings must refuse, never resolve by a coin flip.
+
+    When a table has a target of its own AND every row[1] names a real file,
+    row[1] is either the anchor or the target and nothing in the file says
+    which. No battery in the tree is ambiguous; one that becomes so should be
+    read by a person.
+    """
+    with _Fixture() as fx:
+        rel = os.path.relpath(fx.engine, ROOT).replace(os.sep, '/')
+        _a, reason, _p = fx.battery('mutate_probe_i.py', (
+            'ROWS = [(%r, %r, %r)]\n' % ('r', rel, 'x')))
+    assert reason and 'two ways' in reason, (
+        f'an ambiguous table resolved to reason={reason!r} -- it must refuse')
+    print('  PASS: a table both layouts fit is refused, not guessed')
+
+
+def test_an_anchor_that_looks_like_a_path_stays_an_anchor():
+    """A row's `old` is not a target just because it parses as one.
+
+    Probing `_abs_target(row[1])` per row meant a single row whose anchor was a
+    repo-relative path to a real file was read as that row's TARGET -- the
+    row's new text graded against the file its old text named, reported as a
+    FALSE STALE. The layout is decided once per table, from all its rows.
+    """
+    with _Fixture() as fx:
+        _a, reason, problems = fx.battery('mutate_probe_c.py', (
+            'ROWS = [(%r, %r, %r)]\n'
+            % ('drop-the-path', 'py_router/route_v2.py', 'replacement')))
+    assert reason is None, f'reason={reason!r}'
+    assert [p.kind for p in problems] == [ma.STALE], (
+        f'expected the anchor graded against ENGINE, got '
+        f'{[p.kind for p in problems]}')
+    assert problems[0].anchor.old == 'py_router/route_v2.py', (
+        f'row[1] was read as a TARGET, not as the anchor: '
+        f'old={problems[0].anchor.old!r}')
+    assert problems[0].anchor.target.endswith('engine.py'), (
+        f'the target must come from the table, got {problems[0].anchor.target}')
+    print('  PASS: an anchor that looks like a path stays an anchor')
+
+
+def test_stale_ambiguous_and_ok_are_told_apart():
+    """The three verdicts, on one table, against known content.
+
+    #877 reported `mutate_703.py`'s three 2-match rows as stale. They are a
+    different defect: a stale row rewrites nothing, an ambiguous one rewrites
+    whichever site comes first.
+    """
+    with _Fixture() as fx:
+        anchors, reason, problems = fx.battery('mutate_probe_v.py', (
+            'ROWS = [(%r, %r, %r), (%r, %r, %r), (%r, %r, %r)]\n'
+            % ('fine', UNIQUE, 'x', 'gone', GONE, 'y', 'twice', TWICE, 'z')))
+    assert reason is None and len(anchors) == 3, f'reason={reason!r}'
+    got = {p.anchor.row: p.kind for p in problems}
+    assert got == {'gone': ma.STALE, 'twice': ma.AMBIGUOUS}, (
+        f'expected one STALE and one AMBIGUOUS and the third clean, got {got}')
+    print('  PASS: stale, ambiguous and matching are told apart')
+
+
+def test_a_multi_edit_row_labels_every_edit():
+    """Each `(old, new)` pair of a list-valued row is its own anchor.
+
+    Edit 0 used to print as a bare row name, so a stale FIRST pair looked
+    exactly like a stale scalar row and the reader could not tell which edit to
+    fix.
+    """
+    with _Fixture() as fx:
+        anchors, reason, problems = fx.battery('mutate_probe_m.py', (
+            'ROWS = [(%r, [(%r, %r), (%r, %r)], None, %r)]\n'
+            % ('pair', GONE, 'a', UNIQUE, 'b', 'KILLED')))
+    assert reason is None and len(anchors) == 2, f'reason={reason!r}'
+    assert [a.label for a in anchors] == ['pair[0]', 'pair[1]'], (
+        f'every edit of a multi-edit row must be labelled, got '
+        f'{[a.label for a in anchors]}')
+    assert [(p.anchor.label, p.kind) for p in problems] == [
+        ('pair[0]', ma.STALE)], (
+        f'the stale FIRST pair must be named, got '
+        f'{[(p.anchor.label, p.kind) for p in problems]}')
+    print('  PASS: every edit of a multi-edit row is labelled and graded')
+
+
+def test_the_corpus_is_populated():
+    """A resolver that stopped reading the tree would pass every gate above.
+
+    Those run on fixtures; this one asserts the real corpus is still there, so
+    a green suite cannot mean "found nothing to check". A floor, not a target.
+    """
+    paths = ma.batteries()
+    assert len(paths) >= 30, (
+        f'only {len(paths)} mutation batteries found -- the scan has stopped '
+        f'finding them')
+    total = sum(len(ma.resolve_static(p)[0]) for p in paths)
+    assert total >= 600, (
+        f'only {total} anchor(s) resolved across {len(paths)} batteries -- the '
+        f'resolver has stopped reading the tables')
+    print(f'  PASS: {total} anchor(s) across {len(paths)} real batteries')
+
+
+TESTS = [
+    test_a_helper_built_table_is_refused_not_dropped,
+    test_an_annotated_table_assignment_is_seen,
+    test_a_table_bound_twice_is_counted_once,
+    test_a_create_row_whose_file_exists_is_reported,
+    test_an_ambiguous_table_is_refused_not_guessed,
+    test_an_anchor_that_looks_like_a_path_stays_an_anchor,
+    test_stale_ambiguous_and_ok_are_told_apart,
+    test_a_multi_edit_row_labels_every_edit,
+    test_the_corpus_is_populated,
+]
+
+
+if __name__ == '__main__':
+    for t in TESTS:
+        print(f'--- {t.__name__}')
+        t()
+    print('ALL PASS')

--- a/tests/test_878_far_face_currency.py
+++ b/tests/test_878_far_face_currency.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""#878: the far-face currency measurement, RE-DERIVED rather than read back.
+
+`tests/878_far_face_currency.json` is the committed argument for which rect a
+through-hole part presents on the far face. This is the gate that keeps it from
+rotting, and it re-runs the whole sweep (~18 s) rather than reading its
+conclusions -- `tests/test_803_calibration_claims.py:10-15`'s rule: a regen test
+must RE-DERIVE the aggregate, not read a constant. Five of seven checks in the
+case that motivated that rule read constants, and a 3 mm cap passed green while
+the headline halved.
+
+Four things are pinned, and they fail for different reasons on purpose:
+
+  1  THE NOTARY. `measure_878_far_face_area.PREREGISTRATION` must equal the
+     copy inside the committed JSON, exactly. The committed file is the
+     notarised copy and the module is the live one, so moving a threshold
+     after seeing the numbers turns this red and names the key. That is the
+     whole value of pre-registering: without this check the block is a comment.
+  2  THE CONTROLS. NC1 (currency `none` reproduces `options.grow_board` on
+     eight fields per board/basis) and NC2 (a board with no drilled pad is
+     identical under all three currencies) must both be clean on the FRESH
+     run. A sweep whose control did not reproduce decided nothing.
+  3  THE VERDICT AND WHICH FALSIFIER PRODUCED IT. Not just `selected` --
+     `bound_by` too. An answer that stayed the same because a different
+     criterion started binding is a changed finding wearing the old label,
+     which is exactly how #694's inverted row kept reading as intact.
+  4  THE STRUCTURAL CLAIMS, which hold by construction and not by measurement,
+     so they are the gate's own negative control: `flat_hierarchy`'s
+     far/near under `courtyard` is 1.0 (64 of 64 pad-bearing parts drilled, so
+     the far charge IS the near charge part for part -- the F1 witness), and
+     the one-face sum is each part exactly once under `none` alone.
+
+Sets are compared as sets (a board joining or leaving a flip set is a finding);
+counts and floats are compared in bands, because a board edit or a courtyard
+fix may legitimately move a cell without changing what the sweep concluded.
+"""
+import json
+import os
+import sys
+
+RUN_ALL_TIMEOUT = 600
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(_HERE)
+for _p in (_HERE, ROOT):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import measure_878_far_face_area as M                        # noqa: E402
+
+#: Named in LIVE code, not in prose: `test_718._names_in_live_code` refuses a
+#: baseline registration whose gate mentions the file only in a docstring,
+#: because three registrations did exactly that.
+BASELINE = os.path.join(_HERE, '878_far_face_currency.json')
+
+_fail = []
+_ran = []
+
+
+def check(label, ok, detail=''):
+    print(('  ok  ' if ok else '  BAD ') + label + (('  -- ' + detail)
+                                                    if detail and not ok
+                                                    else ''))
+    _ran.append(label)
+    if not ok:
+        _fail.append(label)
+
+
+def main():
+    if not os.path.isfile(BASELINE):
+        print('BAD: the committed baseline is missing: %s' % BASELINE)
+        print('A missing baseline FAILS rather than passing -- regenerate it '
+              'with `measure_878_far_face_area.py --out`.')
+        return 1
+    with open(BASELINE, encoding='utf-8') as f:
+        base = json.load(f)
+
+    paths = M.boards()
+    if paths is None:
+        print('SKIP: git could not name the tracked corpus')
+        return M.SKIP_EXIT
+    doc, rows, failed = M.build(paths)
+    if failed or not rows:
+        print('BAD: %d board(s) did not measure (%s) -- a gate whose INPUT is '
+              'missing tests nothing.' % (len(failed), ', '.join(failed[:6])))
+        return 1
+    fresh = M.compact(doc)
+
+    # 1 -- the notary.
+    check('the pre-registration is unchanged since it was notarised',
+          M.PREREGISTRATION == base['preregistration'],
+          'keys differing: %s' % sorted(
+              k for k in set(M.PREREGISTRATION) | set(base['preregistration'])
+              if M.PREREGISTRATION.get(k) != base['preregistration'].get(k)))
+
+    # 2 -- the controls, on the FRESH run.
+    c = fresh['control']
+    check('NC1: currency `none` still reproduces grow_board exactly',
+          not c['nc1_mismatches'], str(c['nc1_mismatches'][:2]))
+    check('NC1 is not vacuous (it compared some rows)',
+          c['nc1_rows'] >= 30 and c['nc1_fields_per_row'] == 8,
+          '%d rows x %d fields' % (c['nc1_rows'], c['nc1_fields_per_row']))
+    check('NC2: a board with no drilled pad is identical across currencies',
+          not c['nc2_mismatches'], str(c['nc2_mismatches'][:2]))
+    check('NC2 is not vacuous (some board carries no drilled pad)',
+          len(c['nc2_boards']) >= 3, str(c['nc2_boards']))
+
+    # 3 -- the verdict AND the falsifier that produced it.
+    check('the selected currency is unchanged',
+          fresh['verdict']['selected'] == base['verdict']['selected'],
+          '%r vs %r' % (fresh['verdict']['selected'],
+                        base['verdict']['selected']))
+    check('and the falsifier that produced it is unchanged',
+          fresh['verdict']['bound_by'] == base['verdict']['bound_by'],
+          '%r vs %r' % (fresh['verdict']['bound_by'],
+                        base['verdict']['bound_by']))
+    check('F1 still rejects exactly what it rejected',
+          fresh['verdict']['f1_rejected'] == base['verdict']['f1_rejected'],
+          '%r vs %r' % (fresh['verdict']['f1_rejected'],
+                        base['verdict']['f1_rejected']))
+
+    # 4 -- structural claims: true by construction, so they are this gate's
+    # own negative control. If either of these ever fails, the sweep is not
+    # measuring what its comments say and no other check here means anything.
+    fh = fresh['boards'].get('flat_hierarchy', {}).get('arms', {})
+    fh_arm = (fh.get('one_face_observed') or {}).get('courtyard', {})
+    check('the F1 witness still holds by construction '
+          '(flat_hierarchy far/near == 1.0 under `courtyard`)',
+          abs(fh_arm.get('far_over_near', 0.0) - 1.0) < 1e-9,
+          'got %r' % fh_arm.get('far_over_near'))
+    ph = fresh['post_hoc']['one_face_charged_once']
+    check('the one-face sum is each part ONCE only under `none`',
+          ph['none']['charged_once']
+          and not ph['tht']['charged_once']
+          and not ph['courtyard']['charged_once'],
+          str({k: v['charged_once'] for k, v in ph.items()}))
+
+    # the flip sets, as SETS -- a board joining or leaving is a finding.
+    for arm in sorted(base['headline']['flips']):
+        a = {r[0] for r in fresh['headline']['flips'].get(arm, [])}
+        b = {r[0] for r in base['headline']['flips'][arm]}
+        check('flip set unchanged for %s' % arm, a == b,
+              'gained %s, lost %s' % (sorted(a - b), sorted(b - a)))
+
+    # the confound census: the `courtyard` arm is only clean while this is 0.
+    check('the both-sides courtyard union still confounds nothing',
+          fresh['confound']['courtyard_sides_differ'] == 0,
+          str(fresh['confound']))
+
+    # move counts in a band, not exactly: a board edit may legitimately move one.
+    for arm in sorted(base['headline']['moves']):
+        a = fresh['headline']['moves'].get(arm, {}).get('n', -1)
+        b = base['headline']['moves'][arm]['n']
+        check('move count within 1 for %s (%d vs %d)' % (arm, a, b),
+              abs(a - b) <= 1)
+
+    print('\n%s: %d check(s), %d failed'
+          % ('FAIL' if _fail else 'PASS', len(_ran), len(_fail)))
+    if _fail:
+        print('failing: %s' % _fail)
+        print('\nIf the ENGINE changed on purpose, re-record with:')
+        print('  python3 -X utf8 tests/measure_878_far_face_area.py '
+              '--out tests/878_far_face_currency.json')
+        print('in the SAME commit as the change -- a stale baseline published '
+              'as somebody else\'s effect is a recorded failure here.')
+    return 1 if _fail else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_878_far_face_currency.py
+++ b/tests/test_878_far_face_currency.py
@@ -98,7 +98,7 @@ def main():
     check('NC1: currency `none` still reproduces grow_board exactly',
           not c['nc1_mismatches'], str(c['nc1_mismatches'][:2]))
     check('NC1 is not vacuous (it compared some rows)',
-          c['nc1_rows'] >= 30 and c['nc1_fields_per_row'] == 8,
+          c['nc1_rows'] >= 30 and c['nc1_fields_per_row'] == len(M.NC1_FIELDS),
           '%d rows x %d fields' % (c['nc1_rows'], c['nc1_fields_per_row']))
     check('NC2: a board with no drilled pad is identical across currencies',
           not c['nc2_mismatches'], str(c['nc2_mismatches'][:2]))

--- a/tests/test_878_far_face_currency.py
+++ b/tests/test_878_far_face_currency.py
@@ -3,7 +3,7 @@
 
 `tests/878_far_face_currency.json` is the committed argument for which rect a
 through-hole part presents on the far face. This is the gate that keeps it from
-rotting, and it re-runs the whole sweep (~18 s) rather than reading its
+rotting, and it re-runs the whole sweep (seconds, not minutes) rather than reading its
 conclusions -- `tests/test_803_calibration_claims.py:10-15`'s rule: a regen test
 must RE-DERIVE the aggregate, not read a constant. Five of seven checks in the
 case that motivated that rule read constants, and a 3 mm cap passed green while
@@ -14,12 +14,21 @@ Four things are pinned, and they fail for different reasons on purpose:
   1  THE NOTARY. `measure_878_far_face_area.PREREGISTRATION` must equal the
      copy inside the committed JSON, exactly. The committed file is the
      notarised copy and the module is the live one, so moving a threshold
-     after seeing the numbers turns this red and names the key. That is the
-     whole value of pre-registering: without this check the block is a comment.
-  2  THE CONTROLS. NC1 (currency `none` reproduces `options.grow_board` on
-     eight fields per board/basis) and NC2 (a board with no drilled pad is
-     identical under all three currencies) must both be clean on the FRESH
-     run. A sweep whose control did not reproduce decided nothing.
+     after seeing the numbers turns this red and names the key.
+
+     That only means something because `--out` REFUSES to overwrite a
+     pre-registration it disagrees with. Otherwise the fix printed in this
+     file's own failure message ("re-record with --out") would repair a moved
+     threshold as a side effect of re-recording numbers, and the block would
+     be a comment with extra steps.
+  2  THE CONTROLS. NC1 (the engine reproduces the arm it is meant to
+     implement, on every field per board/basis) and NC2 (a board with no
+     drilled pad is identical under all three currencies) must both be clean
+     on the FRESH run. A sweep whose control did not reproduce decided
+     nothing. The FIELD COUNT is compared against the committed one, not
+     against `len(NC1_FIELDS)` -- the fresh document is built from that same
+     constant, so comparing the two was `len(x) == len(x)`, and it let the
+     count go 8 -> 9 across a commit with nothing reacting.
   3  THE VERDICT AND WHICH FALSIFIER PRODUCED IT. Not just `selected` --
      `bound_by` too. An answer that stayed the same because a different
      criterion started binding is a changed finding wearing the old label,
@@ -95,10 +104,20 @@ def main():
 
     # 2 -- the controls, on the FRESH run.
     c = fresh['control']
-    check('NC1: currency `none` still reproduces grow_board exactly',
+    check('NC1: the engine still reproduces the arm it is meant to implement '
+          '(currency %r)' % M.ENGINE_CURRENCY,
           not c['nc1_mismatches'], str(c['nc1_mismatches'][:2]))
+    # Against the COMMITTED count, not against `len(M.NC1_FIELDS)`. The fresh
+    # doc sets that key FROM `len(NC1_FIELDS)`, so comparing the two was
+    # `len(x) == len(x)` -- unconditionally true, and it let the field count
+    # go 8 -> 9 across a commit with nothing reacting.
+    check('NC1 still compares the same number of fields it was recorded with',
+          c['nc1_fields_per_row'] == base['control']['nc1_fields_per_row'],
+          '%d now vs %d recorded -- if a field was added on purpose, '
+          're-record' % (c['nc1_fields_per_row'],
+                         base['control']['nc1_fields_per_row']))
     check('NC1 is not vacuous (it compared some rows)',
-          c['nc1_rows'] >= 30 and c['nc1_fields_per_row'] == len(M.NC1_FIELDS),
+          c['nc1_rows'] >= 30 and c['nc1_fields_per_row'] >= 8,
           '%d rows x %d fields' % (c['nc1_rows'], c['nc1_fields_per_row']))
     check('NC2: a board with no drilled pad is identical across currencies',
           not c['nc2_mismatches'], str(c['nc2_mismatches'][:2]))

--- a/tests/test_878_side_rule_sites.py
+++ b/tests/test_878_side_rule_sites.py
@@ -57,7 +57,25 @@ from placement.legality import footprint_side, side_of_layer  # noqa: E402
 #: collapse in order to CHECK it -- this file does, twice.
 _TREES = ('py_placer', 'py_router', 'py_tools', 'kicad_routing_plugin')
 
-_COLLAPSE = re.compile(r"""startswith\(\s*['"]B""")
+#: The tuple form `startswith(('B', '*'))` is NOT optional to match: it is live
+#: at `legality.PartPads.__init__`, one line below a plain form, and the first
+#: draft of this scanner saw only the plain one -- so that function's entry read
+#: `(1, ...)` while it holds two sites, and deleting or inverting the tuple one
+#: would have been a silent pass. That is precisely the failure the count is
+#: here to prevent, reproduced inside the guard meant to prevent it.
+_COLLAPSE = re.compile(r"""startswith\(\s*\(?\s*['"]B""")
+
+#: Spellings this scanner CANNOT see, named rather than left to be discovered.
+#: A registry that quietly misses a form is worse than none, because it reads
+#: as coverage. `layer[0] == 'B'`, `layer[:1] == 'B'`, `re.match(r'^B', layer)`,
+#: a named-constant prefix, and a call wrapped across lines so no single line
+#: carries the match. The line-wrapped case FAILS OPEN -- the file-level search
+#: matches, the per-line loop does not, and the site is recorded nowhere -- so
+#: the check below counts file-level hits against per-line hits and refuses
+#: when they disagree.
+_UNMATCHABLE_SPELLINGS = (
+    "layer[0] == 'B'", "layer[:1] == 'B'", "re.match(r'^B', layer)",
+    'startswith(_BACK_PREFIX)', 'a call split across lines')
 
 #: (relpath, enclosing qualname) -> (count, why it is not the canonical call).
 #:
@@ -67,8 +85,12 @@ _DECLARED = {
     ('py_placer/placement/legality.py', 'side_of_layer'):
         (1, 'THE rule. Everything else in this map is measured against it.'),
     ('py_placer/placement/legality.py', 'PartPads.__init__'):
-        (1, 'a 3-VALUED PAD rule (None = through/dual-face), hardened for '
-            '*.Cu and F+B pads (#834). Different arity, different question.'),
+        (2, 'a 3-VALUED PAD rule (None = through/dual-face), hardened for '
+            '*.Cu and F+B pads (#834). Different arity, different question. '
+            'TWO sites: the plain `startswith(\'B\')` and, one line below, the '
+            'tuple form `startswith((\'B\', \'*\'))` -- which the first draft '
+            'of this scanner could not see, so this entry read 1 and half of '
+            'the rule was unguarded.'),
     ('py_placer/placement/fanout_clearance.py', '_Repair.__init__'):
         (1, 'the UNHARDENED twin of the legality pad rule above -- a real '
             'disagreement on *.Cu and dual-face pads, and the exact mutant '
@@ -148,10 +170,20 @@ def _scan():
                     # a file this gate is blind to.
                     found[(rel, 'UNPARSEABLE: %s' % e.msg)] = 1
                     continue
+                per_line = 0
                 for i, line in enumerate(src.splitlines(), 1):
-                    if _COLLAPSE.search(line):
+                    for _m in _COLLAPSE.finditer(line):
+                        per_line += 1
                         key = (rel, qn.get(i, '<module>'))
                         found[key] = found.get(key, 0) + 1
+                # FAIL OPEN GUARD. `\s*` spans newlines, so a call wrapped
+                # across lines matches the file and no line -- the site would
+                # be recorded nowhere and the undeclared check would pass. If
+                # the two counts disagree, say so instead of reporting clean.
+                whole = len(_COLLAPSE.findall(src))
+                if whole != per_line:
+                    found[(rel, 'SPLIT ACROSS LINES: %d file-level match(es), '
+                                '%d on any single line' % (whole, per_line))] = 1
     return found, files
 
 
@@ -188,11 +220,13 @@ def test_the_canonical_rule_agrees_with_every_form_it_replaced():
             seen += 1
             layers.add(fp.layer)
             want = footprint_side(fp)
+            # NOT `side_of_layer(fp.layer)` as a fourth row: that is the
+            # definition of `footprint_side`, so it could never disagree and
+            # would pad the count with a tautology.
             forms = {
                 'fanout/render/movie': 'B' if (fp.layer or '').startswith('B') else 'F',
                 'labels': 'B' if str(fp.layer).startswith('B') else 'F',
                 'gui': 'B' if str(fp.layer or 'F.Cu').startswith('B') else 'F',
-                'canonical_str': side_of_layer(getattr(fp, 'layer', '')),
             }
             for name, got in forms.items():
                 if got != want:
@@ -200,6 +234,50 @@ def test_the_canonical_rule_agrees_with_every_form_it_replaced():
                                 got, want))
     check('every replaced expression agrees with the canonical rule',
           not bad, '%d disagreement(s): %s' % (len(bad), bad[:4]))
+    # WHAT THE CORPUS CANNOT SHOW, stated so the arm above is not read as
+    # more than it is. On a `str` or `None` layer all these spellings are
+    # ALGEBRAICALLY equal, and the corpus carries only `F.Cu` and `B.Cu` --
+    # so "0 disagreements over 1349 footprints" could not have come out any
+    # other way. It is a change detector for `side_of_layer`, not evidence
+    # that the forms differ. The inputs that DO separate them cannot come off
+    # a board, so they are supplied here.
+    class _Odd:                       # a truthy NON-string layer
+        def __init__(self, v):
+            self.v = v
+
+        def startswith(self, p):      # duck-types the old `.startswith` path
+            return str(self.v).startswith(p)
+
+        def __str__(self):
+            return str(self.v)
+
+    edge = []
+    for layer, why in ((None, 'absent'), ('', 'empty'), (0, 'falsy non-str')):
+        # `str(x or 'F.Cu')` -- the GUI form -- substitutes a default BEFORE
+        # the test. On a falsy layer every form still answers 'F', which is
+        # what makes leaving the GUI sites unconverted defensible; assert it
+        # rather than claiming it in a comment.
+        got = {'canonical': side_of_layer(layer),
+               'gui': 'B' if str(layer or 'F.Cu').startswith('B') else 'F',
+               'labels': 'B' if str(layer).startswith('B') else 'F'}
+        if len(set(got.values())) != 1 or got['canonical'] != 'F':
+            edge.append((why, got))
+    check('a falsy layer reads FRONT under every surviving spelling '
+          '(the corpus has none, so this is the only place it is checked)',
+          not edge, str(edge))
+    # And the one real behaviour difference the widening introduced: the old
+    # `(x or '')` form raises on a truthy non-string, where `str(x or '')`
+    # answers. Pinned so "a widening, not a change" stays a measured claim.
+    odd = _Odd('B.Cu')
+    old_raises = False
+    try:
+        ('B' if (odd or '').startswith('B') else 'F')
+    except AttributeError:
+        old_raises = True
+    check('the widening only changes a truthy NON-string layer, and there it '
+          'answers instead of raising',
+          side_of_layer(odd) == 'B' and not old_raises,
+          'side_of_layer=%r old_raises=%r' % (side_of_layer(odd), old_raises))
     # The vacuity floor. A corpus that shows one layer value cannot
     # distinguish these forms at all, and a green tick on it would be a lie.
     check('the proof is not vacuous (enough footprints, >1 distinct layer)',
@@ -209,8 +287,62 @@ def test_the_canonical_rule_agrees_with_every_form_it_replaced():
           % (seen, sorted(map(str, layers))))
 
 
+def test_no_part_obstructs_more_on_the_far_face_than_the_near_one():
+    """The unstated invariant that keeps #878's far charge safe.
+
+    `through_pad_bounds_local` takes `max(drill_radius, projected half pad)`
+    per drilled pad; the near-charge fallback `compute_footprint_bbox_local`
+    has NO drill term. So a courtyard-less part whose drill exceeds its pad
+    copper -- an NPTH mounting hole with a mask-sized `size`, a slot -- can in
+    principle present MORE on the far face than on its own.
+
+    That would matter: on a board populated only on F, `sum(far) <= sum(near)`
+    is what stops `obstructed['B.Cu']` -- pure lead area on a face nobody
+    builds -- from becoming `busiest` and driving `fits_by_area`,
+    `shortfall_mm2_at_least` and the proposed board size.
+
+    Not witnessed on the corpus, which is why it is asserted rather than
+    described: an invariant nothing checks is one nobody notices breaking.
+    """
+    from placement import options as O
+    from placement.legality import footprint_has_through_pads
+    from placement.parser import extract_courtyard_bboxes
+    from placement.utility import compute_footprint_bbox_local
+    from placement.legality import rotate_local_bounds
+    boards = run_utils.corpus_boards()
+    if not boards:
+        print('SKIP: git could not name the tracked corpus')
+        return
+    worse, seen = [], 0
+    for p in boards:
+        try:
+            pcb = parse_kicad_pcb(p)
+            cy = extract_courtyard_bboxes(p) or {}
+        except Exception:                                    # noqa: BLE001
+            continue
+        for ref, fp in (pcb.footprints or {}).items():
+            if not footprint_has_through_pads(fp):
+                continue
+            box = cy.get(ref) or (compute_footprint_bbox_local(fp)
+                                  if fp.pads else None)
+            if box is None:
+                continue
+            gx0, gy0, gx1, gy1 = rotate_local_bounds(*box, fp.rotation or 0.0)
+            near = (gx1 - gx0 + 0.2) * (gy1 - gy0 + 0.2)
+            far = O._far_face_area(fp, 0.2)
+            seen += 1
+            if far > near + 1e-9:
+                worse.append((os.path.basename(p), ref, round(near, 2),
+                              round(far, 2)))
+    check('no drilled part presents more on the far face than on its own',
+          not worse, '%d part(s): %s' % (len(worse), worse[:4]))
+    check('and that was checked against a real population',
+          seen >= 200, '%d drilled part(s) seen' % seen)
+
+
 TESTS = [test_the_side_rule_has_one_home,
-         test_the_canonical_rule_agrees_with_every_form_it_replaced]
+         test_the_canonical_rule_agrees_with_every_form_it_replaced,
+         test_no_part_obstructs_more_on_the_far_face_than_the_near_one]
 
 
 def main():

--- a/tests/test_878_side_rule_sites.py
+++ b/tests/test_878_side_rule_sites.py
@@ -4,7 +4,12 @@
 'F' or 'B' from a layer name is a one-line collapse, which is exactly why the
 tree grew eight independent spellings of it. `legality.side_of_layer` is the
 rule and `legality.footprint_side` is it applied to an object; every site whose
-input really is a footprint layer now calls one of them.
+input is a LAYER NAME now calls one of them. Not all of them are footprint
+layers -- `_seg_side` takes a track segment's and `label_side` a silkscreen
+label's -- which is exactly why the shared primitive is `side_of_layer(layer)`
+and `footprint_side(fp)` is the thin wrapper, rather than the other way round.
+It also means the corpus arm below, which feeds only FOOTPRINT layers, does not
+exercise those two callers' inputs.
 
 This file holds two things that fail for different reasons:
 

--- a/tests/test_878_side_rule_sites.py
+++ b/tests/test_878_side_rule_sites.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""#878: one side rule, and a gate that refuses a ninth copy of it.
+
+'F' or 'B' from a layer name is a one-line collapse, which is exactly why the
+tree grew eight independent spellings of it. `legality.side_of_layer` is the
+rule and `legality.footprint_side` is it applied to an object; every site whose
+input really is a footprint layer now calls one of them.
+
+This file holds two things that fail for different reasons:
+
+  1  THE IDENTITY PROOF. Over every footprint on every tracked board, the
+     canonical rule and the five literal expressions it replaced must agree.
+     That is the direct evidence the conversion is a no-op -- stronger than
+     running a placement suite, because it covers every footprint rather than
+     the handful four boards happen to exercise. It carries its own vacuity
+     floor: a run that saw no footprints, or only one distinct layer value,
+     proves nothing and says so.
+
+  2  THE REGISTRY. Every surviving `startswith('B'...)` in production source is
+     declared here with the reason it is not the canonical call, keyed by
+     (file, enclosing function) and counted. Held in BOTH directions: an
+     undeclared site fails, and so does a declaration that matches nothing or
+     matches a different number of sites. A one-directional registry is how the
+     #696 containment guard passed 28/28 while the thing it named had moved.
+
+     Keyed by ENCLOSING FUNCTION, never by line number -- a registry that
+     re-flows when someone inserts a blank line is a registry that gets
+     deleted. COUNTED as well as keyed, so that removing one of several sites
+     inside a function is a finding rather than a silent pass; every entry
+     happens to be 1 today, and the count is what keeps that a measurement.
+
+WHY NOT IN `test_718_static_test_hygiene.py`: that file's subject is `tests/`,
+and every scanner in it takes `_py_files(only_tests=True)`. This one scans
+production source. Widening test_718's stated subject to carry it would blur
+the edge that file is careful about.
+"""
+import ast
+import io
+import os
+import re
+import sys
+
+RUN_ALL_TIMEOUT = 600
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(_HERE)
+for _p in (_HERE, ROOT, os.path.join(ROOT, 'py_placer'),
+           os.path.join(ROOT, 'py_router'), os.path.join(ROOT, 'py_tools')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import run_utils                                             # noqa: E402
+from kicad_parser import parse_kicad_pcb                     # noqa: E402
+from placement.legality import footprint_side, side_of_layer  # noqa: E402
+
+#: Production trees only. `tests/` is excluded because a test may spell the
+#: collapse in order to CHECK it -- this file does, twice.
+_TREES = ('py_placer', 'py_router', 'py_tools', 'kicad_routing_plugin')
+
+_COLLAPSE = re.compile(r"""startswith\(\s*['"]B""")
+
+#: (relpath, enclosing qualname) -> (count, why it is not the canonical call).
+#:
+#: Everything here is a DECISION with a reason, not a backlog. The two that
+#: would be behaviour changes are named as such and left for their own issue.
+_DECLARED = {
+    ('py_placer/placement/legality.py', 'side_of_layer'):
+        (1, 'THE rule. Everything else in this map is measured against it.'),
+    ('py_placer/placement/legality.py', 'PartPads.__init__'):
+        (1, 'a 3-VALUED PAD rule (None = through/dual-face), hardened for '
+            '*.Cu and F+B pads (#834). Different arity, different question.'),
+    ('py_placer/placement/fanout_clearance.py', '_Repair.__init__'):
+        (1, 'the UNHARDENED twin of the legality pad rule above -- a real '
+            'disagreement on *.Cu and dual-face pads, and the exact mutant '
+            'body of the KILLED row `pside-goes-back-to-back-only` in '
+            'tests/mutate_834_835.py. Unifying it is a behaviour change no '
+            'corpus board can witness, so it needs its own issue, not a '
+            'ride-along on #878.'),
+    ('py_placer/placement/quench.py', 'QuenchState.fab_rect'):
+        (1, 'reads an already-resolved `p.side`, not a layer, and adds a '
+            'defensive .upper(). `side_of_layer` has none, so converting '
+            'would silently drop the hardening.'),
+    ('py_router/movie_camera.py', '_moved_side'):
+        (1, 'py_router. Importing placement.legality here would invert the '
+            'layer graph -- py_placer imports py_router, not the reverse.'),
+    ('py_router/kicad_parser.py', 'flip_layer_token'):
+        (1, "a layer-NAME transform on 'B.' WITH the dot, not a side rule; "
+            'and py_router again.'),
+    ('kicad_routing_plugin/placement_gui.py', 'PlacementTab._pose_moves'):
+        (1, 'runs inside KiCad pcbnew, where py_placer is imported only '
+            'lazily inside try blocks and is not guaranteed importable. Its '
+            'or-F.Cu default is behaviour-identical to side_of_layer.'),
+    ('kicad_routing_plugin/placement_gui.py', 'PlacementTab._apply_pose'):
+        (1, 'same as _pose_moves above -- the GUI half, not importable from '
+            'a py_placer-less pcbnew session.'),
+}
+
+_fail = []
+_ran = []
+
+
+def check(label, ok, detail=''):
+    print(('  ok  ' if ok else '  BAD ') + label
+          + (('  -- ' + detail) if detail and not ok else ''))
+    _ran.append(label)
+    if not ok:
+        _fail.append(label)
+
+
+def _qualname_map(tree):
+    """line -> enclosing qualname, for every line inside a def/class."""
+    out = {}
+
+    def walk(node, prefix):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef,
+                                  ast.ClassDef)):
+                name = prefix + child.name
+                for ln in range(child.lineno, (child.end_lineno or
+                                               child.lineno) + 1):
+                    out[ln] = name
+                walk(child, name + '.')
+            else:
+                walk(child, prefix)
+    walk(tree, '')
+    return out
+
+
+def _scan():
+    found, files = {}, 0
+    for tree in _TREES:
+        base = os.path.join(ROOT, tree)
+        for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [d for d in dirnames if d != '__pycache__']
+            for fn in sorted(filenames):
+                if not fn.endswith('.py'):
+                    continue
+                path = os.path.join(dirpath, fn)
+                rel = os.path.relpath(path, ROOT).replace(os.sep, '/')
+                src = io.open(path, encoding='utf-8', errors='replace').read()
+                files += 1
+                if not _COLLAPSE.search(src):
+                    continue
+                try:
+                    qn = _qualname_map(ast.parse(src))
+                except SyntaxError as e:
+                    # REPORTED, never skipped: a file that will not parse is
+                    # a file this gate is blind to.
+                    found[(rel, 'UNPARSEABLE: %s' % e.msg)] = 1
+                    continue
+                for i, line in enumerate(src.splitlines(), 1):
+                    if _COLLAPSE.search(line):
+                        key = (rel, qn.get(i, '<module>'))
+                        found[key] = found.get(key, 0) + 1
+    return found, files
+
+
+def test_the_side_rule_has_one_home():
+    found, files = _scan()
+    check('the scanner is not vacuous', files >= 100 and bool(found),
+          '%d file(s), %d site(s)' % (files, len(found)))
+    undeclared = {k: v for k, v in found.items() if k not in _DECLARED}
+    check('every side-rule site in production is the canonical call or '
+          'declared here', not undeclared,
+          'undeclared: %s -- call legality.footprint_side / side_of_layer, '
+          'or declare it with its reason' % sorted(undeclared))
+    stale = [k for k in _DECLARED if k not in found]
+    check('and no declaration names a site that has gone', not stale,
+          'stale: %s' % sorted(stale))
+    miscounted = [(k, found[k], _DECLARED[k][0]) for k in _DECLARED
+                  if k in found and found[k] != _DECLARED[k][0]]
+    check('and each declaration still covers the number of sites it claims',
+          not miscounted, 'moved: %s' % miscounted)
+
+
+def test_the_canonical_rule_agrees_with_every_form_it_replaced():
+    boards = run_utils.corpus_boards()
+    if not boards:
+        print('SKIP: git could not name the tracked corpus')
+        return
+    seen, layers, bad = 0, set(), []
+    for p in boards:
+        try:
+            pcb = parse_kicad_pcb(p)
+        except Exception:                                    # noqa: BLE001
+            continue
+        for ref, fp in (pcb.footprints or {}).items():
+            seen += 1
+            layers.add(fp.layer)
+            want = footprint_side(fp)
+            forms = {
+                'fanout/render/movie': 'B' if (fp.layer or '').startswith('B') else 'F',
+                'labels': 'B' if str(fp.layer).startswith('B') else 'F',
+                'gui': 'B' if str(fp.layer or 'F.Cu').startswith('B') else 'F',
+                'canonical_str': side_of_layer(getattr(fp, 'layer', '')),
+            }
+            for name, got in forms.items():
+                if got != want:
+                    bad.append((os.path.basename(p), ref, fp.layer, name,
+                                got, want))
+    check('every replaced expression agrees with the canonical rule',
+          not bad, '%d disagreement(s): %s' % (len(bad), bad[:4]))
+    # The vacuity floor. A corpus that shows one layer value cannot
+    # distinguish these forms at all, and a green tick on it would be a lie.
+    check('the proof is not vacuous (enough footprints, >1 distinct layer)',
+          seen >= 1200 and len(layers) >= 2,
+          '%d footprint(s), layers %s' % (seen, sorted(map(str, layers))))
+    print('    %d footprints, layer values %s'
+          % (seen, sorted(map(str, layers))))
+
+
+TESTS = [test_the_side_rule_has_one_home,
+         test_the_canonical_rule_agrees_with_every_form_it_replaced]
+
+
+def main():
+    for t in TESTS:
+        print('--- %s' % t.__name__)
+        t()
+    print('\n%s: %d check(s), %d failed'
+          % ('FAIL' if _fail else 'PASS', len(_ran), len(_fail)))
+    return 1 if _fail else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_capacity_options.py
+++ b/tests/test_capacity_options.py
@@ -366,18 +366,31 @@ if os.path.isfile(OC):
           f"{max(mf['obstructed_area_by_side_mm2'].values()):.2f} "
           f"charged {mf['charged_area_mm2']}")
     # The far face IS charged now, and this fixture proves it without needing
-    # the verdict to move: orangecrab has 8 drilled parts, so its obstructed
-    # B.Cu must exceed its populated B.Cu by exactly `far_face_area_mm2`.
-    # Without this arm nothing on this board would notice the charge going
-    # away -- its busiest face does not change either way.
+    # the verdict to move: without this arm nothing on this board would notice
+    # the charge going away, because its busiest face does not change either
+    # way.
+    #
+    # The `== far_face_area_mm2` identity is FIXTURE-SPECIFIC, not a general
+    # law, and saying otherwise would be a reason that is not the reason: it
+    # holds because all 8 of orangecrab's drilled parts sit on F.Cu, so the
+    # whole far charge lands on B.Cu and none on F. On a board with drilled
+    # parts on both faces the B-side delta is a subtotal and this equality
+    # fails for no good reason. Pinned here as a property of this fixture,
+    # asserted alongside the F-side condition that makes it true.
     _pop_b = sides['B.Cu']
     _obs_b = mf['obstructed_area_by_side_mm2']['B.Cu']
     check("the far face is charged, and by the amount reported",
           _obs_b > _pop_b
+          # the condition that makes the identity below hold on THIS board:
+          # nothing is charged far onto F, so the B delta is the whole charge
+          and abs(mf['obstructed_area_by_side_mm2']['F.Cu']
+                  - sides['F.Cu']) < 0.02
           and abs((_obs_b - _pop_b) - mf['far_face_area_mm2']) < 0.02
           and mf['far_face_parts'] == 8,
           f"populated B {_pop_b}, obstructed B {_obs_b}, far "
-          f"{mf['far_face_area_mm2']} over {mf['far_face_parts']} part(s)")
+          f"{mf['far_face_area_mm2']} over {mf['far_face_parts']} part(s); "
+          f"F populated {sides['F.Cu']} obstructed "
+          f"{mf['obstructed_area_by_side_mm2']['F.Cu']}")
     # And the POPULATION dict did not move: it is still each part once, and
     # still sums to `part_area_mm2`. A far-face charge leaking into it would
     # double the one-face demand, which is the regression #878's own

--- a/tests/test_capacity_options.py
+++ b/tests/test_capacity_options.py
@@ -352,10 +352,40 @@ if os.path.isfile(OC):
     # the busiest side's area, it has simply stopped being the number the
     # verdict rests on. A key that changed meaning under a flag would be worse
     # than a renamed one.
+    # #878: the busiest side is the busiest OBSTRUCTED face. On this fixture
+    # the two dicts pick the SAME face -- orangecrab's F.Cu leads its B.Cu on
+    # both -- so `max(part_area_by_side_mm2)` would still pass here while
+    # asserting nothing about which dict `busiest` reads. It is pinned against
+    # the obstruction dict, and the arm below is what makes the two differ on
+    # a board where they can.
     check("busiest_side_area_mm2 is still the busiest side, not the charge",
-          abs(mf['busiest_side_area_mm2'] - max(sides.values())) < 0.02
+          abs(mf['busiest_side_area_mm2']
+              - max(mf['obstructed_area_by_side_mm2'].values())) < 0.02
           and mf['busiest_side_area_mm2'] != mf['charged_area_mm2'],
-          f"busiest {mf['busiest_side_area_mm2']} max {max(sides.values()):.2f} "
+          f"busiest {mf['busiest_side_area_mm2']} max "
+          f"{max(mf['obstructed_area_by_side_mm2'].values()):.2f} "
+          f"charged {mf['charged_area_mm2']}")
+    # The far face IS charged now, and this fixture proves it without needing
+    # the verdict to move: orangecrab has 8 drilled parts, so its obstructed
+    # B.Cu must exceed its populated B.Cu by exactly `far_face_area_mm2`.
+    # Without this arm nothing on this board would notice the charge going
+    # away -- its busiest face does not change either way.
+    _pop_b = sides['B.Cu']
+    _obs_b = mf['obstructed_area_by_side_mm2']['B.Cu']
+    check("the far face is charged, and by the amount reported",
+          _obs_b > _pop_b
+          and abs((_obs_b - _pop_b) - mf['far_face_area_mm2']) < 0.02
+          and mf['far_face_parts'] == 8,
+          f"populated B {_pop_b}, obstructed B {_obs_b}, far "
+          f"{mf['far_face_area_mm2']} over {mf['far_face_parts']} part(s)")
+    # And the POPULATION dict did not move: it is still each part once, and
+    # still sums to `part_area_mm2`. A far-face charge leaking into it would
+    # double the one-face demand, which is the regression #878's own
+    # measurement found in two of its three candidate currencies.
+    check("the population dict is untouched and still sums to part_area_mm2",
+          abs(sum(sides.values()) - m['part_area_mm2']) < 0.02
+          and abs(mf['charged_area_mm2'] - mf['part_area_mm2']) < 0.02,
+          f"sides {sum(sides.values()):.2f}, part_area {m['part_area_mm2']}, "
           f"charged {mf['charged_area_mm2']}")
     # The PROPOSAL has to hold the parts it is proposed for. The audit above
     # runs undeclared, where `charged == busiest`, so it cannot tell the two


### PR DESCRIPTION
Closes #878.

> **Stacked on #885.** This branches from that PR's head, so until #885 merges the diff here shows its 41 files too. #878's own change is **19 files, +4515**. #885 is load-bearing for this work: two `mutate_837` anchors sit on lines this touches, and its pre-flight turns a stale anchor into a one-second failure instead of an hour-long one.

`options.grow_board` charged a part's area to its footprint layer only, so a through-hole part's leads — which come out on the far face and block it — were charged to nobody. #878 asked for the currency to be **decided by measurement rather than preference**, because the per-face instruments in this tree disagree about what the far face costs. So the measurement ships first, and it is what selected the answer.

## The measurement, pre-registered before it was run

`tests/measure_878_far_face_area.py` landed in its own commit (`b58d5924`) with **no numbers** — the decision rule, the thresholds and the witness prediction fixed before anything was visible. Then it was run.

3 candidate currencies × 3 bases × the 22 git-tracked boards, one process, ~15 s. `tests/878_far_face_currency.json` is the committed table; `tests/test_878_far_face_currency.py` re-**runs** it rather than reading its conclusions.

**The rule selected the drilled-pad rect**, and its falsifier fired exactly as predicted beforehand: charging the whole courtyard makes `flat_hierarchy`'s far charge equal its near charge part-for-part (64 of its 64 pad-bearing parts are drilled), so `far/near == 1.0000` and the utilisation exactly doubles. That is a double count, not a finding — `courtyard` is rejected on the one-face basis **by a falsifier, not by taste**.

Two negative controls, either of which refuses the whole report:

| control | result |
|---|---|
| NC1 — the engine reproduces the arm it implements, 9 fields per (board, basis) | 37 rows, **0 mismatches** |
| NC2 — a board with no drilled pad is identical under all three currencies | 5 boards, **0 differ** |

The recorded table also *predicted the shipped engine*: the JSON as committed before the engine existed matches `grow_board`'s `utilisation` / `busiest` / `fits_by_area` on all 22 boards.

## What shipped

Two dicts, because there are two questions. `per_side` stays the **population** charge — each part once, on the face a reflow pass places it on — and still sums to `part_area_mm2`. `obstructed` is the new **obstruction** charge, and `busiest` reads it, because what a face can still hold is what is not already blocked on it.

**The one-face sum is deliberately untouched, and that is the half that is easy to get wrong.** Under a declared `F`/`B`, `sum(per_side)` is each part *exactly once* — the demand on the single face the fab populates. A part's leads land on the face nobody populates, where they compete with nothing. Measured: folding the far charge in there double-charges **10 of the 15** one-face boards, worst `flat_hierarchy` 5927.41 → 9404.40 mm². The pre-registered rule selected `tht` for that basis too; the engine is deliberately **more conservative than its own rule**, and that reasoning is recorded as a labelled post-hoc finding rather than smuggled into the notarised block.

Measured effect on the shipping default: `busiest` moves on **1 of 22** boards (`rp2350_fpga_eensy_prePlane`, 0.6220 → 0.6566) and **no** board's verdict flips.

## Three corrections to the issue

1. **#878's instrument table is wrong about `floorplan.rule_keepout`.** It does not charge "courtyard near, drilled-pad rect far". `part.sides` only decides *which* keep-outs bind; `keepout_hit` is then handed both rects and takes a `max`, consulting no face. The near/far rule is `legality.rect_on`.
2. **Its per-board figures were counted with the electrical rule** (`pad_is_plated_through`). The obstruction question wants `drill > 0` — an unplated hole blocks the far side exactly as a plated one does — and that population is *larger*: `flat_hierarchy` 58 → **64**, `splitflap_driver` 22 → **24**. The 17-of-22 headline reproduces exactly.
3. **There are 22 tracked boards, not 23**, including at the commit #878 cites. Two stale `23`s in `mutate_837`'s comments are fixed too.

## The second half: one side rule

The side-rule collapse had eight spellings. `legality.side_of_layer` is now the rule; seven sites call it. The rest are **declared with reasons** in `tests/test_878_side_rule_sites.py`, held in both directions and keyed by enclosing function rather than line number. Deliberately out of scope and named as such: the 3-valued *pad* rule, where `legality` is hardened for `*.Cu`/dual-face pads and `fanout_clearance` is not — they genuinely disagree, and the unhardened form is the mutant body of a KILLED row in `mutate_834_835`, so unifying it needs its own witness board.

#878's explicit warning is honoured **and measured**: `render_placement` keeps the body rule. On `splitflap_driver` that is 0 back-side parts (one panel); `sides_occupied` would say 24 and draw a B-side panel for a board with nothing on its back.

## Disclosed, not fixed: the container blind spot

A container footprint is exempted **before** the far charge — and the sweep shares that exemption, so **no arm of the measurement could see one**. `rp2350`'s excluded U8 is a through-hole module whose drilled-pad box equals its courtyard: **728.3 mm² on the far face**, seven times that board's whole reported far charge, on the same board this PR cites as its one mover. Charging it would take a shipping board to utilisation 1.60 and `fits_by_area` False, and the near-face exemption's rationale — *a frame hosts the parts inside it* — does not transfer to a face where nothing is hosted and the pins are real copper. It is named in the tool's own `not_modelled` as an open question. A reviewer found this; the measurement as designed could not.

## Verification

```
full suite            555 passed, 0 failed (2 budget timeouts, both PASS alone)
mutate_837            31 rows, 29 KILLED, 2 SURVIVED (declared), 0 disagreeing, 0 broken
mutation_anchors      37 batteries, 836 anchors, 0 stale
sweep controls        NC1 37x9 = 0 mismatches; NC2 5 boards = 0 differ
engine vs prediction  22 of 22 boards match the pre-registered table
```

Both new gates were mutation-tested rather than assumed: the sweep gate dies on a moved threshold, a dropped far charge and a misdirected one; the side-rule gate dies on a ninth copy, a stale declaration and a wrong count. Two tests hit their own time budgets during a run that shared the machine with the mutation battery. Re-run alone, `test_431_board_gates.py` and `test_431_skill_commands.py` both PASS (917 s combined) — load artefacts, not failures.

## Review

A code reviewer and an independent fact-checker ran before push — 12 findings, all fixed in `8514732e`. The four worth naming, because each made the work look better than it was:

- **The disclosure claimed a charge the number does not carry** under a declared face. My own pre-registration had required it to become basis-specific in exactly that case; I wrote the rule and then did not follow it.
- **The notary could be re-notarised by its own remedy.** The gate's failure text says "re-record with `--out`", and `--out` rewrote the pre-registration from the live module — so moving a threshold after seeing the numbers would be repaired by the command the failure prints. `--out` now refuses and names the keys.
- **A vacuity check that was a tautology.** `nc1_fields_per_row == len(NC1_FIELDS)` compared a constant with itself, and had already let that count go 8 → 9 with nothing reacting.
- **`side_of_layer`'s docstring said 1406 footprints; it is 1349** — and the claim it supported was overstated, since those spellings are algebraically equal on any `str`/`None` layer. The corpus arm is a change detector, not proof the forms differ, and the inputs that *do* separate them are now exercised synthetically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuQQFQjwZftzzprsnjvk5J
