### PR TITLE
--json-out accounts for the two runs it stayed silent about

### DIFF
--- a/py_router/route.py
+++ b/py_router/route.py
@@ -340,6 +340,40 @@ def _emit_summary_min(gate_report: Optional[dict] = None,
         print(f"  WARNING: could not emit JSON_SUMMARY_MIN: {_e}")
 
 
+def _write_summary_min_file(json_out: Optional[str], status: str) -> None:
+    """Write the --json-out file for a run that legitimately did nothing.
+
+    The console contract above ("exactly one JSON_SUMMARY_MIN per outermost
+    run") has a file twin: a caller that asked for --json-out reads the FILE,
+    and an early return that prints the tally but skips the write leaves that
+    caller unable to tell "nothing to do" from a crash. That is not
+    hypothetical: a wrapper staging an already-routed board got "All nets are
+    already fully connected", exit 0, and no file - and refused the run as
+    unaccounted, three times over, on two different boards.
+
+    The document carries the same empty tally the console line prints, the
+    `status` naming WHY it is empty, and the env-knob echo the normal
+    end-of-run summary carries. Deliberately NO min_clearance_used: a run
+    that routed nothing applied no clearance, and inventing a number here
+    would defeat a reader's floor check.
+    """
+    if not json_out:
+        return
+    try:
+        from route_summary import write_summary_file
+        document = {'successful': 0, 'failed': 0, 'status': status}
+        try:
+            import env_knobs as _ek653
+            document['env_knobs'] = _ek653.active_env_knobs()
+        except Exception:                                       # noqa: BLE001
+            pass
+        write_summary_file(json_out, document)
+        print(f"  route summary written to {json_out}")
+    except Exception as _e:                                     # noqa: BLE001
+        print(f"  WARNING: could not write --json-out {json_out}: "
+              f"{type(_e).__name__}: {_e}")
+
+
 def _late_orphan_sweep659(pcb_data, output_file, return_results, results_data,
                           protect_unfinished, keep_input_copper, skip_routing):
     """Sweep pad-less copper islands off the FINAL board (#659).
@@ -1332,6 +1366,7 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
         print("No valid nets to route!")
         if final_reconcile:
             _emit_summary_min(status='no_valid_nets')
+        _write_summary_min_file(json_out, 'no_valid_nets')
         if return_results:
             return 0, 0, 0.0, _empty_results_data()
         _write_passthrough_output(input_file, output_file)
@@ -1440,6 +1475,7 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
         print("All nets are already fully connected - nothing to route!")
         if final_reconcile:
             _emit_summary_min(status='already_connected')
+        _write_summary_min_file(json_out, 'already_connected')
         # The sweep runs HERE too (#659). The fragment gate diverts a net whose
         # extra fragments are all pad-less to this sweep instead of the router,
         # so a step whose WHOLE scope is diverted lands on this early return --

--- a/tests/test_json_out_summary.py
+++ b/tests/test_json_out_summary.py
@@ -153,6 +153,39 @@ def test_end_to_end_file_equals_merged_stdout():
     print("  PASS: --json-out == merged(stdout) on a real run")
 
 
+def test_a_nothing_to_do_run_still_writes_the_file():
+    """The early returns' file twin of the JSON_SUMMARY_MIN contract.
+
+    "All nets are already fully connected" printed the console tally and
+    wrote NO --json-out file, so a file reader could not tell the routine
+    nothing-to-do state from a crash -- and external wrappers refused the
+    run as unaccounted, which locked every already-routed board out of a
+    re-record. The file carries the same empty tally, the status naming
+    why it is empty, the env-knob echo, and deliberately NO
+    min_clearance_used: a run that routed nothing applied no clearance,
+    and inventing one would defeat a reader's floor check.
+    """
+    import route
+    with tempfile.TemporaryDirectory() as td:
+        js = os.path.join(td, 'summary.json')
+        route._write_summary_min_file(js, 'already_connected')
+        doc = json.load(open(js, encoding='utf-8'))
+        assert doc['status'] == 'already_connected'
+        assert doc['successful'] == 0 and doc['failed'] == 0
+        assert 'min_clearance_used' not in doc, (
+            "a run that routed nothing must not claim an applied clearance")
+        assert isinstance(doc.get('env_knobs'), dict), (
+            "the no-op file still states its environment")
+    # No --json-out requested: a no-op, never a crash.
+    route._write_summary_min_file(None, 'already_connected')
+    # And both early returns actually call it.
+    src = inspect.getsource(route.batch_route)
+    assert src.count('_write_summary_min_file(json_out') >= 2, (
+        "the no_valid_nets and already_connected early returns must both "
+        "write the file they print")
+    print("  PASS: a nothing-to-do run is accounted in the file too")
+
+
 if __name__ == '__main__':
     fns = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
     for fn in fns:


### PR DESCRIPTION
A run that legitimately had nothing to do now writes its `--json-out` file.

**Scope note after merging main:** this PR originally carried a second commit
adding a `plane_fragility` account to the summary. Upstream landed the same
disclosure independently as #831 — better shaped (return-threaded `_geometry`
record, the `machine_dependent` flag mine lacked) — so the merge commit yields
that entire commit to upstream's implementation and its
`test_831_fill_geometry_disclosure`. What remains is the no-op fix below,
which #831 does not touch.

---

## The defect

`_emit_summary_min`'s own docstring states the contract: a step that did
nothing *"must still satisfy it. A missing line there is indistinguishable
from a crash, which is the one reading that would make an agent do the wrong
thing."* The **console** line honors that. The **file** did not: both
nothing-to-do early returns (`already_connected` and `no_valid_nets`) fire
before the end-of-run `if json_out:` block, so a caller that asked for
`--json-out` got *"All nets are already fully connected"*, exit 0, and no
file.

Measured impact: an external wrapper that stages a board and reads the file
as the run's account refused already-routed boards as "unaccounted" — three
attempts, three refusals, on two different boards — locking every
already-routed board out of a re-record, because a re-record's staged source
is by definition a board with nothing left to route.

## The fix

`_write_summary_min_file(json_out, status)`, the file twin of
`_emit_summary_min`, called at both early returns:

```json
{"successful": 0, "failed": 0, "status": "already_connected",
 "env_knobs": {...}}
```

Deliberately **no** `min_clearance_used`: a run that routed nothing applied
no clearance, and inventing a number would defeat a reader's floor check.
Reconciliation sub-runs cannot clobber the parent's file — `json_out` is
already in the stripped `_reconcile_kwargs` set — and the write goes through
`write_summary_file`'s all-or-nothing publish.

## Compatibility

The one behavioral delta is that a file now exists where none did. Readers
were checked:

- `py_placer/converge.route_verdict` scores it `(None, 'unreadable summary')`
  — a non-verdict, exactly as the no-file path scored — because the document
  carries none of the five verdict keys and the key-presence guard (the
  documented schema-drift tripwire) refuses to fabricate a clean 0. A
  `no_valid_nets` run cannot be mistaken for a clean route by the placement
  judge.
- The early returns emit exactly one `JSON_SUMMARY_MIN` and one file with the
  same tally.
- Wrappers that treated a missing file as "unaccounted" can now accept the
  no-op deliberately, and still refuse a contradictory account
  (`already_connected` with a nonzero failure tally).

## Testing

- `tests/test_json_out_summary.py::test_a_nothing_to_do_run_still_writes_the_file`
  — the tally, the status, the env echo, the deliberate absence of
  `min_clearance_used`, `None` as a no-op, and (source-pinned, like the
  file's existing json_out-pop guard) that **both** early returns call the
  writer.
- Post-merge with `grid_router` v0.22.0: `test_json_out_summary` ALL PASS
  including the end-to-end file-equals-merged-stdout route;
  `test_831_fill_geometry_disclosure` 23/23; `test_713_refill_status` 61/61.
- Downstream, the external wrapper's full suite consuming these summaries
  runs green, including an end-to-end accounted no-op that reaches adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
