### PR TITLE
Smoother: trust the foreign-segment cache between its own splices; bounding boxes built once

### DIFF
--- a/py_router/pcb_modification.py
+++ b/py_router/pcb_modification.py
@@ -4335,308 +4335,320 @@ def smooth_octolinear_chains(results, pcb_data: PCBData, scope_net_ids=None,
              'segs_removed': 0, 'segs_added': 0, 'saved_mm': 0.0,
              'chains_reverted': 0}
 
-    for net_id in sorted(segs_by_net.keys()):
-        if net_id in skip_net_ids:
-            continue
-        net_segs = segs_by_net[net_id]
-        if len(net_segs) < 2:
-            continue
-        if len(net_segs) > max_net_segs:
-            stats['nets_skipped_large'] += 1
-            continue
-        stats['nets'] += 1
-        net_pads = pcb_data.pads_by_net.get(net_id, [])
-        net_vias = vias_by_net.get(net_id, [])
-
-        candidates = [s for s in net_segs
-                      if not getattr(s, 'graphic', False)
-                      and (not keep_input_copper or id(s) in routed_seg_result)
-                      and math.hypot(s.end_x - s.start_x, s.end_y - s.start_y) > 1e-6]
-        if len(candidates) < 2:
-            continue
-
-        # Endpoint incidence over ALL same-net segments (any layer/width): an
-        # interior chain vertex must be touched by exactly its two chain
-        # segments -- a third endpoint there (other width, other layer via a
-        # barrel, a tee) makes it an anchor.
-        inc = defaultdict(int)
-        for s in net_segs:
-            inc[vk(s.start_x, s.start_y)] += 1
-            inc[vk(s.end_x, s.end_y)] += 1
-        via_pts = {vk(v.x, v.y) for v in net_vias}
-
-        def pad_reach(pad):
-            return math.hypot(pad.size_x, pad.size_y) / 2.0
-
-        def pad_on_layer(pad, layer):
-            return layer in pad.layers or any('*' in L for L in pad.layers)
-
-        groups = defaultdict(list)
-        for s in candidates:
-            groups[(s.layer, round(s.width, 4))].append(s)
-
-        before = None
-        net_changed = False
-        for (layer, w), gsegs in sorted(groups.items()):
-            if len(gsegs) < 2:
+    # This pass edits copper only by SPLICING pcb_data.segments, and drops
+    # the foreign-segment cache at every splice below, so between its own
+    # invalidations the cache is trusted (no per-query O(segments) digest,
+    # see _foreign_seg_arrays); the flag is cleared on every exit path.
+    _trust_prev = getattr(pcb_data, '_foreign_seg_arr_trust', False)
+    if hasattr(pcb_data, '_foreign_seg_arr_cache'):
+        pcb_data._foreign_seg_arr_cache = None
+    pcb_data._foreign_seg_arr_trust = True
+    try:
+        for net_id in sorted(segs_by_net.keys()):
+            if net_id in skip_net_ids:
                 continue
-            gadj = defaultdict(list)
-            for s in gsegs:
-                gadj[vk(s.start_x, s.start_y)].append(s)
-                gadj[vk(s.end_x, s.end_y)].append(s)
+            net_segs = segs_by_net[net_id]
+            if len(net_segs) < 2:
+                continue
+            if len(net_segs) > max_net_segs:
+                stats['nets_skipped_large'] += 1
+                continue
+            stats['nets'] += 1
+            net_pads = pcb_data.pads_by_net.get(net_id, [])
+            net_vias = vias_by_net.get(net_id, [])
 
-            def pad_anchored(x, y):
-                for pad in net_pads:
-                    if not pad_on_layer(pad, layer):
-                        continue
-                    r = pad_reach(pad) + w / 2.0 + COINCIDENCE_TOL
-                    if abs(x - pad.global_x) > r or abs(y - pad.global_y) > r:
-                        continue
-                    if point_to_pad_distance(x, y, pad) <= w / 2.0 + COINCIDENCE_TOL:
-                        return True
-                return False
+            candidates = [s for s in net_segs
+                          if not getattr(s, 'graphic', False)
+                          and (not keep_input_copper or id(s) in routed_seg_result)
+                          and math.hypot(s.end_x - s.start_x, s.end_y - s.start_y) > 1e-6]
+            if len(candidates) < 2:
+                continue
 
-            def interior(v):
-                return (len(gadj[v]) == 2 and inc[v] == 2 and v not in via_pts
-                        and not pad_anchored(v[0], v[1]))
+            # Endpoint incidence over ALL same-net segments (any layer/width): an
+            # interior chain vertex must be touched by exactly its two chain
+            # segments -- a third endpoint there (other width, other layer via a
+            # barrel, a tee) makes it an anchor.
+            inc = defaultdict(int)
+            for s in net_segs:
+                inc[vk(s.start_x, s.start_y)] += 1
+                inc[vk(s.end_x, s.end_y)] += 1
+            via_pts = {vk(v.x, v.y) for v in net_vias}
 
-            anchors = [v for v in gadj if not interior(v)]
-            used = set()
-            for start_key in anchors:
-                for seg0 in list(gadj[start_key]):
-                    if id(seg0) in used:
-                        continue
-                    # Walk from this anchor to the next anchor, carrying the
-                    # ACTUAL endpoint coordinates (keys are only adjacency).
-                    chain = []
-                    if vk(seg0.start_x, seg0.start_y) == start_key:
-                        vpts = [(seg0.start_x, seg0.start_y)]
-                    else:
-                        vpts = [(seg0.end_x, seg0.end_y)]
-                    cur_key = start_key
-                    s = seg0
-                    while True:
-                        used.add(id(s))
-                        chain.append(s)
-                        if vk(s.start_x, s.start_y) == cur_key:
-                            nxt_pt = (s.end_x, s.end_y)
-                        else:
-                            nxt_pt = (s.start_x, s.start_y)
-                        vpts.append(nxt_pt)
-                        cur_key = vk(*nxt_pt)
-                        if cur_key == start_key:
-                            break                     # ring
-                        if not interior(cur_key) or len(chain) >= max_chain_segs:
-                            break
-                        nxt = [t for t in gadj[cur_key] if id(t) not in used]
-                        if not nxt:
-                            break
-                        s = nxt[0]
-                    if cur_key == start_key or len(chain) < 2:
-                        continue
-                    stats['chains'] += 1
-                    n = len(chain)
-                    cum = [0.0]
-                    for k in range(n):
-                        cum.append(cum[-1] + math.hypot(vpts[k + 1][0] - vpts[k][0],
-                                                        vpts[k + 1][1] - vpts[k][1]))
+            def pad_reach(pad):
+                return math.hypot(pad.size_x, pad.size_y) / 2.0
 
-                    # Same-net copper touching the chain mid-body: each touch
-                    # pins its span unless the touch sits at a kept endpoint.
-                    # (touch_x, touch_y, chain_seg_index, reach)
-                    chain_ids = {id(s) for s in chain}
-                    _cxs = [p[0] for p in vpts]
-                    _cys = [p[1] for p in vpts]
-                    _bb = (min(_cxs), min(_cys), max(_cxs), max(_cys))
-                    touches = []
-                    for v in net_vias:
-                        r = getattr(v, 'size', 0.0) / 2.0 + w / 2.0 + COINCIDENCE_TOL
-                        for k in range(n):
-                            if _pt_seg_dist(v.x, v.y, vpts[k][0], vpts[k][1],
-                                            vpts[k + 1][0], vpts[k + 1][1]) < r:
-                                touches.append((v.x, v.y, k, r))
-                    pad_touches = []  # (pad, chain_seg_index)
+            def pad_on_layer(pad, layer):
+                return layer in pad.layers or any('*' in L for L in pad.layers)
+
+            groups = defaultdict(list)
+            for s in candidates:
+                groups[(s.layer, round(s.width, 4))].append(s)
+
+            before = None
+            net_changed = False
+            for (layer, w), gsegs in sorted(groups.items()):
+                if len(gsegs) < 2:
+                    continue
+                gadj = defaultdict(list)
+                for s in gsegs:
+                    gadj[vk(s.start_x, s.start_y)].append(s)
+                    gadj[vk(s.end_x, s.end_y)].append(s)
+
+                def pad_anchored(x, y):
                     for pad in net_pads:
                         if not pad_on_layer(pad, layer):
                             continue
                         r = pad_reach(pad) + w / 2.0 + COINCIDENCE_TOL
-                        for k in range(n):
-                            if _pt_seg_dist(pad.global_x, pad.global_y,
-                                            vpts[k][0], vpts[k][1],
-                                            vpts[k + 1][0], vpts[k + 1][1]) < r:
-                                pad_touches.append((pad, k))
-                    for o in net_segs:
-                        if id(o) in chain_ids or o.layer != layer:
+                        if abs(x - pad.global_x) > r or abs(y - pad.global_y) > r:
                             continue
-                        r = (o.width + w) / 2.0 + COINCIDENCE_TOL
-                        # bbox prefilter: sibling nowhere near the chain
-                        if (max(o.start_x, o.end_x) < _bb[0] - r or
-                                min(o.start_x, o.end_x) > _bb[2] + r or
-                                max(o.start_y, o.end_y) < _bb[1] - r or
-                                min(o.start_y, o.end_y) > _bb[3] + r):
+                        if point_to_pad_distance(x, y, pad) <= w / 2.0 + COINCIDENCE_TOL:
+                            return True
+                    return False
+
+                def interior(v):
+                    return (len(gadj[v]) == 2 and inc[v] == 2 and v not in via_pts
+                            and not pad_anchored(v[0], v[1]))
+
+                anchors = [v for v in gadj if not interior(v)]
+                used = set()
+                for start_key in anchors:
+                    for seg0 in list(gadj[start_key]):
+                        if id(seg0) in used:
                             continue
-                        _obb = (min(o.start_x, o.end_x) - r,
-                                min(o.start_y, o.end_y) - r,
-                                max(o.start_x, o.end_x) + r,
-                                max(o.start_y, o.end_y) + r)
+                        # Walk from this anchor to the next anchor, carrying the
+                        # ACTUAL endpoint coordinates (keys are only adjacency).
+                        chain = []
+                        if vk(seg0.start_x, seg0.start_y) == start_key:
+                            vpts = [(seg0.start_x, seg0.start_y)]
+                        else:
+                            vpts = [(seg0.end_x, seg0.end_y)]
+                        cur_key = start_key
+                        s = seg0
+                        while True:
+                            used.add(id(s))
+                            chain.append(s)
+                            if vk(s.start_x, s.start_y) == cur_key:
+                                nxt_pt = (s.end_x, s.end_y)
+                            else:
+                                nxt_pt = (s.start_x, s.start_y)
+                            vpts.append(nxt_pt)
+                            cur_key = vk(*nxt_pt)
+                            if cur_key == start_key:
+                                break                     # ring
+                            if not interior(cur_key) or len(chain) >= max_chain_segs:
+                                break
+                            nxt = [t for t in gadj[cur_key] if id(t) not in used]
+                            if not nxt:
+                                break
+                            s = nxt[0]
+                        if cur_key == start_key or len(chain) < 2:
+                            continue
+                        stats['chains'] += 1
+                        n = len(chain)
+                        cum = [0.0]
                         for k in range(n):
-                            if (max(vpts[k][0], vpts[k + 1][0]) < _obb[0] or
-                                    min(vpts[k][0], vpts[k + 1][0]) > _obb[2] or
-                                    max(vpts[k][1], vpts[k + 1][1]) < _obb[1] or
-                                    min(vpts[k][1], vpts[k + 1][1]) > _obb[3]):
+                            cum.append(cum[-1] + math.hypot(vpts[k + 1][0] - vpts[k][0],
+                                                            vpts[k + 1][1] - vpts[k][1]))
+
+                        # Same-net copper touching the chain mid-body: each touch
+                        # pins its span unless the touch sits at a kept endpoint.
+                        # (touch_x, touch_y, chain_seg_index, reach)
+                        chain_ids = {id(s) for s in chain}
+                        _cxs = [p[0] for p in vpts]
+                        _cys = [p[1] for p in vpts]
+                        _bb = (min(_cxs), min(_cys), max(_cxs), max(_cys))
+                        touches = []
+                        for v in net_vias:
+                            r = getattr(v, 'size', 0.0) / 2.0 + w / 2.0 + COINCIDENCE_TOL
+                            for k in range(n):
+                                if _pt_seg_dist(v.x, v.y, vpts[k][0], vpts[k][1],
+                                                vpts[k + 1][0], vpts[k + 1][1]) < r:
+                                    touches.append((v.x, v.y, k, r))
+                        pad_touches = []  # (pad, chain_seg_index)
+                        for pad in net_pads:
+                            if not pad_on_layer(pad, layer):
                                 continue
-                            # Mid-body X-crossings connect copper too (#162
-                            # self-crossings exist) but have no close endpoint
-                            # pair -- take the true crossing point; collinear
-                            # overlaps pin at the sibling's midpoint.
-                            if segments_intersect(vpts[k][0], vpts[k][1],
-                                                  vpts[k + 1][0], vpts[k + 1][1],
-                                                  o.start_x, o.start_y,
-                                                  o.end_x, o.end_y):
-                                xp = _seg_cross_point(vpts[k][0], vpts[k][1],
+                            r = pad_reach(pad) + w / 2.0 + COINCIDENCE_TOL
+                            for k in range(n):
+                                if _pt_seg_dist(pad.global_x, pad.global_y,
+                                                vpts[k][0], vpts[k][1],
+                                                vpts[k + 1][0], vpts[k + 1][1]) < r:
+                                    pad_touches.append((pad, k))
+                        for o in net_segs:
+                            if id(o) in chain_ids or o.layer != layer:
+                                continue
+                            r = (o.width + w) / 2.0 + COINCIDENCE_TOL
+                            # bbox prefilter: sibling nowhere near the chain
+                            if (max(o.start_x, o.end_x) < _bb[0] - r or
+                                    min(o.start_x, o.end_x) > _bb[2] + r or
+                                    max(o.start_y, o.end_y) < _bb[1] - r or
+                                    min(o.start_y, o.end_y) > _bb[3] + r):
+                                continue
+                            _obb = (min(o.start_x, o.end_x) - r,
+                                    min(o.start_y, o.end_y) - r,
+                                    max(o.start_x, o.end_x) + r,
+                                    max(o.start_y, o.end_y) + r)
+                            for k in range(n):
+                                if (max(vpts[k][0], vpts[k + 1][0]) < _obb[0] or
+                                        min(vpts[k][0], vpts[k + 1][0]) > _obb[2] or
+                                        max(vpts[k][1], vpts[k + 1][1]) < _obb[1] or
+                                        min(vpts[k][1], vpts[k + 1][1]) > _obb[3]):
+                                    continue
+                                # Mid-body X-crossings connect copper too (#162
+                                # self-crossings exist) but have no close endpoint
+                                # pair -- take the true crossing point; collinear
+                                # overlaps pin at the sibling's midpoint.
+                                if segments_intersect(vpts[k][0], vpts[k][1],
                                                       vpts[k + 1][0], vpts[k + 1][1],
                                                       o.start_x, o.start_y,
-                                                      o.end_x, o.end_y)
-                                if xp is None:
-                                    xp = ((o.start_x + o.end_x) / 2.0,
-                                          (o.start_y + o.end_y) / 2.0)
-                                touches.append((xp[0], xp[1], k, r))
-                                continue
-                            d, pt_on_chain, _pt2 = segment_to_segment_closest_points(
-                                Segment(start_x=vpts[k][0], start_y=vpts[k][1],
-                                        end_x=vpts[k + 1][0], end_y=vpts[k + 1][1],
-                                        width=w, layer=layer, net_id=net_id), o)
-                            if d < r:
-                                touches.append((pt_on_chain[0], pt_on_chain[1], k, r))
-
-                    def span_free(i, j):
-                        ax, ay = vpts[i]
-                        bx, by = vpts[j]
-                        for tx, ty, k, r in touches:
-                            if i <= k < j:
-                                if math.hypot(tx - ax, ty - ay) >= r and \
-                                   math.hypot(tx - bx, ty - by) >= r:
-                                    return False
-                        # Pad touches are exempt only when the pad EXACTLY
-                        # touches a kept endpoint's capsule end -- a bounding-
-                        # radius "near the endpoint" test waived mid-span pad
-                        # contacts on big rect pads (anyshake GNDA: C75/C76
-                        # stranded, masked in-pass by pour outline credit).
-                        for pad, k in pad_touches:
-                            if i <= k < j:
-                                if point_to_pad_distance(ax, ay, pad) > w / 2.0 + COINCIDENCE_TOL and \
-                                   point_to_pad_distance(bx, by, pad) > w / 2.0 + COINCIDENCE_TOL:
-                                    return False
-                        return True
-
-                    # Greedy farthest-reachable-vertex shortcutting.
-                    spans = {}
-                    i = 0
-                    while i < n - 1:
-                        found = None
-                        for j in range(n, i + 1, -1):
-                            sub_len = cum[j] - cum[i]
-                            if sub_len <= min_gain:
-                                break                 # closer spans only shrink
-                            if not span_free(i, j):
-                                continue
-                            A, B = vpts[i], vpts[j]
-                            for inter in _octolinear_bends(A, B):
-                                pts = [A] + inter + [B]
-                                new_len = sum(math.hypot(pts[q + 1][0] - pts[q][0],
-                                                         pts[q + 1][1] - pts[q][1])
-                                              for q in range(len(pts) - 1))
-                                if new_len > sub_len - min_gain:
+                                                      o.end_x, o.end_y):
+                                    xp = _seg_cross_point(vpts[k][0], vpts[k][1],
+                                                          vpts[k + 1][0], vpts[k + 1][1],
+                                                          o.start_x, o.start_y,
+                                                          o.end_x, o.end_y)
+                                    if xp is None:
+                                        xp = ((o.start_x + o.end_x) / 2.0,
+                                              (o.start_y + o.end_y) / 2.0)
+                                    touches.append((xp[0], xp[1], k, r))
                                     continue
-                                if all(clears(pts[q][0], pts[q][1],
-                                              pts[q + 1][0], pts[q + 1][1],
-                                              layer, net_id, w)
-                                       for q in range(len(pts) - 1)):
-                                    found = (j, pts, sub_len - new_len)
+                                d, pt_on_chain, _pt2 = segment_to_segment_closest_points(
+                                    Segment(start_x=vpts[k][0], start_y=vpts[k][1],
+                                            end_x=vpts[k + 1][0], end_y=vpts[k + 1][1],
+                                            width=w, layer=layer, net_id=net_id), o)
+                                if d < r:
+                                    touches.append((pt_on_chain[0], pt_on_chain[1], k, r))
+
+                        def span_free(i, j):
+                            ax, ay = vpts[i]
+                            bx, by = vpts[j]
+                            for tx, ty, k, r in touches:
+                                if i <= k < j:
+                                    if math.hypot(tx - ax, ty - ay) >= r and \
+                                       math.hypot(tx - bx, ty - by) >= r:
+                                        return False
+                            # Pad touches are exempt only when the pad EXACTLY
+                            # touches a kept endpoint's capsule end -- a bounding-
+                            # radius "near the endpoint" test waived mid-span pad
+                            # contacts on big rect pads (anyshake GNDA: C75/C76
+                            # stranded, masked in-pass by pour outline credit).
+                            for pad, k in pad_touches:
+                                if i <= k < j:
+                                    if point_to_pad_distance(ax, ay, pad) > w / 2.0 + COINCIDENCE_TOL and \
+                                       point_to_pad_distance(bx, by, pad) > w / 2.0 + COINCIDENCE_TOL:
+                                        return False
+                            return True
+
+                        # Greedy farthest-reachable-vertex shortcutting.
+                        spans = {}
+                        i = 0
+                        while i < n - 1:
+                            found = None
+                            for j in range(n, i + 1, -1):
+                                sub_len = cum[j] - cum[i]
+                                if sub_len <= min_gain:
+                                    break                 # closer spans only shrink
+                                if not span_free(i, j):
+                                    continue
+                                A, B = vpts[i], vpts[j]
+                                for inter in _octolinear_bends(A, B):
+                                    pts = [A] + inter + [B]
+                                    new_len = sum(math.hypot(pts[q + 1][0] - pts[q][0],
+                                                             pts[q + 1][1] - pts[q][1])
+                                                  for q in range(len(pts) - 1))
+                                    if new_len > sub_len - min_gain:
+                                        continue
+                                    if all(clears(pts[q][0], pts[q][1],
+                                                  pts[q + 1][0], pts[q + 1][1],
+                                                  layer, net_id, w)
+                                           for q in range(len(pts) - 1)):
+                                        found = (j, pts, sub_len - new_len)
+                                        break
+                                if found:
                                     break
                             if found:
-                                break
-                        if found:
-                            spans[i] = found
-                            i = found[0]
-                        else:
-                            i += 1
-                    if not spans:
-                        continue
+                                spans[i] = found
+                                i = found[0]
+                            else:
+                                i += 1
+                        if not spans:
+                            continue
 
-                    new_chain_segs = []
-                    removed_chain = []
-                    gain = 0.0
-                    k = 0
-                    while k < n:
-                        if k in spans:
-                            j, pts, g = spans[k]
-                            gain += g
-                            for q in range(len(pts) - 1):
-                                # Drop degenerate elbow legs (near-diagonal
-                                # spans put the bend within a hair of an
-                                # endpoint); the sub-writer-precision gap is
-                                # far below SOFT_JOINT_MIN_GAP.
-                                if math.hypot(pts[q + 1][0] - pts[q][0],
-                                              pts[q + 1][1] - pts[q][1]) > 1e-5:
-                                    new_chain_segs.append(Segment(
-                                        start_x=pts[q][0], start_y=pts[q][1],
-                                        end_x=pts[q + 1][0], end_y=pts[q + 1][1],
-                                        width=w, layer=layer, net_id=net_id))
-                            removed_chain.extend(chain[k:j])
-                            k = j
-                        else:
-                            k += 1
-                    # NO pour credit in the guard (deliberate, unlike the graze
-                    # nudge): raw zone-OUTLINE credit overstates the real fill
-                    # (clearance carving), so it can bless a chain whose
-                    # removed span was the only REAL path to a pad (anyshake
-                    # GNDA). Endpoints are preserved by construction, so
-                    # requiring the track/via/pad graph alone not to degrade
-                    # costs nothing on genuinely pour-served nets.
-                    if before is None:
-                        before = check_net_connectivity(net_id, net_segs, net_vias,
-                                                        net_pads, [],
-                                                        pcb_data=pcb_data)
-                    _rm = {id(s) for s in removed_chain}
-                    trial = [s for s in net_segs if id(s) not in _rm] + new_chain_segs
-                    if worse(before, check_net_connectivity(net_id, trial, net_vias,
+                        new_chain_segs = []
+                        removed_chain = []
+                        gain = 0.0
+                        k = 0
+                        while k < n:
+                            if k in spans:
+                                j, pts, g = spans[k]
+                                gain += g
+                                for q in range(len(pts) - 1):
+                                    # Drop degenerate elbow legs (near-diagonal
+                                    # spans put the bend within a hair of an
+                                    # endpoint); the sub-writer-precision gap is
+                                    # far below SOFT_JOINT_MIN_GAP.
+                                    if math.hypot(pts[q + 1][0] - pts[q][0],
+                                                  pts[q + 1][1] - pts[q][1]) > 1e-5:
+                                        new_chain_segs.append(Segment(
+                                            start_x=pts[q][0], start_y=pts[q][1],
+                                            end_x=pts[q + 1][0], end_y=pts[q + 1][1],
+                                            width=w, layer=layer, net_id=net_id))
+                                removed_chain.extend(chain[k:j])
+                                k = j
+                            else:
+                                k += 1
+                        # NO pour credit in the guard (deliberate, unlike the graze
+                        # nudge): raw zone-OUTLINE credit overstates the real fill
+                        # (clearance carving), so it can bless a chain whose
+                        # removed span was the only REAL path to a pad (anyshake
+                        # GNDA). Endpoints are preserved by construction, so
+                        # requiring the track/via/pad graph alone not to degrade
+                        # costs nothing on genuinely pour-served nets.
+                        if before is None:
+                            before = check_net_connectivity(net_id, net_segs, net_vias,
                                                             net_pads, [],
-                                                            pcb_data=pcb_data)):
-                        stats['chains_reverted'] += 1
-                        continue
+                                                            pcb_data=pcb_data)
+                        _rm = {id(s) for s in removed_chain}
+                        trial = [s for s in net_segs if id(s) not in _rm] + new_chain_segs
+                        if worse(before, check_net_connectivity(net_id, trial, net_vias,
+                                                                net_pads, [],
+                                                                pcb_data=pcb_data)):
+                            stats['chains_reverted'] += 1
+                            continue
 
-                    stats['spans'] += len(spans)
-                    stats['segs_removed'] += len(removed_chain)
-                    stats['segs_added'] += len(new_chain_segs)
-                    stats['saved_mm'] += gain
-                    if dry_run:
-                        continue
+                        stats['spans'] += len(spans)
+                        stats['segs_removed'] += len(removed_chain)
+                        stats['segs_added'] += len(new_chain_segs)
+                        stats['saved_mm'] += gain
+                        if dry_run:
+                            continue
 
-                    res = None
-                    for s in removed_chain:
-                        if id(s) in routed_seg_result:
-                            removed_ids.add(id(s))
-                            res = res or routed_seg_result[id(s)]
-                        else:
-                            original_to_remove.append(s)
-                    if res is None:
-                        res = {'new_segments': [], 'new_vias': [],
-                               'cleanup': 'smooth_octolinear'}
-                        results.append(res)
-                    res['new_segments'] = list(res.get('new_segments') or []) + new_chain_segs
-                    added_segments.extend(new_chain_segs)
-                    # Splice pcb_data NOW, per commit (#508 finding 5): later
-                    # chains/nets must see this one's copper at its new place.
-                    pcb_data.segments = [s for s in pcb_data.segments
-                                         if id(s) not in _rm] + new_chain_segs
-                    if hasattr(pcb_data, '_foreign_seg_arr_cache'):
-                        pcb_data._foreign_seg_arr_cache = None
-                    net_segs = trial
-                    net_changed = True
-        if net_changed:
-            nets_changed += 1
-
+                        res = None
+                        for s in removed_chain:
+                            if id(s) in routed_seg_result:
+                                removed_ids.add(id(s))
+                                res = res or routed_seg_result[id(s)]
+                            else:
+                                original_to_remove.append(s)
+                        if res is None:
+                            res = {'new_segments': [], 'new_vias': [],
+                                   'cleanup': 'smooth_octolinear'}
+                            results.append(res)
+                        res['new_segments'] = list(res.get('new_segments') or []) + new_chain_segs
+                        added_segments.extend(new_chain_segs)
+                        # Splice pcb_data NOW, per commit (#508 finding 5): later
+                        # chains/nets must see this one's copper at its new place.
+                        pcb_data.segments = [s for s in pcb_data.segments
+                                             if id(s) not in _rm] + new_chain_segs
+                        if hasattr(pcb_data, '_foreign_seg_arr_cache'):
+                            pcb_data._foreign_seg_arr_cache = None
+                        net_segs = trial
+                        net_changed = True
+            if net_changed:
+                nets_changed += 1
+    finally:
+        pcb_data._foreign_seg_arr_trust = _trust_prev
+        if hasattr(pcb_data, '_foreign_seg_arr_cache'):
+            pcb_data._foreign_seg_arr_cache = None
     if removed_ids:
         for r in results:
             segs = r.get('new_segments')

--- a/py_router/single_ended_routing.py
+++ b/py_router/single_ended_routing.py
@@ -347,9 +347,19 @@ def _foreign_seg_arrays(pcb_data, layer):
     sig = (len(segs), len(vias), id(segs), id(vias),
            (tail.start_x, tail.start_y, tail.end_x, tail.end_y,
             tail.layer, tail.width, tail.net_id) if tail is not None else None,
-           (vtail.x, vtail.y, vtail.size, vtail.net_id) if vtail is not None else None,
-           sum(map(id, segs)), sum(map(id, vias)),
-           hash(tuple(sg.layer for sg in segs)))
+           (vtail.x, vtail.y, vtail.size, vtail.net_id) if vtail is not None else None)
+    # The whole-list digest below is O(segments) per call. A caller that
+    # never edits copper in place and DROPS the cache itself at every
+    # splice (smooth_octolinear_chains: `_foreign_seg_arr_cache = None`
+    # per commit) may declare the cache TRUSTED between its own
+    # invalidations, and the digest is skipped: 23.6k calls on a
+    # 2.5k-segment board spent 16 s of a 46 s braid validating a cache
+    # that was never stale (2026-09-06). The identity of the list, its
+    # length and its tail are still checked. Unset (the default), every
+    # call pays the #803 digest as before.
+    if not getattr(pcb_data, '_foreign_seg_arr_trust', False):
+        sig = sig + (sum(map(id, segs)), sum(map(id, vias)),
+                     hash(tuple(sg.layer for sg in segs)))
     cache = getattr(pcb_data, '_foreign_seg_arr_cache', None)
     if cache is None or cache[0] != sig:
         cache = (sig, {})
@@ -373,7 +383,23 @@ def _foreign_seg_arrays(pcb_data, layer):
                np.asarray(ay, dtype=float), np.asarray(bx, dtype=float),
                np.asarray(by, dtype=float), np.asarray(hw, dtype=float))
         per_layer[layer] = arr
+        # the per-item bounding boxes _seg_foreign_seg_dist windows on,
+        # once per rebuild instead of four array ops per query (23.6k
+        # queries per braid smoothing pass, 2026-09-06)
+        _n, _ax, _ay, _bx, _by, _hw = arr
+        per_layer[(layer, 'bbox')] = (np.minimum(_ax, _bx) - _hw,
+                                      np.maximum(_ax, _bx) + _hw,
+                                      np.minimum(_ay, _by) - _hw,
+                                      np.maximum(_ay, _by) + _hw)
     return arr
+
+
+def _foreign_seg_bboxes(pcb_data, layer):
+    """(min_x, max_x, min_y, max_y) arrays of the foreign segments+vias
+    on `layer`, built with -- and valid exactly as long as -- the arrays
+    of _foreign_seg_arrays."""
+    _foreign_seg_arrays(pcb_data, layer)
+    return pcb_data._foreign_seg_arr_cache[1][(layer, 'bbox')]
 
 
 def _seg_foreign_seg_dist(pcb_data, net_id, x1, y1, x2, y2, layer,
@@ -403,8 +429,7 @@ def _seg_foreign_seg_dist(pcb_data, net_id, x1, y1, x2, y2, layer,
         return 1e9
     n = max(2, int(math.hypot(x2 - x1, y2 - y1) / 0.02) + 1)
     R = _FOREIGN_PAD_WINDOW
-    fminx = np.minimum(fax, fbx) - fhw; fmaxx = np.maximum(fax, fbx) + fhw
-    fminy = np.minimum(fay, fby) - fhw; fmaxy = np.maximum(fay, fby) + fhw
+    fminx, fmaxx, fminy, fmaxy = _foreign_seg_bboxes(pcb_data, layer)
     near = ((fmaxx >= min(x1, x2) - R) & (fminx <= max(x1, x2) + R) &
             (fmaxy >= min(y1, y2) - R) & (fminy <= max(y1, y2) + R) & (nid != net_id))
     if not near.any():


### PR DESCRIPTION
## What

The octolinear smoother (`smooth_octolinear_chains`, #536) spent most of its time validating a cache that was never stale. `_foreign_seg_arrays` recomputes an O(segments) digest (sum of ids, a hash of every layer -- the #803 hardening) on **every** query, and the smoother makes one query per candidate span per helper: on a 2,500-segment board that was 23,577 queries and 16 of the pass's 19 s.

The smoother edits copper only by splicing `pcb_data.segments`, and already drops the cache at both splice sites. So:

- `_foreign_seg_arrays` skips the digest only while the caller has set `pcb_data._foreign_seg_arr_trust`; list identity, length and tail are still checked. Unset (the default), every other caller pays the #803 digest exactly as before.
- `smooth_octolinear_chains` sets the flag around its loop and resets it in a `finally`, dropping the cache on the way in and out. The loop body moves under a `try`; `git diff -w` shows the 14-line change.
- The per-item bounding boxes `_seg_foreign_seg_dist` windows on are built once per cache rebuild (`_foreign_seg_bboxes`) instead of four array operations per query.

## Evidence

- **Copper identical.** `route.py` on `kicad_files/splitflap_driver.kicad_pcb`, main vs this branch: 1,422 segments / 168 vias byte-identical, same JSON summary. The #622 braid boards (K35 1,752 segments, K41 1,790) byte-identical before/after.
- **Gain scales with segment count**: 16 -> 12.7 s of smoothing on the 2,500-segment board (the remaining cost is numpy per-call overhead over the windowed arrays); nothing measurable on the small parity board (7.4 s either way).
- `tests/test_smooth_route.py`, `tests/test_617_pcb_modification_hole_clearance.py`, `tests/test_760_hole_local_clearance.py` pass; the full suite was not run for this PR (by request).

## Why it is safe

The trust never outlives the smoother's own loop, and inside it the only copper mutation is the splice that drops the cache. An exception inside the loop clears the flag on the way out. No CLI flag, no GUI control, no behaviour change: a caller that does edit segments in place (the #803 site) never sets the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LttmRACcfGJchusgrdNduj
