### PR TITLE
#896 + #891: one body model for courtyard-less libraries, and the context sheet that reads it

### DIFF
--- a/.claude/skills/plan-pcb-placement/SKILL.md
+++ b/.claude/skills/plan-pcb-placement/SKILL.md
@@ -768,6 +768,41 @@ whose `design_brief` section is the only DECLARED one in that document; every
 other section, `mechanical` included, is inference. `docs/design-brief.md` is
 the reference.
 
+**Read the component-context sheet before you decide any pose** (#891). It is
+the one document that prints what you actually need to reason from -- per part
+the body extent AND which geometry it came from, every pad grouped by the board
+face it escapes through at the current rotation with its net and pin function,
+which parts each net reaches, partners ranked by shared nets, and the
+pin-order-agreement table:
+
+```bash
+python3 -X utf8 py_tools/board_context.py board.kicad_pcb --md
+python3 -X utf8 py_tools/board_context.py board.kicad_pcb --panels wk/panels
+```
+
+(`-o PATH` writes it to a file, and `--json` gives the same document as data;
+the panels are referenced from the markdown by name.)
+
+Two rows to read first, because they are the ones a layout cannot recover from
+later:
+
+* **Pin-order agreement**, at BOTH scopes. A `CROSSED` pair forces at least
+  `inversions` crossings on any router, and on a two-layer board that is a via
+  per net or back-side copper under the pour. Rotation cannot fix it -- parity
+  flips only under a mirror or a via hop. Run 25 shipped a board whose USB pair
+  was crossed at every rotation of U1; the fact was visible before placement
+  started and was found after routing. `UNDETERMINED` means the two pads
+  project to one point on the channel axis, so the order is not a fact about
+  the board at that pose -- it is not a pass.
+* **Body source.** A part reading `pad_bbox` has no drawn body at all, and a
+  part reading `silk` was graded on a silkscreen marking, which a library may
+  draw as an assembly outline rather than the part. Neither is a defect; both
+  change how much a seam number is worth.
+
+Every derived column names its source and prints `unknown` where inference ran
+out, so a claim you carry forward can always be traced to the channel it came
+from.
+
 **1. List what the spec fixes, and cite the requirement next to each ref.**
 Read the board's requirements/spec before touching placement. Anything with a
 coordinate, a pitch, a mating standard or an enclosure feature is fixed:

--- a/README.md
+++ b/README.md
@@ -666,6 +666,7 @@ KiCadRoutingTools/
 │   │   ├── parser.py             # Courtyard boundary extraction
 │   │   ├── writer.py             # Footprint position modification
 │   │   ├── groups.py             # Group-move support
+│   │   ├── body.py               # THE footprint body model (#896)
 │   │   ├── legality.py           # Placement legality checks
 │   │   └── utility.py            # Shared placement utilities
 │   └── ...                       # plus the rest of the engine modules — see Module Overview below

--- a/krt_capabilities.py
+++ b/krt_capabilities.py
@@ -70,6 +70,10 @@ KNOWN_MODULES = (
     # no .md file anywhere -- an instrument nobody can discover produces no
     # findings.
     'check_channels.py', 'check_capacity.py',
+    # #891. The per-part context sheet a model reasons from -- body and
+    # its source, pads by board face, pin-order agreement, partners. An
+    # instrument nobody can discover produces no findings.
+    'board_context.py',
 )
 
 # Scripts whose flag set a consumer may want to pin.

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -1220,10 +1220,86 @@ is followed by a settle beat, so the moves only play once the camera has arrived
 | `cli_gates.py` | argparse shared by both placement CLIs so they cannot drift |
 | `../render_placement.py` | Headless PNG stills of placement status (#431) |
 | `legality.py` | Hard constraints shared by both engines: board side, real Edge.Cuts containment, and the OO/OoB graders (#456) |
-| `parser.py` | Courtyard boundary and locked-footprint extraction |
+| `body.py` | THE body model (#896): courtyard -> fab -> silk U pads -> pad bbox, with the occupancy rect and the source that answered |
+| `parser.py` | Courtyard, fab, silk and locked-footprint extraction |
 | `writer.py` | Writes new positions/rotations (rotates pad angles with the footprint, as KiCad stores pad angle = footprint + pad rotation). Resolves blocks through `kicad_parser.iter_footprint_blocks`, so one placement moves ONE block even when two share a reference (#726) |
 | `board_grid.py` | The pitch a board was laid out on, inferred from its footprint origins (#708). Pure; no engine imports |
 | `utility.py` | Shared utilities (bbox from pads, grid snapping) |
+
+## Body model (`body.py`, #896)
+
+What a footprint's *body* is, decided once. Before this module the answer lived
+in five places with three ladders, and the one most consumers reached through
+went straight from courtyard to the **pad bounding box** -- it never looked at
+`.Fab`. On a library that draws no courtyard, every placement instrument was
+therefore grading pad boxes. Measured on `esp_prog` (OLIMEX): **0 of 21**
+footprints draw a courtyard, and six of them -- CON1, CON2, U1, U2, Q1, Q2 --
+draw no `.Fab` either. Those six are the connector housings, the SSOP and the
+SOT89 whose collisions cost run 25 two laps, each found only by a reviewer
+writing its own geometry.
+
+**Two ladders, one reader**, because they answer different questions:
+
+```
+occupancy    courtyard -> fab -> silk U pad_bbox -> pad_bbox -> synthetic
+drawn body   fab -> silk U pad_bbox -> (nothing)
+```
+
+`occupancy_local` is *what does this part occupy* and never shrinks; it is what
+`part_local_bounds` publishes and what every consumer deciding whether
+something may be seated somewhere reads. `drawn_local` is *what did the library
+draw as this part's body*, and the courtyard is deliberately NOT on it -- a
+courtyard is a body plus an assembly margin plus any shell overhang, which is
+exactly why run 6 calibrated the courtyard channel and the fab channel apart. A
+part can have `source == 'courtyard'` and `drawn_source == 'fab'` at once.
+
+**Only the silk rung unions with the pads**, and that is measured rather than
+assumed. Silk is not an outline: on a stock KiCad footprint it is a pair of
+clipped side ticks. Over the 10 esp_prog footprints drawing both, the silk bbox
+is narrower than the `.Fab` body along the pad axis on 10 of 10 (Y1: 0.508 mm
+against a 3.200 mm body) and wider across it on 10 of 10, so no offset
+reconciles them -- the sign of the error differs per axis. Taken bare it would
+SHRINK parts (Q1/Q2 SOT23: a 3.610 x 2.902 pad box becomes 0.838 x 2.845),
+which is the unsafe direction. Unioning the courtyard and fab rungs too would
+be a different measurement: it moves lap-3 `U1<->Y1` from -0.1330 to -0.2830,
+because Y1's pads overhang its fab body.
+
+**A pad-less footprint gets no silk body.** Allowing it put 5 corpus pairs
+above the run-23 blocking floors and all five were logos (`logo`, `oshw:oshw`,
+`Glasgow:nono_hana_lines`).
+
+**A silk-sourced body never GATES**, structurally rather than by a census
+coming out clean. On the shipped esp_prog, U2's OLIMEX SOT89 draws four corner
+brackets at +/-2.5 mm plus a pin-1 dot -- a 5.2 x 5.2 mm assembly square
+centred on an origin its pads are not centred on -- and R1, which clears U2's
+real body by 2.1 mm, reads as 89% CONTAINED. The pair is reported, with its
+source; it does not decide. The exclusion is scoped per channel (containment
+reads `drawn_source`, the courtyard channel the occupancy source), because
+scoping it to one set threw away four pre-existing findings silk had nothing to
+do with.
+
+**There is no offset constant, deliberately.** #896 proposes expanding silk by
+"the silk-to-body offset the library uses, ~0.2 mm on OLIMEX"; that turns its
+own acceptance numbers -0.12 / -0.09 / -0.133 into -0.52 / -0.49 / -0.53. Silk
+at stroke centreline, unioned with the pads, reproduces all three exactly.
+
+Corpus effect over the 22 tracked boards, symmetric diff, nothing lost:
+
+| | before | after |
+|---|---|---|
+| `fab_unjudged` | 140 | **77** |
+| `blocking` | 0 | 0 |
+| `containment_blocking` | 0 | 0 |
+| `courtyard_blocking` | 118 | 119 |
+| `advisory` | 177 | 183 |
+
+Source mix over 1349 corpus parts: 1267 courtyard, 27 fab, 6 silk, 49 pad bbox,
+0 with no geometry at all; 2 silk boxes refused as tick marks.
+
+`tightest_body_seam` reports the closest drawn-body pair on a board, signed
+(negative is an overlap, the same convention as `rect_gap`) and naming the
+source each side rests on. `body_overlap_pairs` reports a depth only for pairs
+that already overlap, so a board a hair from a collision said nothing at all.
 
 ## Legality model (`legality.py`, #456)
 

--- a/py_placer/placement/body.py
+++ b/py_placer/placement/body.py
@@ -16,15 +16,28 @@ and the SOT89 whose collisions cost run 25 two laps; each was found only by an
 adversarial reviewer writing its own geometry, because no checker in the chain
 could see a housing at all.
 
-THE LADDER
-----------
-    courtyard  ->  fab  ->  silk U pad_bbox  ->  pad_bbox  ->  synthetic
+TWO LADDERS, ONE READER
+-----------------------
+They answer different questions, so they are two values and not one value with
+a flag:
 
-`source` names the rung that answered, always, so a consumer reports "body from
-silk" rather than "no body", and a pad-bbox answer is disclosed rather than
-passing as geometry somebody drew.
+    occupancy   courtyard -> fab -> silk U pad_bbox -> pad_bbox -> synthetic
+    drawn body  fab -> silk U pad_bbox -> (nothing)
 
-Two rules the ladder encodes, both measured rather than assumed:
+`occupancy_local` is *what does this part occupy* -- what a consumer deciding
+whether something may be seated somewhere must read. It never shrinks.
+
+`drawn_local` is *what did the library draw as this part's body*, and the
+courtyard is deliberately NOT on it: a courtyard is a body plus an assembly
+margin plus any shell overhang, which is exactly why run-6 calibrated the
+courtyard channel and the fab channel apart. A part with both a courtyard and a
+fab outline has `source == 'courtyard'` and `drawn_source == 'fab'` at once.
+
+`source` and `drawn_source` name the rung that answered, always, so a consumer
+reports "body from silk" rather than "no body", and a pad-bbox answer is
+disclosed rather than passing as geometry somebody drew.
+
+Two rules the ladders encode, both measured rather than assumed:
 
 1. **Courtyard and fab are taken AS DRAWN; only the silk rung unions with the
    pads.** Silk is not an outline -- on a stock KiCad footprint it is a pair of
@@ -110,6 +123,15 @@ class BodyGeometry(NamedTuple):
     occupancy_local: Optional[Bbox]
     source: str
     silk_rejected: bool = False
+    # #896. The DRAWN BODY, on its own ladder: fab, else silk U pads, else
+    # None. Deliberately NOT the winner of the ladder above, because a
+    # courtyard is not a body -- it is a body plus an assembly margin plus any
+    # shell overhang, which is why run-6 calibrated the courtyard channel and
+    # the fab channel apart in the first place. A part can therefore have a
+    # courtyard `source` and a fab `drawn_source` at once, and the body-overlap
+    # channel reads THIS pair, not the occupancy one.
+    drawn_local: Optional[Bbox] = None
+    drawn_source: str = SOURCE_NONE
 
 
 def _union(a: Bbox, b: Bbox) -> Bbox:
@@ -156,35 +178,50 @@ def body_geometry(fp, side: str,
         except Exception:                                    # noqa: BLE001
             pads = None
 
-    drawn = _for_side(courtyard_sides, side)
-    if drawn is not None:
-        return BodyGeometry(ref, drawn,
-                            drawn if pads is None else _union(drawn, pads),
-                            SOURCE_COURTYARD)
-
-    drawn = _for_side(fab_sides, side)
-    if drawn is not None:
-        return BodyGeometry(ref, drawn,
-                            drawn if pads is None else _union(drawn, pads),
-                            SOURCE_FAB)
-
+    fab = _for_side(fab_sides, side)
     silk = _for_side(silk_sides, side)
-    if silk is not None and pads is not None:
-        # Rule 1: the silk rung unions. Rule 2 (pad-less refusal) is the
-        # `pads is not None` guard above -- a logo reaches the branch below and
-        # is recorded as rejected.
-        body = _union(silk, pads)
-        if _contained(silk, pads):
-            # A tick mark: the union IS the pad bbox, so say `pad_bbox`.
-            return BodyGeometry(ref, body, body, SOURCE_PADS,
-                                silk_rejected=True)
-        return BodyGeometry(ref, body, body, SOURCE_SILK)
 
-    if pads is not None:
-        return BodyGeometry(ref, pads, pads, SOURCE_PADS,
-                            silk_rejected=silk is not None)
-    return BodyGeometry(ref, None, None, SOURCE_NONE,
-                        silk_rejected=silk is not None)
+    # -- the DRAWN-BODY ladder: fab, else silk U pads. Courtyard is not on it.
+    drawn_local: Optional[Bbox] = None
+    drawn_source = SOURCE_NONE
+    silk_rejected = False
+    if fab is not None:
+        drawn_local, drawn_source = fab, SOURCE_FAB
+    elif silk is not None:
+        if pads is None:
+            # Rule 2: a pad-less footprint gets no SILK body. A logo, an OSHW
+            # mark or a decorative drawing is not a part to collide with, and
+            # allowing them put 5 corpus pairs above the run-23 floors, all
+            # five of them logos.
+            silk_rejected = True
+        else:
+            # Rule 1: the silk rung unions with the pads, because silk alone
+            # is a pair of clipped ticks and would SHRINK the part.
+            body = _union(silk, pads)
+            if _contained(silk, pads):
+                # A tick mark: the union IS the pad bbox, so it says nothing
+                # about the body and must not be labelled one.
+                silk_rejected = True
+            else:
+                drawn_local, drawn_source = body, SOURCE_SILK
+
+    # -- the OCCUPANCY ladder: courtyard, else the drawn body, else the pads.
+    court = _for_side(courtyard_sides, side)
+    if court is not None:
+        body_local, source = court, SOURCE_COURTYARD
+    elif drawn_local is not None:
+        body_local, source = drawn_local, drawn_source
+    elif pads is not None:
+        body_local, source = pads, SOURCE_PADS
+    else:
+        return BodyGeometry(ref, None, None, SOURCE_NONE,
+                            silk_rejected=silk_rejected,
+                            drawn_local=None, drawn_source=SOURCE_NONE)
+
+    occupancy = (body_local if pads is None else _union(body_local, pads))
+    return BodyGeometry(ref, body_local, occupancy, source,
+                        silk_rejected=silk_rejected,
+                        drawn_local=drawn_local, drawn_source=drawn_source)
 
 
 def board_bodies(pcb_data, pcb_file: Optional[str] = None

--- a/py_placer/placement/body.py
+++ b/py_placer/placement/body.py
@@ -1,0 +1,258 @@
+"""One body model for every placement instrument (#896).
+
+WHAT THIS IS FOR
+----------------
+A footprint's "body" is not one thing a board file states; it is whatever the
+library happened to draw. Before this module the answer was decided in five
+places with three different ladders, and the ladder that most consumers used --
+`legality.part_local_bounds` -- went straight from courtyard to the PAD BOUNDING
+BOX. On a library that draws no courtyard, every placement instrument therefore
+graded pad boxes and could not see a body at all.
+
+Measured on `esp_prog` (OLIMEX), the board that produced #896: **0 of 21**
+footprints draw a courtyard, and six of them -- CON1, CON2, U1, U2, Q1, Q2 --
+draw no `.Fab` outline either. Those six are the connector housings, the SSOP
+and the SOT89 whose collisions cost run 25 two laps; each was found only by an
+adversarial reviewer writing its own geometry, because no checker in the chain
+could see a housing at all.
+
+THE LADDER
+----------
+    courtyard  ->  fab  ->  silk U pad_bbox  ->  pad_bbox  ->  synthetic
+
+`source` names the rung that answered, always, so a consumer reports "body from
+silk" rather than "no body", and a pad-bbox answer is disclosed rather than
+passing as geometry somebody drew.
+
+Two rules the ladder encodes, both measured rather than assumed:
+
+1. **Courtyard and fab are taken AS DRAWN; only the silk rung unions with the
+   pads.** Silk is not an outline -- on a stock KiCad footprint it is a pair of
+   clipped side ticks. Over the 10 esp_prog footprints that draw both fab and
+   silk, the silk bbox is narrower than the fab body along the pad axis on 10 of
+   10 (Y1: 0.508mm against a 3.200mm body, an 84% loss) and wider across it on
+   10 of 10, so no offset reconciles them -- the sign of the error differs per
+   axis. Taken bare, silk would SHRINK parts, which is the unsafe direction
+   (`legality.LocalBounds`' own comment: shrinking can flip `zone_is_anchor`
+   True->False, whose non-anchor branch has a strictly smaller admissible origin
+   box). esp_prog Q1/Q2 (SOT23) would go from a 3.610 x 2.902 pad box to a
+   0.838 x 2.845 silk box. Unioning the silk rung with the pad bbox removes that
+   hazard entirely and -- verified -- changes none of the three numbers #896
+   asks for.
+
+   Unioning the courtyard and fab rungs too would be a DIFFERENT measurement:
+   it moves lap-3 U1<->Y1 from -0.1330 to -0.2830, because Y1's pads overhang
+   its fab body by 0.15mm on the facing side. That is the occupancy question,
+   not the body question; see `occupancy_local` below.
+
+2. **A pad-less footprint gets no silk body.** A logo, an OSHW mark or a
+   decorative silk drawing is not a part to collide with. Measured: allowing
+   them produced 5 corpus pairs above the run-23 blocking floors and ALL FIVE
+   were logos (`logo`, `oshw:oshw`, `Glasgow:nono_hana_lines`). Refusing them
+   leaves 4 new pairs corpus-wide and 0 above the floors.
+
+NO OFFSET CONSTANT, DELIBERATELY. #896 proposes expanding silk by "the
+silk-to-body offset the library uses, ~0.2 mm on OLIMEX". That is refuted by the
+issue's own acceptance numbers: a 0.2mm expansion on both parts turns
+-0.12 / -0.09 / -0.133 into -0.52 / -0.49 / -0.53. Silk at its stroke
+centreline, unioned with the pads, reproduces all three exactly.
+
+WHAT THIS MODULE DOES NOT DECIDE
+--------------------------------
+It reports geometry and its provenance. It does not waive, gate or price
+anything, and a body never relaxes a pad-pair clearance -- pads remain the DRC
+truth (`legality.grade_pad_legality`, `check_drc.check_pad_pad_overlap`).
+"""
+from __future__ import annotations
+
+from typing import Dict, NamedTuple, Optional, Tuple
+
+Bbox = Tuple[float, float, float, float]
+
+# The rungs, in order, as they appear in `BodyGeometry.source`. `pad_bbox` and
+# `none` keep the spellings `board_brief.parts_section` already ships so a
+# reader meets one vocabulary; `courtyard`, `fab` and `silk` name the drawn
+# geometry that answered.
+SOURCE_COURTYARD = 'courtyard'
+SOURCE_FAB = 'fab'
+SOURCE_SILK = 'silk'
+SOURCE_PADS = 'pad_bbox'
+SOURCE_NONE = 'none'
+
+#: Ladder order, for reporting a source mix in a stable sequence.
+SOURCES = (SOURCE_COURTYARD, SOURCE_FAB, SOURCE_SILK, SOURCE_PADS,
+           SOURCE_NONE)
+
+
+class BodyGeometry(NamedTuple):
+    """One footprint's body, in the footprint's own UNROTATED local frame.
+
+    `body_local` answers *what is this part's body* -- the assembly question, and
+    the one #896's numbers are measured against. `occupancy_local` answers *what
+    does this part occupy*, which is body united with the pad bbox: a part
+    occupies its copper as well as its plastic, and a consumer that decides
+    whether something may be SEATED somewhere must never be handed the smaller
+    of the two. They are stored as two values rather than one value and a flag
+    because they are two questions with two right answers.
+
+    Both are `None` only when the footprint has neither drawn geometry nor pads,
+    which is `SOURCE_NONE`; `legality.LocalBounds.synthetic` is the population
+    that then falls back to the +-0.5mm fiction.
+
+    `silk_rejected` records that silk was drawn but did not survive -- either
+    the footprint has no pads (a logo) or its silk bbox lies inside the pad bbox
+    (a pin-1 tick, a polarity bar), so the union is the pad bbox and the source
+    reads `pad_bbox`. It is a disclosure, not an error: a fragment must not be
+    LABELLED a body.
+    """
+    ref: str
+    body_local: Optional[Bbox]
+    occupancy_local: Optional[Bbox]
+    source: str
+    silk_rejected: bool = False
+
+
+def _union(a: Bbox, b: Bbox) -> Bbox:
+    return (min(a[0], b[0]), min(a[1], b[1]),
+            max(a[2], b[2]), max(a[3], b[3]))
+
+
+def _contained(inner: Bbox, outer: Bbox, eps: float = 1e-9) -> bool:
+    return (inner[0] >= outer[0] - eps and inner[1] >= outer[1] - eps
+            and inner[2] <= outer[2] + eps and inner[3] <= outer[3] + eps)
+
+
+def _for_side(sides: Optional[Dict[str, Bbox]],
+              side: str) -> Optional[Bbox]:
+    """The bbox a part on `side` should use: its own side's if drawn, else the
+    other side's, else None.
+
+    Deliberately the same rule as `parser.courtyard_for_side`, and it calls it,
+    so the three rungs cannot drift apart on the "library drew only the F side"
+    case -- which is common enough that the courtyard reader documents it.
+    """
+    from placement.parser import courtyard_for_side
+    return courtyard_for_side(sides, side)
+
+
+def body_geometry(fp, side: str,
+                  courtyard_sides: Optional[Dict[str, Bbox]] = None,
+                  fab_sides: Optional[Dict[str, Bbox]] = None,
+                  silk_sides: Optional[Dict[str, Bbox]] = None,
+                  ref: str = '') -> BodyGeometry:
+    """THE ladder, for one footprint. Per-side bboxes come from the caller.
+
+    Split from `board_bodies` so a consumer that already holds the three
+    per-side maps (the quench holds one, `grade_body_overlap` holds two) pays
+    the file read once, and so the rung logic has exactly one home.
+    """
+    from placement.utility import compute_footprint_bbox_local
+
+    ref = ref or getattr(fp, 'reference', '') or ''
+    pads: Optional[Bbox] = None
+    if getattr(fp, 'pads', None):
+        try:
+            pads = compute_footprint_bbox_local(fp)
+        except Exception:                                    # noqa: BLE001
+            pads = None
+
+    drawn = _for_side(courtyard_sides, side)
+    if drawn is not None:
+        return BodyGeometry(ref, drawn,
+                            drawn if pads is None else _union(drawn, pads),
+                            SOURCE_COURTYARD)
+
+    drawn = _for_side(fab_sides, side)
+    if drawn is not None:
+        return BodyGeometry(ref, drawn,
+                            drawn if pads is None else _union(drawn, pads),
+                            SOURCE_FAB)
+
+    silk = _for_side(silk_sides, side)
+    if silk is not None and pads is not None:
+        # Rule 1: the silk rung unions. Rule 2 (pad-less refusal) is the
+        # `pads is not None` guard above -- a logo reaches the branch below and
+        # is recorded as rejected.
+        body = _union(silk, pads)
+        if _contained(silk, pads):
+            # A tick mark: the union IS the pad bbox, so say `pad_bbox`.
+            return BodyGeometry(ref, body, body, SOURCE_PADS,
+                                silk_rejected=True)
+        return BodyGeometry(ref, body, body, SOURCE_SILK)
+
+    if pads is not None:
+        return BodyGeometry(ref, pads, pads, SOURCE_PADS,
+                            silk_rejected=silk is not None)
+    return BodyGeometry(ref, None, None, SOURCE_NONE,
+                        silk_rejected=silk is not None)
+
+
+def board_bodies(pcb_data, pcb_file: Optional[str] = None
+                 ) -> Dict[str, BodyGeometry]:
+    """`{ref: BodyGeometry}` for a whole board, one file read.
+
+    Needs the board FILE, because footprint graphics reach neither parse path:
+    `kicad_parser.Footprint` carries no courtyard, fab or silk field on the text
+    side or the pcbnew side. Falls back to `pcb_data.source_path` -- which
+    `build_pcb_data_from_board` fills from `board.GetFileName()`, so the GUI
+    reaches the same geometry -- and to pad bboxes everywhere when there is no
+    readable path at all.
+
+    A ref is ABSENT only when even the pad fallback raised, matching
+    `legality.part_local_bounds` so both see one universe.
+    """
+    from placement.legality import footprint_side
+    from placement.parser import (extract_courtyard_sides, extract_fab_sides,
+                                  extract_silk_sides)
+
+    path = pcb_file or getattr(pcb_data, 'source_path', None)
+    crt: Dict[str, Dict[str, Bbox]] = {}
+    fab: Dict[str, Dict[str, Bbox]] = {}
+    silk: Dict[str, Dict[str, Bbox]] = {}
+    if path:
+        for reader, target in ((extract_courtyard_sides, 'crt'),
+                               (extract_fab_sides, 'fab'),
+                               (extract_silk_sides, 'silk')):
+            try:
+                got = reader(path)
+            except Exception:                                # noqa: BLE001
+                got = {}
+            if target == 'crt':
+                crt = got
+            elif target == 'fab':
+                fab = got
+            else:
+                silk = got
+
+    out: Dict[str, BodyGeometry] = {}
+    for ref, fp in sorted((pcb_data.footprints or {}).items()):
+        geom = body_geometry(fp, footprint_side(fp),
+                             courtyard_sides=crt.get(ref),
+                             fab_sides=fab.get(ref),
+                             silk_sides=silk.get(ref), ref=ref)
+        if geom.body_local is None and geom.source != SOURCE_NONE:
+            continue
+        out[ref] = geom
+    return out
+
+
+def source_mix(bodies) -> Dict[str, int]:
+    """`{source: count}` over `BodyGeometry` records, in ladder order.
+
+    The number `check_assembly`'s BODY COVERAGE line reports, so the coverage
+    claim and the geometry cannot drift apart.
+    """
+    counts = {s: 0 for s in SOURCES}
+    for g in (bodies.values() if isinstance(bodies, dict) else bodies):
+        counts[g.source] = counts.get(g.source, 0) + 1
+    return counts
+
+
+def format_source_mix(bodies) -> str:
+    """One line naming every rung that answered, zeros included.
+
+    Zeros are kept deliberately: "0 courtyard" on a board is the finding, and a
+    mix that only lists what it found cannot say that.
+    """
+    counts = source_mix(bodies)
+    return ', '.join(f'{counts[s]} {s}' for s in SOURCES)

--- a/py_placer/placement/body.py
+++ b/py_placer/placement/body.py
@@ -273,6 +273,51 @@ def board_bodies(pcb_data, pcb_file: Optional[str] = None
     return out
 
 
+class BodySeam(NamedTuple):
+    """The tightest gap between two parts' DRAWN bodies, signed.
+
+    Negative is an overlap, the same convention as `legality.rect_gap`, so a
+    seam and an overlap are one number and a reader never has to reconcile two.
+    `source_a` / `source_b` name the geometry the number rests on, because a
+    seam measured between two silk markings is a much weaker claim than one
+    between two drawn .Fab bodies.
+    """
+    mm: float
+    ref_a: str
+    ref_b: str
+    source_a: str
+    source_b: str
+
+
+def tightest_body_seam(parts) -> Optional[BodySeam]:
+    """The tightest drawn-body seam on a board, or None if fewer than two
+    parts draw a body.
+
+    #896 asks for this on every review sheet, because run 25's final layout had
+    a 0.183mm seam -- header plastic to an 0402 body -- that no instrument in
+    the chain produced: `body_overlap_pairs` reports `depth_mm` only for pairs
+    that already OVERLAP, so a board one micron from a collision reported
+    nothing at all. "How close is the closest thing on this board" is the
+    question a human asks first and the toolchain could not answer.
+
+    `parts` is an iterable of `(ref, sides, side, rect, tht_rect, source)`,
+    already in board coordinates -- the caller owns the pose, this owns the
+    comparison. It calls `legality.pair_min_gap`, so the shared-side rule is
+    the one the graders already use rather than a second copy of it.
+    """
+    from placement.legality import pair_min_gap
+    parts = list(parts)
+    best: Optional[BodySeam] = None
+    for i, (ra, sa, sda, rca, ta, srca) in enumerate(parts):
+        for rb, sb, sdb, rcb, tb, srcb in parts[i + 1:]:
+            g = pair_min_gap(sa, sda, rca, ta, sb, sdb, rcb, tb)
+            if g is None:
+                continue
+            if best is None or g < best.mm:
+                best = BodySeam(round(g, 4), ra, rb, srca, srcb)
+    return best
+
+
 def source_mix(bodies) -> Dict[str, int]:
     """`{source: count}` over `BodyGeometry` records, in ladder order.
 

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -941,6 +941,13 @@ class GradedPart(NamedTuple):
     # artifact. A pad-bbox fallback (pads exist, courtyard missing) stays
     # False: those bounds are real copper.
     synthetic: bool = False
+    # #896. WHICH drawn geometry `rect` came from -- one of
+    # `body.SOURCES`. Carried here because `graded_parts_from_file` used to
+    # drop `LocalBounds.from_courtyard` on the floor, and every downstream
+    # consumer reads GradedPart, not LocalBounds: a pair reported against a
+    # pad bbox and a pair reported against a drawn housing are different
+    # claims, and a reader could not tell them apart.
+    source: str = ''
 
     @property
     def sides(self) -> frozenset:
@@ -1163,49 +1170,67 @@ class LocalBounds(NamedTuple):
     # geometry may differ in EITHER direction, which is why it is recorded
     # per part rather than assumed away.
     from_courtyard: bool
+    # #896. The rung of `body.body_geometry`'s ladder that answered:
+    # 'courtyard' | 'fab' | 'silk' | 'pad_bbox' | 'none'. `from_courtyard`
+    # above is kept as a FIELD rather than becoming a property derived from
+    # this -- a NamedTuple cannot carry both under one name, and removing it
+    # would change `_fields`, the arity and `_asdict()` ordering that
+    # floorplan's `measured` dict and tests/mutate_799.py both read.
+    source: str = ''
+    # #896. Silk was drawn but did not survive the ladder: either the
+    # footprint has no pads (a logo) or its silk bbox lies inside the pad
+    # bbox (a pin-1 tick), so the union IS the pad bbox. A disclosure, not
+    # an error -- a fragment must not be LABELLED a body.
+    silk_rejected: bool = False
 
 
 def part_local_bounds(pcb_data, pcb_file: Optional[str] = None
                       ) -> Dict[str, LocalBounds]:
     """THE local-bounds chain, once: `{ref: LocalBounds}`.
 
-    Same geometry rules as the quench state (#456: one definition of legal):
-    courtyard for the part's own side via the text parser, pad-bbox fallback
-    when the footprint draws none, drilled-pad box on the far side. Needs the
-    board FILE for courtyards (the text parser reads it); falls back to
-    `pcb_data.source_path`, then to pad bboxes everywhere.
+    The geometry decision itself lives in `placement.body` (#896) and this is
+    its pose-independent half plus the drilled-pad box: courtyard, else the
+    drawn .Fab body, else silk unioned with the pad bbox, else the pad bbox --
+    with `source` naming which rung answered. Before #896 this ladder went
+    straight from courtyard to the pad bbox, so on a library drawing no
+    courtyard every consumer of this function graded pad boxes and no
+    instrument could see a connector housing at all.
+
+    Needs the board FILE for the drawn geometry (neither parse path carries
+    footprint graphics on `Footprint`); falls back to `pcb_data.source_path`,
+    then to pad bboxes everywhere.
+
+    NOT the quench's ladder. `quench._Part.__init__` keeps its own
+    courtyard-or-pad-bbox bounds deliberately (see `body.py`): adopting the
+    model there changes which poses `pose_ok` admits and therefore the basin
+    the anneal lands in, which is a search change needing its own A/B, not a
+    ride-along on a reporting one.
 
     A ref is ABSENT when even the pad fallback raised -- the same parts
     `graded_parts_from_file` skips, so both consumers see one universe.
     """
-    from placement.parser import courtyard_for_side, extract_courtyard_sides
+    from placement.body import (SOURCE_COURTYARD, SOURCE_NONE, board_bodies)
     from placement.utility import compute_footprint_bbox_local
 
-    path = pcb_file or getattr(pcb_data, 'source_path', None)
-    sides: Dict[str, Dict] = {}
-    if path:
-        try:
-            sides = extract_courtyard_sides(path)
-        except Exception:
-            sides = {}
+    bodies = board_bodies(pcb_data, pcb_file)
     out: Dict[str, LocalBounds] = {}
     for ref, fp in sorted((pcb_data.footprints or {}).items()):
         own = footprint_side(fp)
-        local = None
-        synthetic = False
-        from_courtyard = False
-        if sides.get(ref):
-            local = courtyard_for_side(sides[ref], own)
-            from_courtyard = local is not None
+        geom = bodies.get(ref)
+        local = geom.body_local if geom is not None else None
+        source = geom.source if geom is not None else ''
+        silk_rejected = bool(geom.silk_rejected) if geom is not None else False
         if local is None:
+            # SOURCE_NONE, or no readable board file at all: the +/-0.5mm
+            # fiction, which `synthetic` marks so it can never gate.
             try:
                 local = compute_footprint_bbox_local(fp)
-                # No courtyard AND no pads: the +/-0.5mm fiction, not geometry.
-                synthetic = not (fp.pads or ())
+                source = source or SOURCE_NONE
             except Exception:
                 local = None
         if local is None:
             continue
+        synthetic = not (fp.pads or ())
         tht_local = None
         has_tht = footprint_has_through_pads(fp)
         if has_tht:
@@ -1214,7 +1239,8 @@ def part_local_bounds(pcb_data, pcb_file: Optional[str] = None
                                tht_local=(tuple(tht_local)
                                           if tht_local is not None else None),
                                has_tht=has_tht, synthetic=synthetic,
-                               from_courtyard=from_courtyard)
+                               from_courtyard=(source == SOURCE_COURTYARD),
+                               source=source, silk_rejected=silk_rejected)
     return out
 
 
@@ -1238,7 +1264,7 @@ def graded_parts_from_file(pcb_data, pcb_file: Optional[str] = None
             tht = (fp.x + tx0, fp.y + ty0, fp.x + tx1, fp.y + ty1)
         out.append(GradedPart(ref=ref, side=lb.side, rect=rect,
                               tht_rect=tht, has_tht=lb.has_tht,
-                              synthetic=lb.synthetic))
+                              synthetic=lb.synthetic, source=lb.source))
     return out
 
 

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1381,6 +1381,8 @@ def grade_body_overlap(pcb_data, clearance: float,
     # and it NEVER gates -- see the exclusion below, which is structural rather
     # than a measured coincidence.
     silk_sourced: set = set()
+    # #896. Seam inputs: every judged part's DRAWN body in board coordinates.
+    seam_parts: list = []
 
     # -- courtyard channel (advisory + the run-23 blocking policy below) ------
     for p in body_overlap_pairs(_graded):
@@ -1415,8 +1417,21 @@ def grade_body_overlap(pcb_data, clearance: float,
             own = footprint_side(fp)
             rot = fp.rotation or 0.0
             x0, y0, x1, y1 = rotate_local_bounds(*lb, rot)
-            fab_parts.append((ref, own,
-                              (fp.x + x0, fp.y + y0, fp.x + x1, fp.y + y1)))
+            _rect = (fp.x + x0, fp.y + y0, fp.x + x1, fp.y + y1)
+            fab_parts.append((ref, own, _rect))
+            # #896 seam input. The drilled-pad box rides along so the seam
+            # obeys the same shared-side rule the graders use: a B-side part
+            # and an F-side part have no seam at all unless a barrel makes
+            # them share a face.
+            _has_tht = footprint_has_through_pads(fp)
+            _tht = None
+            if _has_tht:
+                _t = through_pad_bounds_local(fp)
+                if _t is not None:
+                    tx0, ty0, tx1, ty1 = rotate_local_bounds(*_t, rot)
+                    _tht = (fp.x + tx0, fp.y + ty0, fp.x + tx1, fp.y + ty1)
+            seam_parts.append((ref, sides_occupied(own, _has_tht), own,
+                               _rect, _tht, body_sources[ref]))
         for i, (ra, sa, rca) in enumerate(fab_parts):
             for rb, sb, rcb in fab_parts[i + 1:]:
                 if sa != sb:
@@ -1694,6 +1709,8 @@ def grade_body_overlap(pcb_data, clearance: float,
         # #896, same rule as containment above: a silk-sourced body reports,
         # it does not gate.
         and not _silk_occupancy_pair(p)]
+    from placement.body import tightest_body_seam as _tbs
+    _seam = _tbs(seam_parts)
     return {'blocking': len(blocking),
             'advisory': len(advisory),
             'waived': sum(1 for p in pairs if p.waived),
@@ -1753,6 +1770,14 @@ def grade_body_overlap(pcb_data, clearance: float,
             # so a reader can tell a housing outline from a fab outline
             # rather than being told only that something was judged.
             'body_sources': dict(body_sources),
+            # #896. The tightest DRAWN-body seam on the board, signed
+            # (negative = overlap). `body_overlap_pairs` reports a depth only
+            # for pairs that already overlap, so a board one micron from a
+            # collision reported nothing; run 25's final layout sat at
+            # 0.183mm, header plastic to an 0402 body, and no instrument in
+            # the chain produced that number. None when fewer than two parts
+            # draw a body.
+            'body_seam': (_seam._asdict() if _seam is not None else None),
             # Run-23 courtyard blocking channel -- see the selection above.
             # NOTE these pairs also remain in `advisory`/`advisory_pairs`
             # (that count's meaning is unchanged for its existing consumers);

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1217,7 +1217,16 @@ def part_local_bounds(pcb_data, pcb_file: Optional[str] = None
     for ref, fp in sorted((pcb_data.footprints or {}).items()):
         own = footprint_side(fp)
         geom = bodies.get(ref)
-        local = geom.body_local if geom is not None else None
+        # OCCUPANCY, not the bare body. Every consumer of this chain asks an
+        # occupancy question -- does this part's extent intrude here -- and the
+        # rect must therefore never SHRINK: measured over the 22 corpus boards,
+        # taking the drawn body bare removed three real run-23 courtyard
+        # findings on ulx3s and two on esp_prog, because a .Fab body is
+        # routinely narrower than the pads it sits between (ulx3s AUDIO1
+        # 194.5 -> 115.6 mm2, 0.59x; U3/U4/U5 TSOT-25 0.55x). The BODY rect is
+        # what the assembly seam and the body-source disclosure report, and
+        # they read `placement.body` directly.
+        local = geom.occupancy_local if geom is not None else None
         source = geom.source if geom is not None else ''
         silk_rejected = bool(geom.silk_rejected) if geom is not None else False
         if local is None:
@@ -1230,7 +1239,15 @@ def part_local_bounds(pcb_data, pcb_file: Optional[str] = None
                 local = None
         if local is None:
             continue
-        synthetic = not (fp.pads or ())
+        # #896. `synthetic` means "not geometry anyone drew", and that is now
+        # SOURCE_NONE -- not "has no pads". A pad-less footprint that draws a
+        # real .Fab body is a real body: watchy's REF** is a 1.54" e-paper
+        # display, 31.8 x 37.3mm on a 33.8 x 46mm board, which graded as the
+        # +/-0.5mm fiction and therefore could never gate anything, while parts
+        # genuinely sit under it. The silk rung already refuses pad-less
+        # footprints (a logo is decoration, not a part), so this admits drawn
+        # bodies without admitting silk graphics.
+        synthetic = source == SOURCE_NONE
         tht_local = None
         has_tht = footprint_has_through_pads(fp)
         if has_tht:

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1365,33 +1365,54 @@ def grade_body_overlap(pcb_data, clearance: float,
             return 'edge_class'
         return ''
 
+    from placement.body import SOURCE_SILK as _BODY_SILK_NAME
+
     pairs: List[BodyOverlapPair] = []
-    # Refs the fab channel could not judge (no .Fab geometry). A board with no
+    # Refs the DRAWN-BODY channel could not judge: no .Fab outline and no
+    # usable silk either (#896 widened this from ".Fab only"). A board with no
     # readable source path leaves this empty AND judges nothing -- both are
     # reported rather than silently conflated with "clean".
     fab_unjudged: set = set()
+    # #896. Per-ref `drawn_source` for every judged part, so the caller can
+    # report "body from silk" instead of "no body" and can say which claims
+    # rest on a housing outline rather than a fab outline.
+    body_sources: Dict[str, str] = {}
+    # #896. Refs whose body came from SILK. Silk is the least trustworthy rung
+    # and it NEVER gates -- see the exclusion below, which is structural rather
+    # than a measured coincidence.
+    silk_sourced: set = set()
 
     # -- courtyard channel (advisory + the run-23 blocking policy below) ------
     for p in body_overlap_pairs(_graded):
         waiver = _waiver_for(p.a, p.b)
         pairs.append(p._replace(waived=bool(waiver), waiver=waiver))
 
-    # -- fab BODY channel (advisory) ------------------------------------------
+    # -- DRAWN BODY channel (advisory) ----------------------------------------
+    # Reads `placement.body`'s drawn-body ladder rather than calling
+    # extract_fab_sides itself: this loop WAS the second implementation of
+    # "what is this part's body" (#896), and its .Fab-only ladder is why six
+    # esp_prog parts -- the connector housings, the SSOP and the SOT89 -- were
+    # unjudged on a board where silk is the only body drawn.
     path = pcb_file or getattr(pcb_data, 'source_path', None)
     if path:
+        from placement.body import (SOURCE_NONE as _BODY_NONE,
+                                    SOURCE_SILK as _BODY_SILK, board_bodies)
         try:
-            from placement.parser import extract_fab_sides
-            fab = extract_fab_sides(path)
-        except Exception:
-            fab = {}
+            _bodies = board_bodies(pcb_data, path)
+        except Exception:                                    # noqa: BLE001
+            _bodies = {}
         fab_parts = []
         for ref, fp in sorted(fps.items()):
-            sides = fab.get(ref)
-            if not sides:
+            geom = _bodies.get(ref)
+            lb = geom.drawn_local if geom is not None else None
+            if lb is None:
                 fab_unjudged.add(ref)
                 continue
+            body_sources[ref] = (geom.drawn_source if geom is not None
+                                 else _BODY_NONE)
+            if body_sources[ref] == _BODY_SILK:
+                silk_sourced.add(ref)
             own = footprint_side(fp)
-            lb = sides.get(own) or next(iter(sides.values()))
             rot = fp.rotation or 0.0
             x0, y0, x1, y1 = rotate_local_bounds(*lb, rot)
             fab_parts.append((ref, own,
@@ -1547,8 +1568,33 @@ def grade_body_overlap(pcb_data, clearance: float,
     #
     # Corpus effect, measured: ZERO boards gate on this.
     _GATE_EXEMPT = ('marker_class', 'container_class', 'intent_declared')
+    # #896. A SILK-sourced body never gates, structurally -- not because a
+    # census happened to come out clean. Silk is the last rung and the least
+    # trustworthy: it is whatever the library drew on the silkscreen, and on a
+    # hand-rolled library that is routinely an assembly outline rather than a
+    # body. Measured on the shipped esp_prog: U2's OLIMEX SOT89 draws four
+    # corner brackets at +/-2.5mm plus a pin-1 dot, a 5.2 x 5.2mm square
+    # centred on an origin the pads are not centred on -- and R1, which clears
+    # U2's real body by 2.1mm, read as 89% CONTAINED inside it and gated the
+    # board NOT BUILDABLE. The pairs are still reported, with their source, in
+    # `pairs` / `advisory` and `body_sources`; what they may not do is decide.
+    # Scoped PER CHANNEL, because the two channels grade different rects: the
+    # containment/drawn-body channel reads `drawn_source`, the courtyard
+    # channel reads the occupancy source on `GradedPart`. A part can carry a
+    # real courtyard AND a silk drawn body at once, and suppressing its
+    # COURTYARD pair for that reason threw away findings silk had nothing to
+    # do with -- measured, glasgow_revC's J1<->TP13, J1<->TP15, J3<->TP1 and
+    # orangecrab's J5<->J6, all pre-existing.
+    _silk_occupancy = {g.ref for g in _graded if g.source == _BODY_SILK_NAME}
+
+    def _silk_drawn_pair(p) -> bool:
+        return p.a in silk_sourced or p.b in silk_sourced
+
+    def _silk_occupancy_pair(p) -> bool:
+        return p.a in _silk_occupancy or p.b in _silk_occupancy
     containment_blocking = [p for p in contained
-                            if p.waiver not in _GATE_EXEMPT]
+                            if p.waiver not in _GATE_EXEMPT
+                            and not _silk_drawn_pair(p)]
     # Courtyard BLOCKING (run-23): the subset of courtyard pairs that gates.
     # Both floors must trip -- area >= COURTYARD_BLOCKING_MIN_MM2 and depth
     # >= COURTYARD_BLOCKING_MIN_DEPTH_MM -- so by-design slivers a healthy
@@ -1644,7 +1690,10 @@ def grade_body_overlap(pcb_data, clearance: float,
         and (p.area_mm2 >= COURTYARD_BLOCKING_MIN_MM2
              or (p.contained_frac or 0.0) >= COURTYARD_BLOCKING_MIN_FRAC)
         and p.depth_mm >= COURTYARD_BLOCKING_MIN_DEPTH_MM
-        and p.a not in _synthetic_refs and p.b not in _synthetic_refs]
+        and p.a not in _synthetic_refs and p.b not in _synthetic_refs
+        # #896, same rule as containment above: a silk-sourced body reports,
+        # it does not gate.
+        and not _silk_occupancy_pair(p)]
     return {'blocking': len(blocking),
             'advisory': len(advisory),
             'waived': sum(1 for p in pairs if p.waived),
@@ -1700,6 +1749,10 @@ def grade_body_overlap(pcb_data, clearance: float,
             # let a reader judge.
             'fab_unjudged': len(fab_unjudged),
             'fab_unjudged_refs': sorted(fab_unjudged),
+            # #896. Which drawn geometry each judged part's body came from,
+            # so a reader can tell a housing outline from a fab outline
+            # rather than being told only that something was judged.
+            'body_sources': dict(body_sources),
             # Run-23 courtyard blocking channel -- see the selection above.
             # NOTE these pairs also remain in `advisory`/`advisory_pairs`
             # (that count's meaning is unchanged for its existing consumers);

--- a/py_placer/placement/pair_order.py
+++ b/py_placer/placement/pair_order.py
@@ -88,18 +88,32 @@ def _escape_pads(part, nets, toward_xy, pose=None) -> Dict[int, Tuple[float, flo
 
 def pair_metrics(state, ref_a: str, ref_b: str,
                  pose_a: Optional[Tuple[float, float, float]] = None,
-                 pose_b: Optional[Tuple[float, float, float]] = None
-                 ) -> Optional[Dict]:
+                 pose_b: Optional[Tuple[float, float, float]] = None,
+                 only_nets=None) -> Optional[Dict]:
     """{'inversions', 'lis', 'nets'} for one part pair, or None when they share
     fewer than 2 scoring nets (one net cannot be out of order).
 
     ``pose_a`` / ``pose_b`` override the live poses -- this is what makes the
     delta cheap: nothing on the state is mutated or rebuilt.
+
+    ``only_nets`` (net ids) narrows the question to a SUBSET of the shared
+    nets; None, the default, keeps the whole-interface question every existing
+    caller asks. It exists because the two questions have different answers,
+    and #891 is about the narrow one: on esp_prog U1 and USB1 share three nets
+    and their overall order AGREES, while the two forming the USB differential
+    pair are CROSSED -- USB1 pad 2 = /D_N sits north of pad 3 = /D_P, and U1
+    pad 6 = /D_P sits north of pad 7 = /D_N. That parity cannot be fixed by
+    rotating either part; only a mirror or a via hop flips it. Reporting the
+    interface number alone hides the fact behind a third net, which is exactly
+    how run 25 shipped without seeing it.
     """
     pa, pb = state.parts.get(ref_a), state.parts.get(ref_b)
     if pa is None or pb is None:
         return None
     shared = sorted(set(pa.nets) & set(pb.nets) & set(state.net_refs))
+    if only_nets is not None:
+        keep = set(only_nets)
+        shared = [n for n in shared if n in keep]
     if len(shared) < 2:
         return None
     ax, ay = (pose_a[0], pose_a[1]) if pose_a is not None else (pa.x, pa.y)
@@ -122,7 +136,24 @@ def pair_metrics(state, ref_a: str, ref_b: str,
                                         nid)))}
     seq = [rank_b[nid] for nid in order_a]
     lis = _lis_length(seq)
-    return {'inversions': _merge_count(seq), 'lis': lis, 'nets': len(common)}
+    # #891. How many of the projections TIE, on either side. Both sorts above
+    # fall back to the net id when two pads land on the same coordinate along
+    # the channel axis, which is deterministic but arbitrary: it invents an
+    # order the geometry does not have. Measured on the tracked esp_prog, U1's
+    # /D_P and /D_N sit at the SAME y while the channel to USB1 runs along x,
+    # so both project to one point and the pair reported `inversions 0` --
+    # "AGREES" -- for a question that has no answer at this pose.
+    #
+    # Reported rather than resolved: the count is additive, every existing
+    # consumer of `inversions` / `lis` is unaffected, and a reader that cares
+    # about a two-net pair (where one tie makes the whole verdict meaningless)
+    # can say UNDETERMINED instead of inheriting the tie-break's opinion.
+    def _ties(esc):
+        proj = sorted(round(esc[nid][0] * vx + esc[nid][1] * vy, 6)
+                      for nid in common)
+        return sum(1 for i in range(1, len(proj)) if proj[i] == proj[i - 1])
+    return {'inversions': _merge_count(seq), 'lis': lis, 'nets': len(common),
+            'ties': _ties(ea) + _ties(eb)}
 
 
 def pair_inversions(state) -> Dict[Tuple[str, str], Dict]:

--- a/py_placer/placement/parser.py
+++ b/py_placer/placement/parser.py
@@ -43,6 +43,13 @@ _FP_ELEMENT_GAP = r'(?:(?!\(fp_|\(pad\b|\(layers?\b)[\s\S])*?'
 
 _CRTYD_LAYER = r'\(layer\s+"([FB])\.CrtYd"\)'
 _FAB_LAYER = r'\(layer\s+"([FB])\.Fab"\)'
+# #896. The LAST resort before the pad bbox, and the only drawn geometry a
+# hand-rolled library may carry at all: on esp_prog (OLIMEX) not one of 21
+# footprints draws a courtyard and six -- CON1, CON2, U1, U2, Q1, Q2 -- draw no
+# .Fab either, so silk is their only body. Read through the same
+# `_courtyard_points_by_side`, so `_FP_ELEMENT_GAP` protects it too; a
+# hand-written silk regex is exactly how #456 item 3 comes back.
+_SILK_LAYER = r'\(layer\s+"([FB])\.SilkS"\)'
 _NUM = r'([\d.eE+-]+)'
 
 
@@ -190,6 +197,31 @@ def extract_fab_sides(pcb_file: str) -> Dict[str, Dict[str, Bbox]]:
         if '.Fab"' not in fp_text:
             continue
         by_side = _courtyard_points_by_side(fp_text, _FAB_LAYER)
+        if by_side:
+            result[ref] = {side: _bbox(pts) for side, pts in by_side.items()}
+    return result
+
+
+def extract_silk_sides(pcb_file: str) -> Dict[str, Dict[str, Bbox]]:
+    """Per-side F/B.SilkS bboxes -- `extract_fab_sides`'s sibling (#896).
+
+    THIS IS NOT A BODY ON ITS OWN, and callers must not treat it as one. On a
+    stock KiCad footprint silk is a pair of clipped side ticks that bracket the
+    pads on one axis and are cut away on the other: measured on esp_prog, all 10
+    footprints drawing both fab and silk have a silk bbox NARROWER than the fab
+    body along the pad axis (Y1: 0.508mm against a 3.200mm body) and WIDER
+    across it. There is no offset that reconciles the two -- the sign of the
+    error differs per axis -- which is why `placement.body` unions this with the
+    pad bbox rather than substituting it, and why nothing here applies an
+    expansion. `placement.body.body_geometry` is the only intended consumer.
+    """
+    with open(pcb_file, 'r', encoding='utf-8') as f:
+        content = f.read()
+    result: Dict[str, Dict[str, Bbox]] = {}
+    for ref, fp_text in _footprint_blocks(content):
+        if '.SilkS"' not in fp_text:
+            continue
+        by_side = _courtyard_points_by_side(fp_text, _SILK_LAYER)
         if by_side:
             result[ref] = {side: _bbox(pts) for side, pts in by_side.items()}
     return result

--- a/py_tools/board_brief.py
+++ b/py_tools/board_brief.py
@@ -336,27 +336,37 @@ def state_section(pcb, pcb_file, skipped):
 def parts_section(pcb, pcb_file, skipped):
     """Per part: what an author needs to decide where it goes.
 
-    Size comes from the courtyard where the footprint has one and the pad
-    bounding box where it does not -- and `courtyard` says which, because a
-    pad bbox carries NO courtyard margin and treating the two alike is how a
-    part gets seated tighter than its own footprint allows (the quench warns
-    about this on every board that needs it).
+    Size comes from `placement.body` (#896), whose ladder is courtyard, else
+    the drawn .Fab body, else silk unioned with the pad bbox, else the pad
+    bbox -- and `extent_source` says WHICH, because a pad bbox carries no
+    courtyard margin and treating the two alike is how a part gets seated
+    tighter than its own footprint allows (the quench warns about this on
+    every board that needs it).
+
+    It reads the model rather than its own ladder because this table and the
+    body-overlap channel used to answer the same question differently: this
+    one went courtyard-or-pad-bbox and never looked at .Fab, so on a
+    courtyard-less library it reported a pad box for a part the assembly audit
+    was grading as a drawn housing.
     """
+    from placement.body import board_bodies
     from placement.legality import rotate_local_bounds
-    from placement.parser import extract_courtyard_bboxes
-    from placement.utility import compute_footprint_bbox_local
+    from placement.utility import compute_footprint_bbox_local  # noqa: F401
     from placement.part_class import classify_part
     from placement.escape import lane_pitch  # noqa: F401 (documents origin)
 
-    cy = _safe('parts.courtyards', extract_courtyard_bboxes, skipped,
-               pcb_file) or {}
+    bodies = _safe('parts.bodies', board_bodies, skipped, pcb, pcb_file) or {}
     out = {}
     for ref, fp in sorted(pcb.footprints.items()):
         pads = fp.pads or []
-        box = cy.get(ref)
-        if box:
-            src = 'courtyard'
-        elif pads:
+        geom = bodies.get(ref)
+        # OCCUPANCY, not the bare body: this extent is fed to `--fit WxH` and
+        # to grow_board's utilisation, both of which ask what the part takes
+        # up rather than what its plastic measures. A .Fab body is routinely
+        # narrower than the pads it sits between.
+        box = geom.occupancy_local if geom is not None else None
+        src = geom.source if geom is not None else 'none'
+        if box is None and pads:
             # compute_footprint_bbox_local, NOT max(global_x) - min(global_x).
             # The pad-CENTRE span omits the pads' own size, so a two-pad part
             # measures ZERO width along its pad axis: esp_prog C1 (an 0603)
@@ -365,9 +375,6 @@ def parts_section(pcb, pcb_file, skipped):
             # board -- a number grow_board's utilisation is computed from.
             box = compute_footprint_bbox_local(fp)
             src = 'pad_bbox'
-        else:
-            box = None
-            src = 'none'
         if box is None:
             w = h = 0.0
             rect = None

--- a/py_tools/board_context.py
+++ b/py_tools/board_context.py
@@ -182,6 +182,62 @@ def pads_by_face(pcb_data, clearance: float, track_width: float):
 # The sheet
 # ---------------------------------------------------------------------------
 
+def mating_faces(pcb_data, pcb_file: str, clearance: float):
+    """`{ref: {edge, dist_mm, interior, overhang_mm}}` for connector-family
+    parts.
+
+    The edge and distance come from `render_placement.connector_edge_facts`,
+    which is the list the review sheet already prints -- deliberately broader
+    than `part_class`'s gating classes, because run 23 seated four generic
+    connectors mid-board and no instrument said so.
+
+    `overhang_mm` is measured here because that function CLAMPS its distance at
+    zero (`max(0.0, dist)`), which is right for "how far from the edge" and
+    loses the sign for "how far PAST it" -- and a receptacle's overhang is the
+    fact a mating face is about. USB1 on esp_prog overhangs; a header does not.
+    """
+    import render_placement as RP
+    from placement.body import board_bodies
+    from placement.legality import rotate_local_bounds
+    from placement.part_class import INTERIOR_AFFINITY_MM
+    model = RP.PlacementModel(pcb_data, pcb_file,
+                              quench_kwargs={'clearance': clearance})
+    if model.state is None:
+        return {}
+    bounds = getattr(pcb_data.board_info, 'board_bounds', None)
+    if not bounds:
+        return {}
+    bodies = board_bodies(pcb_data, pcb_file)
+    out = {}
+    # WHICH parts are connector-family is `connector_edge_facts`' question and
+    # it keeps it -- a heuristic broader than part_class's gating classes,
+    # because run 23 seated four generic connectors mid-board and nothing said
+    # so. WHERE the part's edge is, this measures from the BODY model rather
+    # than reusing that function's number, because it reads `model.rect` --
+    # the quench's pad-box ladder, which this PR deliberately does not
+    # convert. Reusing it would put two different geometries on one sheet,
+    # which is what #896 exists to stop: measured on esp_prog, USB1's pad box
+    # sits 0.49mm inside the west edge while its drawn .Fab body overhangs it,
+    # and the overhang is the fact a mating face is about.
+    for ref, _cls, _edge, _dist, _interior in RP.connector_edge_facts(model):
+        geom = bodies.get(ref)
+        fp = pcb_data.footprints.get(ref)
+        if geom is None or geom.occupancy_local is None or fp is None:
+            continue
+        x0, y0, x1, y1 = rotate_local_bounds(*geom.occupancy_local,
+                                             fp.rotation or 0.0)
+        rect = (fp.x + x0, fp.y + y0, fp.x + x1, fp.y + y1)
+        dists = {'W': rect[0] - bounds[0], 'N': rect[1] - bounds[1],
+                 'E': bounds[2] - rect[2], 'S': bounds[3] - rect[3]}
+        edge, dist = min(dists.items(), key=lambda kv: kv[1])
+        out[ref] = {'edge': edge,
+                    'dist_mm': round(max(0.0, dist), 3),
+                    'interior': bool(dist > INTERIOR_AFFINITY_MM),
+                    'overhang_mm': round(max(0.0, -dist), 3),
+                    'class': _cls, 'basis': geom.source}
+    return out
+
+
 def build_context(pcb_data, pcb_file: str, *, clearance: float,
                   track_width: float, brief=None) -> Dict[str, object]:
     """The whole document, as data. `format_md` renders it."""
@@ -229,6 +285,11 @@ def build_context(pcb_data, pcb_file: str, *, clearance: float,
         for row in (getattr(brief, 'raw', None) or {}).get('interfaces', []):
             if isinstance(row, dict) and row.get('ref') and row.get('role'):
                 declared_roles[row['ref']] = row['role']
+
+    try:
+        faces_out = mating_faces(pcb_data, pcb_file, clearance)
+    except Exception:                                        # noqa: BLE001
+        faces_out = {}
 
     parts = []
     for ref, fp in sorted((pcb_data.footprints or {}).items()):
@@ -287,6 +348,7 @@ def build_context(pcb_data, pcb_file: str, *, clearance: float,
             'dnp': bool(getattr(fp, 'dnp', False)),
             'pads_by_face': side_pads,
             'partners': [{'ref': r, 'shared_nets': n} for n, r in partners],
+            'mating': faces_out.get(ref),
             'serves': ({'ref': tethers[ref][0],
                         'distance_mm': round(tethers[ref][1], 3)}
                        if ref in tethers and tethers[ref][0] else None),
@@ -314,6 +376,11 @@ def build_context(pcb_data, pcb_file: str, *, clearance: float,
                           '(rejects 2-terminal resonators)',
             'role': 'inferred here from footprint / prefix / value; the '
                     'board carries no datasheet or 3D-model field to cite',
+            'mating': 'which parts count as connectors: '
+                      'render_placement.connector_edge_facts. Where the edge '
+                      'is: measured from the placement.body occupancy rect, '
+                      'because that function reads the quench pad-box ladder '
+                      'and would put two geometries on one sheet',
         },
     }
 
@@ -484,6 +551,15 @@ def format_md(doc) -> str:
                      f"`{p['role']['contradicts_inference']}`. The brief "
                      f"wins, and the disagreement is printed rather than "
                      f"resolved silently.")
+        if p.get('mating'):
+            m = p['mating']
+            L.append('')
+            L.append(f"Mating face **{m['edge']}**, {m['dist_mm']}mm from that "
+                     f"edge"
+                     + (f", overhanging it by {m['overhang_mm']}mm"
+                        if m['overhang_mm'] > 0 else '')
+                     + ('  --  INTERIOR for a connector, which a reviewer '
+                        'should explain' if m['interior'] else ''))
         if p['serves']:
             L.append('')
             L.append(f"Serves **{p['serves']['ref']}** "

--- a/py_tools/board_context.py
+++ b/py_tools/board_context.py
@@ -1,0 +1,643 @@
+#!/usr/bin/env python3
+"""#891: the component-context sheet -- what a model needs to reason about a
+layout, printed once, for a reader.
+
+WHY THIS EXISTS
+---------------
+The model is the only thing in the chain that can reason about a layout: which
+pin row faces which connector, where a regulator's input and output sit
+relative to their sources, whether a pair's pin order crosses. It cannot do
+that from what the tools emit. Nothing printed, per part, the package and body
+size, each pad with its net and pin function, which other parts each net
+reaches, and which SIDE of the part those partners are on.
+
+Run 25 paid for it exactly once and completely. USB1 pad 2 = /D_N is north of
+pad 3 = /D_P, while U1 pad 6 = /D_P is north of pad 7 = /D_N: the pair is
+polarity-crossed at every rotation of U1, because parity cannot be flipped by
+rotation -- only by a mirror or a via hop. That single fact decided the board's
+only open clause. It was visible in a throwaway probe the teammate wrote by
+hand, read by nobody, and rediscovered after routing.
+
+WHAT IT IS NOT
+--------------
+It is an ASSEMBLER, not a new engine. Every number here is computed by the
+function that already owns it, and the ones that matter say so on the sheet:
+
+    body extent + source   placement.body            (#896's one model)
+    pads by board face     placement.escape.assign_faces  (#850's one rule)
+    pin-order agreement    placement.pair_order.pair_metrics
+    part class             placement.part_class.classify_part
+    decap partner          placement.groups (_elect_tethers / decap_populations)
+    diff pairs             list_nets.find_differential_pairs (resonator-safe)
+    net classes            list_nets.net_class_memberships
+    floors                 list_nets.board_floor_knobs
+
+Two rules it obeys, both from #711's design brief:
+
+* **Every derived fact carries its source.** A role read off a footprint name
+  and a role declared in a brief are different claims and are printed as such.
+* **"unknown" is a first-class answer.** Looked-and-could-not-tell is printed
+  apart from nobody-looked, and neither is ever guessed.
+
+THE ROLE COLUMN, SCOPED HONESTLY
+--------------------------------
+The parser reads a footprint's `Value` on both paths, but there is NO
+`Datasheet` field, no `Description`, and no `(model ...)` path anywhere in
+`PCBData`. So a role here cannot cite a datasheet, and this tool does not
+pretend to: it infers from what the board actually carries -- footprint name,
+reference prefix, `pinfunction`/`pintype`, copper pad count and geometry, net
+names -- and prints `unknown` where that runs out. The datasheet pass stays
+where it already lives, in the skill layer (`/analyze-power-nets`,
+`/identify-diff-pairs`), and a `--brief` declaration outranks any inference and
+is flagged when the two disagree.
+"""
+from __future__ import annotations
+
+import _path  # noqa: F401
+import argparse
+import contextlib
+import json
+import os
+import sys
+from typing import Dict, List, Optional
+
+SCHEMA = 1
+
+
+# ---------------------------------------------------------------------------
+# Roles. Deliberately NOT part of `part_class.classify_part`.
+#
+# `grade_body_overlap._waiver_for` branches on that classifier's `.name`
+# against its marker and edge tables, so adding a role vocabulary there would
+# silently change waivers on the body-overlap channel. These live beside it and
+# read it, never inside it.
+# ---------------------------------------------------------------------------
+
+#: (role, evidence-kind) by footprint-name substring. Lower-cased match.
+_ROLE_FP = (
+    ('crystal', ('xtal', 'crystal', 'resonator', 'oscillator')),
+    ('usb receptacle', ('usb_micro', 'usb-micro', 'usb_c', 'usb_b', 'usb_a',
+                        'uicro')),
+    ('pin header', ('pinheader', 'hn1x', 'socket_strip', 'header')),
+    ('npn/pnp transistor', ('sot23', 'sot-23', 'sot323', 'to92')),
+    ('regulator', ('sot89', 'sot-89', 'sot223', 'to252', 'dpak')),
+    ('mounting hole', ('mountinghole',)),
+)
+
+#: role by reference prefix, used only when nothing stronger fired.
+_ROLE_PREFIX = {
+    'C': 'capacitor', 'R': 'resistor', 'L': 'inductor', 'D': 'diode',
+    'Q': 'transistor', 'U': 'integrated circuit', 'Y': 'crystal',
+    'X': 'crystal', 'J': 'connector', 'SW': 'switch', 'FB': 'ferrite bead',
+    'TP': 'test point', 'FID': 'fiducial', 'LED': 'led',
+}
+
+
+def _prefix(ref: str) -> str:
+    out = ''
+    for ch in ref:
+        if ch.isalpha() or ch in '#*':
+            out += ch
+        else:
+            break
+    return out.upper()
+
+
+def infer_role(fp, ref: str, cls_name: Optional[str]) -> Dict[str, object]:
+    """`{'role', 'source', 'evidence'}` -- or role `'unknown'`.
+
+    Ordered strongest-first, and each rung names itself. `unknown` is returned
+    rather than a prefix guess when the reference carries no convention this
+    table knows: "I looked and could not tell" is a different statement from a
+    low-confidence guess, and a reader who cannot tell them apart will trust
+    the guess.
+    """
+    name = (getattr(fp, 'footprint_name', '') or '').lower()
+    value = (getattr(fp, 'value', '') or '').strip()
+    pref = _prefix(ref)
+
+    if cls_name in ('mount_hole', 'fiducial', 'testpoint', 'edge_receptacle',
+                    'edge_actuator'):
+        return {'role': cls_name.replace('_', ' '), 'source': 'part_class',
+                'evidence': [f'placement.part_class says {cls_name}']}
+    for role, keys in _ROLE_FP:
+        hit = next((k for k in keys if k in name), None)
+        if hit:
+            return {'role': role, 'source': 'footprint',
+                    'evidence': [f'footprint name contains {hit!r}']}
+    if pref in _ROLE_PREFIX:
+        ev = [f'reference prefix {pref!r} (convention only)']
+        if value:
+            ev.append(f'value {value!r}')
+        return {'role': _ROLE_PREFIX[pref], 'source': 'ref_prefix',
+                'evidence': ev}
+    return {'role': 'unknown', 'source': 'looked',
+            'evidence': [f'footprint {name!r}, value {value!r}, prefix '
+                         f'{pref!r} match no rule here']}
+
+
+# ---------------------------------------------------------------------------
+# Faces
+# ---------------------------------------------------------------------------
+
+def pads_by_face(pcb_data, clearance: float, track_width: float):
+    """`{ref: {face: [pad, ...]}}` at each part's CURRENT pose.
+
+    Calls `escape.assign_faces`, the one face rule (#850), rather than
+    re-deriving one: three copies of that loop existed and each PAIRED the pad
+    box and the part box differently, which on one corpus board made all 244
+    pads read interior. `interior` collects the pads that escape through no
+    face -- they need a via, not a lane.
+    """
+    from placement.escape import assign_faces, board_copper_geometry
+    from placement.escape import _part_rect        # noqa: PLC2701
+    try:
+        obstruction = board_copper_geometry(pcb_data, clearance)
+    except Exception:                                        # noqa: BLE001
+        obstruction = {}
+    lane = track_width + clearance
+    out: Dict[str, Dict[str, List]] = {}
+    for ref, fp in (pcb_data.footprints or {}).items():
+        own = obstruction.get(ref)
+        if own is None and not (fp.pads or ()):
+            # A pad-less block (a logo, a panel tab): `_part_rect` is a
+            # min/max over pad centres and raises on an empty set. It has no
+            # face to escape through either, so skipping is the answer rather
+            # than a fabricated box.
+            continue
+        rect = own.rect if own is not None else _part_rect(fp)
+        try:
+            asg = assign_faces(fp, own, lane_mm=lane, fallback_rect=rect,
+                               clearance=clearance, track_width=track_width)
+        except Exception:                                    # noqa: BLE001
+            continue
+        by: Dict[str, List] = {}
+        for pad, face in asg.faces:
+            by.setdefault(face or 'interior', []).append(pad)
+        out[ref] = by
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The sheet
+# ---------------------------------------------------------------------------
+
+def build_context(pcb_data, pcb_file: str, *, clearance: float,
+                  track_width: float, brief=None) -> Dict[str, object]:
+    """The whole document, as data. `format_md` renders it."""
+    from placement.body import board_bodies
+    from placement.legality import footprint_side, rotate_local_bounds
+    from placement.part_class import classify_part
+    import list_nets
+
+    bodies = board_bodies(pcb_data, pcb_file)
+    faces = pads_by_face(pcb_data, clearance, track_width)
+
+    # net_id -> the refs it reaches, and net_id -> name.
+    net_refs: Dict[int, set] = {}
+    net_name: Dict[int, str] = {}
+    for ref, fp in (pcb_data.footprints or {}).items():
+        for pad in (fp.pads or ()):
+            nid = getattr(pad, 'net_id', 0) or 0
+            if not nid:
+                continue
+            net_refs.setdefault(nid, set()).add(ref)
+            net_name.setdefault(nid, getattr(pad, 'net_name', '') or '')
+
+    try:
+        pairs = list_nets.find_differential_pairs(pcb_data)
+    except Exception:                                        # noqa: BLE001
+        pairs = {}
+    # `serves` is the tether election RESTRICTED to the near population.
+    # The raw election is radius-free and always names SOMETHING: on esp_prog
+    # it puts C1 17.24mm from the USB socket, which is not a fact about what
+    # C1 serves. #902 is the issue for the election itself (a 3-pad regulator
+    # can never be a target, `DECAP_MIN_IC_PADS = 4`); until then this column
+    # reports only what is within the module's own radius and says nothing
+    # otherwise.
+    tethers = {}
+    try:
+        from placement.groups import DECAP_RADIUS_MM
+        for cap, ic, dist in _elect(pcb_data):
+            if ic and dist is not None and dist <= DECAP_RADIUS_MM:
+                tethers[cap] = (ic, dist)
+    except Exception:                                        # noqa: BLE001
+        tethers = {}
+
+    declared_roles = {}
+    if brief is not None:
+        for row in (getattr(brief, 'raw', None) or {}).get('interfaces', []):
+            if isinstance(row, dict) and row.get('ref') and row.get('role'):
+                declared_roles[row['ref']] = row['role']
+
+    parts = []
+    for ref, fp in sorted((pcb_data.footprints or {}).items()):
+        geom = bodies.get(ref)
+        cls = classify_part(fp, ref)
+        role = infer_role(fp, ref, getattr(cls, 'name', None))
+        if ref in declared_roles:
+            inferred = role['role']
+            role = {'role': declared_roles[ref], 'source': 'brief',
+                    'evidence': [f'declared in the design brief']}
+            if inferred not in ('unknown', declared_roles[ref]):
+                role['contradicts_inference'] = inferred
+
+        extent = None
+        if geom is not None and geom.body_local is not None:
+            x0, y0, x1, y1 = rotate_local_bounds(*geom.body_local,
+                                                 fp.rotation or 0.0)
+            extent = [round(x1 - x0, 3), round(y1 - y0, 3)]
+
+        side_pads = {}
+        for face, pads in sorted((faces.get(ref) or {}).items()):
+            side_pads[face] = [{
+                'pad': p.pad_number,
+                'net': getattr(p, 'net_name', '') or '',
+                'pinfunction': getattr(p, 'pinfunction', '') or '',
+                'pintype': getattr(p, 'pintype', '') or '',
+                'reaches': sorted(net_refs.get(
+                    getattr(p, 'net_id', 0) or 0, set()) - {ref}),
+            } for p in pads]
+
+        weights: Dict[str, set] = {}
+        for pad in (fp.pads or ()):
+            nid = getattr(pad, 'net_id', 0) or 0
+            for other in net_refs.get(nid, set()):
+                if other != ref:
+                    weights.setdefault(other, set()).add(nid)
+        partners = sorted(((len(v), k) for k, v in weights.items()),
+                          reverse=True)
+
+        parts.append({
+            'ref': ref,
+            'footprint': getattr(fp, 'footprint_name', '') or '',
+            'value': getattr(fp, 'value', '') or '',
+            'role': role,
+            'part_class': getattr(cls, 'name', None),
+            'part_class_confidence': getattr(cls, 'confidence', None),
+            'body_mm': extent,
+            'body_source': (geom.source if geom is not None else 'none'),
+            'drawn_body_source': (geom.drawn_source if geom is not None
+                                  else 'none'),
+            'pads': len(fp.pads or ()),
+            'side': footprint_side(fp),
+            'at': [round(fp.x, 3), round(fp.y, 3),
+                   round(fp.rotation or 0.0, 3)],
+            'locked': bool(getattr(fp, 'locked', False)),
+            'dnp': bool(getattr(fp, 'dnp', False)),
+            'pads_by_face': side_pads,
+            'partners': [{'ref': r, 'shared_nets': n} for n, r in partners],
+            'serves': ({'ref': tethers[ref][0],
+                        'distance_mm': round(tethers[ref][1], 3)}
+                       if ref in tethers and tethers[ref][0] else None),
+        })
+
+    return {
+        'schema': SCHEMA,
+        'board': os.path.basename(pcb_file),
+        'bounds': list(pcb_data.board_info.board_bounds or ()),
+        'copper_layers': list(pcb_data.board_info.copper_layers or ()),
+        'floors': {'clearance': clearance, 'track_width': track_width},
+        # `find_differential_pairs` returns (positive, negative) tuples.
+        'diff_pairs': [list(t) for t in sorted(pairs or ())],
+        'parts': parts,
+        'pin_order': pin_order_rows(pcb_data, pcb_file, clearance),
+        'sources': {
+            'body_mm / body_source': 'placement.body.board_bodies (#896)',
+            'pads_by_face': 'placement.escape.assign_faces (#850)',
+            'pin_order': 'placement.pair_order.pair_metrics',
+            'part_class': 'placement.part_class.classify_part',
+            'serves': 'placement.groups tether election '
+                      '(DECAP_MIN_IC_PADS = 4, so a 3-pad regulator can '
+                      'never be a target -- see #902)',
+            'diff_pairs': 'list_nets.find_differential_pairs '
+                          '(rejects 2-terminal resonators)',
+            'role': 'inferred here from footprint / prefix / value; the '
+                    'board carries no datasheet or 3D-model field to cite',
+        },
+    }
+
+
+def _elect(pcb_data):
+    from placement.groups import _elect_tethers      # noqa: PLC2701
+    return _elect_tethers(pcb_data)
+
+
+def _verdict(m):
+    """AGREES / CROSSED / UNDETERMINED.
+
+    A tie means two pads project to one point on the channel axis, so their
+    order is not a fact about the board -- `pair_metrics`' deterministic
+    tie-break invents one. On a two-net pair a single tie makes the verdict
+    meaningless, which is why UNDETERMINED wins over the inversion count
+    rather than being a footnote to it: the tracked esp_prog reports exactly
+    this for the USB pair at U1's current rotation, and calling it AGREES
+    would tell a reader the polarity is fine when nothing measured it.
+    """
+    if m.get('ties'):
+        return 'UNDETERMINED (pads tie on the channel axis)'
+    return 'AGREES' if not m.get('inversions') else 'CROSSED'
+
+
+def pin_order_rows(pcb_data, pcb_file: str, clearance: float):
+    """Pin-order agreement for every connected part pair sharing >= 2 nets.
+
+    `pair_order.pair_inversions` is the implementation and the argument
+    (Supowit 1987; Leiserson & Pinter 1983): `inversions` is a LOWER BOUND on
+    the crossings any router must pay, and `lis` is the largest subset routable
+    with none. This prints its verdict; it does not re-derive it.
+    """
+    try:
+        from placement.pair_order import pair_inversions
+        # `PlacementModel` builds the QuenchState, resolving the board's own
+        # floors and handling the no-outline fallback. Constructing one here
+        # would be a second copy of a ten-argument block that has already
+        # drifted once (render vs place_optimize, before #431 fixed it).
+        from render_placement import PlacementModel
+        model = PlacementModel(pcb_data, pcb_file,
+                               quench_kwargs={'clearance': clearance})
+        if model.state is None:
+            return {'error': 'the quench state could not be built', 'rows': []}
+        got = pair_inversions(model.state)
+    except Exception as exc:                                 # noqa: BLE001
+        return {'error': f'{type(exc).__name__}: {exc}', 'rows': []}
+    rows = []
+    for (a, b), m in sorted(got.items()):
+        rows.append({
+            'a': a, 'b': b, 'nets': m.get('nets'), 'scope': 'interface',
+            'inversions': m.get('inversions'), 'lis': m.get('lis'),
+            'ties': m.get('ties', 0), 'verdict': _verdict(m),
+        })
+
+    # PAIR-SCOPED rows, and they are the point. A differential pair's polarity
+    # parity is a two-net question, and asking it as part of the whole
+    # interface hides it: on esp_prog U1<->USB1 shares three nets and AGREES
+    # overall while /D_P and /D_N alone are CROSSED. That fact decided run
+    # 25's only open clause and was found after routing.
+    try:
+        from placement.pair_order import pair_metrics
+        import list_nets
+        name_to_id = {}
+        for ref, fp in (pcb_data.footprints or {}).items():
+            for pad in (fp.pads or ()):
+                nm = getattr(pad, 'net_name', '') or ''
+                if nm:
+                    name_to_id.setdefault(nm, getattr(pad, 'net_id', 0) or 0)
+        for pos, neg in (list_nets.find_differential_pairs(pcb_data) or ()):
+            ids = [name_to_id.get(pos), name_to_id.get(neg)]
+            if None in ids or 0 in ids:
+                continue
+            carriers = sorted({r for r, fp in (pcb_data.footprints or {}).items()
+                               if any((getattr(q, 'net_id', 0) or 0) in ids
+                                      for q in (fp.pads or ()))})
+            for i, a in enumerate(carriers):
+                for b in carriers[i + 1:]:
+                    m = pair_metrics(model.state, a, b, only_nets=ids)
+                    if m is None:
+                        continue
+                    rows.append({
+                        'a': a, 'b': b, 'nets': m['nets'],
+                        'scope': f'pair {pos}/{neg}',
+                        'inversions': m['inversions'], 'lis': m['lis'],
+                        'ties': m.get('ties', 0), 'verdict': _verdict(m),
+                    })
+    except Exception as exc:                                 # noqa: BLE001
+        rows.append({'a': '-', 'b': '-', 'nets': 0, 'scope': 'pair',
+                     'inversions': None, 'lis': None,
+                     'verdict': f'NOT MEASURED ({type(exc).__name__})'})
+
+    # Pair rows first: they are the narrow, unfixable-by-rotation claim.
+    rows.sort(key=lambda r: (r['scope'] == 'interface',
+                             -(r['inversions'] or 0), r['a'], r['b']))
+    return {'error': None, 'rows': rows}
+
+
+def format_md(doc) -> str:
+    """The sheet, for a reader. Markdown because the audience is a model and a
+    human reading the same page, and a table is how a pin row reads."""
+    L = []
+    b = doc['bounds']
+    L.append(f"# Component context -- {doc['board']}")
+    L.append('')
+    if b:
+        L.append(f"Board {round(b[2] - b[0], 2)} x {round(b[3] - b[1], 2)} mm, "
+                 f"layers {', '.join(doc['copper_layers'])}, floors "
+                 f"clearance {doc['floors']['clearance']}mm / track "
+                 f"{doc['floors']['track_width']}mm.")
+    if doc.get('panels_error'):
+        L.append(f"PANELS NOT WRITTEN ({doc['panels_error']}).")
+        L.append('')
+    if doc['diff_pairs']:
+        L.append('Differential pairs: '
+                 + ', '.join('/'.join(t) for t in doc['diff_pairs']) + '.')
+    L.append('')
+    L.append('Every derived column names its source; `unknown` means the tool '
+             'looked and could not tell, which is not the same as absent. '
+             'See the SOURCES section at the end.')
+    L.append('')
+
+    po = doc['pin_order']
+    L.append('## Pin-order agreement')
+    L.append('')
+    if po.get('error'):
+        L.append(f"NOT MEASURED ({po['error']}) -- this sheet cannot say "
+                 f"whether any pair's order crosses.")
+    elif not po['rows']:
+        L.append('No two parts share 2 or more nets, so there is no pin order '
+                 'to agree about.')
+    else:
+        L.append('A CROSSED pair forces at least `inversions` crossings on '
+                 'ANY router: on a 2-layer board that is a via per net or '
+                 'back-side copper. Rotation cannot fix it -- parity flips '
+                 'only under a mirror.')
+        L.append('')
+        L.append('| A | B | scope | nets | inversions | max planar | '
+                 'verdict |')
+        L.append('|---|---|---|---|---|---|---|')
+        for r in po['rows']:
+            L.append(f"| {r['a']} | {r['b']} | {r['scope']} | {r['nets']} | "
+                     f"{r['inversions']} | {r['lis']} | {r['verdict']} |")
+    L.append('')
+
+    L.append('## Parts')
+    L.append('')
+    for p in doc['parts']:
+        body = (f"{p['body_mm'][0]} x {p['body_mm'][1]} mm"
+                if p['body_mm'] else 'no body geometry')
+        L.append(f"### {p['ref']}  --  {p['role']['role']}"
+                 f"  ({p['role']['source']})")
+        L.append('')
+        L.append(f"`{p['footprint']}`"
+                 + (f"  value `{p['value']}`" if p['value'] else '')
+                 + f"  --  body {body} from **{p['body_source']}**, "
+                 f"{p['pads']} pad(s), side {p['side']}, "
+                 f"pose ({p['at'][0]}, {p['at'][1]}, {p['at'][2]}deg)"
+                 + ('  LOCKED' if p['locked'] else '')
+                 + ('  DNP' if p['dnp'] else ''))
+        if p.get('panel'):
+            L.append('')
+            L.append(f"![{p['ref']}]({os.path.basename(p['panel'])})")
+        if p['role'].get('contradicts_inference'):
+            L.append('')
+            L.append(f"> The brief declares this a "
+                     f"`{p['role']['role']}`; inference off the board says "
+                     f"`{p['role']['contradicts_inference']}`. The brief "
+                     f"wins, and the disagreement is printed rather than "
+                     f"resolved silently.")
+        if p['serves']:
+            L.append('')
+            L.append(f"Serves **{p['serves']['ref']}** "
+                     f"({p['serves']['distance_mm']}mm away).")
+        if p['pads_by_face']:
+            L.append('')
+            for face, pads in p['pads_by_face'].items():
+                bits = []
+                for q in pads:
+                    t = f"{q['pad']} {q['net'] or '-'}"
+                    if q['pinfunction']:
+                        t += f" ({q['pinfunction']})"
+                    if q['reaches']:
+                        t += ' -> ' + ' '.join(q['reaches'])
+                    bits.append(t)
+                L.append(f"- **{face}**: " + ' | '.join(bits))
+        if p['partners']:
+            L.append('')
+            L.append('- partners by shared nets: '
+                     + ', '.join(f"{q['ref']} ({q['shared_nets']})"
+                                 for q in p['partners'][:8]))
+        L.append('')
+
+    L.append('## Sources')
+    L.append('')
+    for k, v in sorted(doc['sources'].items()):
+        L.append(f"- **{k}** -- {v}")
+    L.append('')
+    return '\n'.join(L)
+
+
+def write_panels(pcb_data, pcb_file: str, out_dir: str, refs,
+                 clearance: float):
+    """One cropped PNG per part, through `render_placement`'s own machinery.
+
+    `PanelSpec` + `render_panel` + `union_view` are the same three calls the
+    renderer makes for a `--zoom-group` crop; nothing about the drawing is
+    re-implemented here, so a panel on this sheet and a panel on a review
+    sheet cannot disagree about what the board looks like.
+
+    Returns `{ref: path}` for the panels actually written.
+    """
+    import render_placement as RP
+    os.makedirs(out_dir, exist_ok=True)
+    model = RP.PlacementModel(pcb_data, pcb_file,
+                              quench_kwargs={'clearance': clearance})
+    if model.state is None:
+        return {}
+    out = {}
+    for ref in refs:
+        rect = model.rect(ref)
+        if rect is None:
+            continue
+        spec = RP.PanelSpec(model, view=RP.union_view([rect], 2.0),
+                            side=model.side(ref), prominent={ref},
+                            moves=(), hot_nets=(), blocker_nets=(),
+                            pick_nets=(), label=ref,
+                            opts=dict(ratsnest=True), defects=())
+        img = RP.render_panel(spec, size=700, supersample=2)
+        # A ref can carry characters a filesystem will not (`Ref*~2`,
+        # `#uuid`), so the name is sanitised and the MAP is what the sheet
+        # references -- never a name reconstructed from the ref.
+        safe = ''.join(c if (c.isalnum() or c in '-_.') else '_'
+                       for c in ref) or 'part'
+        path = os.path.join(out_dir, f'{safe}.png')
+        img.save(path)
+        out[ref] = path
+    return out
+
+
+def build_parser():
+    p = argparse.ArgumentParser(
+        description='#891: a per-part context sheet a model can reason from.')
+    p.add_argument('board', help='the .kicad_pcb to read')
+    g = p.add_mutually_exclusive_group()
+    g.add_argument('--md', action='store_true',
+                   help='markdown to stdout (the default)')
+    g.add_argument('--json', action='store_true',
+                   help='the same document as JSON on stdout')
+    p.add_argument('-o', '--output', help='write to this file instead')
+    p.add_argument('--clearance', type=float, default=None,
+                   help="override the board's own clearance floor")
+    p.add_argument('--track-width', type=float, default=None,
+                   help="override the board's own track width")
+    p.add_argument('--panels', metavar='DIR',
+                   help='write one cropped PNG per part into DIR and '
+                        'reference them from the sheet')
+    try:
+        from placement.cli_gates import add_brief_arg
+        add_brief_arg(p)
+    except Exception:                                        # noqa: BLE001
+        pass
+    return p
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    from kicad_parser import parse_kicad_pcb
+    import list_nets
+    import routing_defaults as defaults
+
+    pcb = parse_kicad_pcb(args.board)
+    clr, _edge, _knobs = list_nets.board_floor_knobs(
+        args.board, clearance=args.clearance)
+    tw = args.track_width
+    if tw is None:
+        tw = (list_nets.board_default_netclass_param(
+            args.board, 'track_width') or defaults.TRACK_WIDTH)
+
+    brief = None
+    try:
+        from placement.cli_gates import load_brief_or_exit
+        brief, _bpath, code = load_brief_or_exit(args, args.board)
+        if code:
+            return code
+    except Exception:                                        # noqa: BLE001
+        brief = None
+
+    # Everything the LIBRARIES print goes to stderr while the document is
+    # built. `cli_banner` is not the only thing that can poison a bare-JSON
+    # stdout: `parser.warn_missing_courtyards` prints to stdout from inside
+    # the quench, and on esp_prog -- 18 courtyard-less parts -- that alone
+    # made `--json` a JSONDecodeError at char 2. The warning is worth keeping;
+    # it just is not part of the document.
+    with contextlib.redirect_stdout(sys.stderr):
+        doc = build_context(pcb, args.board, clearance=clr, track_width=tw,
+                            brief=brief)
+    if args.panels:
+        try:
+            with contextlib.redirect_stdout(sys.stderr):
+                panels = write_panels(pcb, args.board, args.panels,
+                                      [p['ref'] for p in doc['parts']], clr)
+        except Exception as exc:                             # noqa: BLE001
+            # Named, never silent: a sheet whose pictures failed must say so,
+            # or a reader concludes the parts have nothing worth showing.
+            doc['panels_error'] = f'{type(exc).__name__}: {exc}'
+            panels = {}
+        for part in doc['parts']:
+            part['panel'] = panels.get(part['ref'])
+        doc['panels_written'] = len(panels)
+    text = (json.dumps(doc, indent=1, sort_keys=True) if args.json
+            else format_md(doc))
+    if args.output:
+        with open(args.output, 'w', encoding='utf-8') as fh:
+            fh.write(text + '\n')
+        print(f'wrote {args.output}', file=sys.stderr)
+    else:
+        print(text)
+    return 0
+
+
+# NO cli_banner.install() here, deliberately -- `--json` writes a bare
+# document to stdout and a `CMD:` line ahead of it is a JSONDecodeError at
+# char 0. `board_brief.py` and `converge.py` make the same choice for the same
+# reason; converge's comment is the canonical statement of it.
+if __name__ == '__main__':
+    sys.exit(main())

--- a/py_tools/check_assembly.py
+++ b/py_tools/check_assembly.py
@@ -259,6 +259,7 @@ def main():
           + (f"  new-vs-baseline {len(new_advisory)}"
              if new_advisory is not None else ""))
     _cb_keys = {(q.a, q.b) for q in g['courtyard_blocking_pairs']}
+    _body_src = g.get('body_sources') or {}
     for q in g['pairs']:
         label = ('BLOCKING' if q.kind == 'pad_intersection'
                  else ('COURTYARD-BLOCKING'
@@ -271,7 +272,17 @@ def main():
         cont = ''
         if q.contained:
             cont = f"  CONTAINED {q.contained_frac:.0%}"
-        print(f"    {q.a} <-> {q.b}  {q.kind}  {q.area_mm2}mm2 "
+        # #896. Name the geometry the claim rests on. `kind` says which
+        # CHANNEL judged the pair; it does not say whether the body came from
+        # a drawn .Fab outline or from silkscreen, and those are claims of
+        # very different strength -- a silk body may be an assembly marking,
+        # which is why it never gates.
+        kind = q.kind
+        if kind == 'fab':
+            _sa, _sb = _body_src.get(q.a, ''), _body_src.get(q.b, '')
+            if 'silk' in (_sa, _sb):
+                kind = f'body({_sa}/{_sb})'
+        print(f"    {q.a} <-> {q.b}  {kind}  {q.area_mm2}mm2 "
               f"side {q.side}  {label}{cont}{star}")
         # Different-net pads touching is a short on top of the overlap. Say so
         # here rather than making a reader re-derive it from the board.
@@ -333,11 +344,31 @@ def main():
             print(f"    None of these BLOCK: each is a by-design containment "
                   f"(a marker or a board-sized container), which the corpus "
                   f"ships legitimately -- orangecrab FID2/J5 at 100%.")
+    # BODY COVERAGE (#896). Printed UNCONDITIONALLY, including the fully
+    # covered case: "which geometry was this board graded on" is a fact about
+    # every run, and a line that appears only when something is missing cannot
+    # tell a reader that a board was judged on silk rather than on drawn
+    # bodies. The mix comes from `grade_body_overlap`'s own `body_sources`, so
+    # the coverage claim and the geometry cannot drift apart.
+    _srcs = g.get('body_sources') or {}
+    _mix = {}
+    for _v in _srcs.values():
+        _mix[_v] = _mix.get(_v, 0) + 1
+    _judged = ', '.join(f"{_mix[k]} {k}" for k in ('fab', 'silk')
+                        if _mix.get(k))
+    print(f"  BODY COVERAGE: {len(_srcs)} of {len(pcb.footprints)} part(s) "
+          f"draw a body the containment channel can judge"
+          + (f" ({_judged})" if _judged else ""))
+    if _mix.get('silk'):
+        print(f"    A silk body is the LAST resort and never gates: a "
+              f"library may draw an assembly outline there rather than the "
+              f"part (esp_prog's SOT89 draws corner brackets 5.2mm apart "
+              f"around a 4.5mm part). Such pairs are reported, with their "
+              f"source, and excluded from the blocking channels.")
     if g['fab_unjudged']:
         _u = g['fab_unjudged_refs']
-        print(f"  BODY COVERAGE: {g['fab_unjudged']} of "
-              f"{len(pcb.footprints)} part(s) draw no .Fab outline, so the "
-              f"containment channel cannot judge them: "
+        print(f"    {g['fab_unjudged']} part(s) draw no body at all (no .Fab, "
+              f"no usable silk), so the channel cannot judge them: "
               + ', '.join(_u[:8]) + (' ...' if len(_u) > 8 else ''))
 
     # ASSEMBLY SIDES (#837). Report-only, and deliberately not a conjunct:

--- a/py_tools/render_placement.py
+++ b/py_tools/render_placement.py
@@ -246,6 +246,8 @@ def legality_findings(model) -> Dict[str, object]:
            'courtyard_overlap_pairs_refs': [],
            'courtyard_blocking_pairs_refs': [],
            'courtyard_overlap_mm2': 0.0,
+           'body_seam': None,
+           'body_sources': {},
            'cross_side_stacks': [],
            # None = the census ran. A string = it could NOT be built, and the
            # sheet/gate say NOT MEASURED rather than reporting "blocking: none"
@@ -408,6 +410,22 @@ def legality_findings(model) -> Dict[str, object]:
             # either list above.
             out['courtyard_overlap_mm2'] = round(sum(
                 q.area_mm2 for q in _g['pairs'] if q.kind == 'courtyard'), 4)
+            # #896. The tightest DRAWN-body seam, signed, with the geometry it
+            # rests on. The courtyard numbers above only ever speak about
+            # pairs that already OVERLAP, so a board a hair from a collision
+            # said nothing; run 25 shipped at 0.183mm (header plastic to an
+            # 0402 body) and no instrument produced that number. The source
+            # mix rides along because a seam between two silk markings is a
+            # weaker claim than one between two drawn .Fab bodies.
+            out['body_seam'] = _g.get('body_seam')
+            out['body_sources'] = dict(_g.get('body_sources') or {})
+            # Hang it on the model too: `draw_courtyards` needs it per ref and
+            # is called from seven places that have no business learning a new
+            # parameter -- the same reason #897 put `intent_waivers` here.
+            try:
+                model.body_sources = out['body_sources']
+            except Exception:                                # noqa: BLE001
+                pass
             # run-23 (ulx3s review): FRONT<->BACK stacks. Panels draw both
             # faces' outlines with only a ghost tint, so a battery holder
             # behind the buttons (BAT1/B4: 68.7mm2 of XY overlap, ZERO
@@ -758,7 +776,23 @@ def draw_courtyards(d, r, model, refs, *, side=None, color=None, dim=False,
         if ref in locked:
             col = C_LOCKED
         box = _rect_pts(r, rect)
-        d.rectangle(box, outline=col, width=_w(r, width_mm))
+        # #896. A body the model took from SILK is drawn DASHED, so a reviewer
+        # can see at a glance which outlines rest on a silkscreen marking
+        # rather than on drawn geometry -- the difference between the two is
+        # what made esp_prog's SOT89 look 5.2mm wide when the part is 4.5mm,
+        # and it is why a silk body never gates. A dash rather than a colour
+        # because the four colours here already carry side and lock state.
+        _src = (getattr(model, 'body_sources', None) or {}).get(ref)
+        _wpx = _w(r, width_mm)
+        if _src == 'silk':
+            _on, _off = max(3, _wpx * 4), max(3, _wpx * 3)
+            corners = [(box[0], box[1]), (box[2], box[1]),
+                       (box[2], box[3]), (box[0], box[3])]
+            for _i in range(4):
+                _dash(d, corners[_i], corners[(_i + 1) % 4], _on, _off,
+                      col, _wpx)
+        else:
+            d.rectangle(box, outline=col, width=_wpx)
         if ref in locked:      # hatch so "locked" reads without a legend
             d.line([box[0], box[1], box[2], box[3]], fill=col, width=_w(r, 0.06))
 
@@ -1132,6 +1166,27 @@ def write_review_sheet(path, panel_paths, fnd, conn_facts) -> None:
             + (f"  |  BLOCKING, past the floors ({len(cb)}): " + '  |  '.join(
                 f"{a}<->{b} {m}mm2/depth {dp}mm" for a, b, m, dp in cb)
                if cb else "  |  blocking, past the floors: none"))
+    # #896. The tightest seam, ALWAYS, because "how close is the closest thing
+    # on this board" is the first question a reviewer asks and the strip above
+    # can only answer it for pairs that already collide. Signed: negative is
+    # an overlap. The sources are printed because a seam measured against a
+    # silk marking is a weaker claim than one against a drawn body.
+    _seam = fnd.get('body_seam')
+    if _seam:
+        _mix = {}
+        for _v in (fnd.get('body_sources') or {}).values():
+            _mix[_v] = _mix.get(_v, 0) + 1
+        lines.append(
+            f"tightest body seam: {_seam['mm']:+.3f}mm  "
+            f"{_seam['ref_a']}<->{_seam['ref_b']} "
+            f"({_seam['source_a']}/{_seam['source_b']})"
+            f"  |  bodies from " + ', '.join(f"{_mix[k]} {k}" for k in
+                                             sorted(_mix))
+            + ("  |  below 0.3mm is a hand-assembly finding"
+               if _seam['mm'] < 0.3 else ""))
+    else:
+        lines.append("tightest body seam: NOT MEASURED -- fewer than two "
+                     "parts on this board draw a body")
     if conn_facts:
         chunk = []
         for ref, _cls, edge, dist, interior in conn_facts:
@@ -1209,6 +1264,11 @@ def draw_legend(d, r, spec) -> None:
                 (C_COURT_OVL, 'solid', 'courtyard interpenetration'),
                 (C_HOLE, 'ring', 'NPTH keepout'),
                 (C_LOCKED, 'hatch', 'KiCad-locked (never moved)')]
+        # #896. Only when the board actually has one -- a legend row for a
+        # mark nothing on the panel carries teaches the reader to look for
+        # something that is not there.
+        if 'silk' in (getattr(spec.model, 'body_sources', None) or {}).values():
+            rows.append((C_COURT_F, 'dashed', 'body from SILK (never gates)'))
         if spec.moves:
             rows.append((C_ARROW, 'arrow', 'moved since --before'))
         if spec.hot_nets:
@@ -2340,6 +2400,13 @@ def main(argv=None):
             'b_courtyard_blocking_pairs':
                 fnd['courtyard_blocking_pairs_refs'],
             'b_courtyard_overlap_mm2': fnd['courtyard_overlap_mm2'],
+            #   b_body_seam -- #896: the tightest DRAWN-body seam on the
+            #     board, signed (negative = overlap), with the geometry each
+            #     side rests on. None when fewer than two parts draw a body.
+            #   b_body_sources -- which rung answered per part, so a reader
+            #     can see a board graded on silk rather than on drawn bodies.
+            'b_body_seam': fnd.get('body_seam'),
+            'b_body_sources': fnd.get('body_sources') or {},
             # None when the census ran. --gate reads it: a render that
             # could not build the census must not report "blocking: none".
             'b_courtyard_census_error': fnd['courtyard_census_error'],

--- a/tests/fixtures/run25/esp_prog_lap3.kicad_pcb
+++ b/tests/fixtures/run25/esp_prog_lap3.kicad_pcb
@@ -1,0 +1,5791 @@
+(kicad_pcb
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(general
+		(thickness 1.6)
+		(legacy_teardrops no)
+	)
+	(paper "A4")
+	(layers
+		(0 "F.Cu" signal)
+		(2 "B.Cu" signal)
+		(9 "F.Adhes" user)
+		(11 "B.Adhes" user)
+		(13 "F.Paste" user)
+		(15 "B.Paste" user)
+		(5 "F.SilkS" user)
+		(7 "B.SilkS" user)
+		(1 "F.Mask" user)
+		(3 "B.Mask" user)
+		(17 "Dwgs.User" user)
+		(19 "Cmts.User" user)
+		(21 "Eco1.User" user)
+		(23 "Eco2.User" user)
+		(25 "Edge.Cuts" user)
+		(27 "Margin" user)
+		(31 "F.CrtYd" user)
+		(29 "B.CrtYd" user)
+		(35 "F.Fab" user)
+		(33 "B.Fab" user)
+	)
+	(setup
+		(pad_to_mask_clearance 0.0508)
+		(solder_mask_min_width 0.0508)
+		(pad_to_paste_clearance -0.0508)
+		(allow_soldermask_bridges_in_footprints no)
+		(tenting
+			(front yes)
+			(back yes)
+		)
+		(covering
+			(front no)
+			(back no)
+		)
+		(plugging
+			(front no)
+			(back no)
+		)
+		(capping no)
+		(filling no)
+		(aux_axis_origin 114 105.5)
+		(pcbplotparams
+			(layerselection 0x00000000_00000000_55555555_575575ff)
+			(plot_on_all_layers_selection 0x00000000_00000000_00000000_00000000)
+			(disableapertmacros no)
+			(usegerberextensions no)
+			(usegerberattributes no)
+			(usegerberadvancedattributes no)
+			(creategerberjobfile no)
+			(dashed_line_dash_ratio 12)
+			(dashed_line_gap_ratio 3)
+			(svgprecision 4)
+			(plotframeref no)
+			(mode 1)
+			(useauxorigin no)
+			(pdf_front_fp_property_popups yes)
+			(pdf_back_fp_property_popups yes)
+			(pdf_metadata yes)
+			(pdf_single_document no)
+			(dxfpolygonmode yes)
+			(dxfimperialunits yes)
+			(dxfusepcbnewfont yes)
+			(psnegative no)
+			(psa4output no)
+			(plot_black_and_white yes)
+			(sketchpadsonfab no)
+			(plotpadnumbers no)
+			(hidednponfab no)
+			(sketchdnponfab yes)
+			(crossoutdnponfab yes)
+			(subtractmaskfromsilk no)
+			(outputformat 1)
+			(mirror no)
+			(drillshape 0)
+			(scaleselection 1)
+			(outputdirectory "gerbers/")
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:C_0603_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3efb")
+		(at 123.250000 98.100000)
+		(descr "Resistor SMD 0603, reflow soldering, Vishay (see dcrcw.pdf)")
+		(tags "resistor 0603")
+		(property "Reference" "C1"
+			(at 0.02 1.42 90)
+			(layer "F.SilkS")
+			(uuid "f75a27fd-d1c4-458f-8b68-56b483dc9e19")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2.2uF"
+			(at 0.127 1.778 90)
+			(layer "F.Fab")
+			(uuid "72de1e9a-e38b-4467-8c50-032e9cd51554")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1852f3c8-e8cc-47e0-b367-8611cc6f47b5")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6d88cc1b-1f4b-472c-9c5e-19af7292f099")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000055069cf9")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.508 -0.762)
+			(end 0.508 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "35ea92c1-9e3b-4387-aa21-b42022e5b828")
+		)
+		(fp_line
+			(start -0.508 0.762)
+			(end 0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "785854c6-f55d-4a27-80f7-1af3aaa9866d")
+		)
+		(fp_line
+			(start 1.651 -0.762)
+			(end 1.651 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d9de512a-6634-4766-b8c2-61fcb9e8fca9")
+		)
+		(fp_line
+			(start 0.508 -0.762)
+			(end 1.651 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "692ad022-7a42-4c15-b38a-24353cee65ed")
+		)
+		(fp_line
+			(start -0.508 -0.762)
+			(end -1.651 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1ddd5c01-ccc6-4201-ab2b-10ffcd50d633")
+		)
+		(fp_line
+			(start -1.651 -0.762)
+			(end -1.651 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c3158be1-8f7d-45f7-817c-d3c1451f270e")
+		)
+		(fp_line
+			(start 1.651 0.762)
+			(end 0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0776f5ac-0e9e-463d-a90e-bbc33109bf83")
+		)
+		(fp_line
+			(start -1.651 0.762)
+			(end -0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6331247c-8849-4ade-90f0-f2e2e262a0d3")
+		)
+		(fp_line
+			(start 0.762 -0.381)
+			(end 0 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7b34b4c4-07b8-447e-bb1a-55abdda3902e")
+		)
+		(fp_line
+			(start 0 -0.381)
+			(end -0.762 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4f29cb63-5415-4a1a-95e1-7e2dc701541b")
+		)
+		(fp_line
+			(start -0.762 -0.381)
+			(end -0.762 0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "29c2be3d-d493-46ec-8913-4e58dcfb8f7e")
+		)
+		(fp_line
+			(start 0.762 0.381)
+			(end 0.762 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d2012f09-e8e3-4b76-b29f-2416acbd1872")
+		)
+		(fp_line
+			(start -0.762 0.381)
+			(end 0.762 0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b0f6cd93-e2fc-4dff-8413-e11a8d411b8a")
+		)
+		(pad "1" smd rect
+			(at -0.889 0)
+			(size 1.016 1.016)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "c9fe2374-c58b-407e-90b5-0df5c3cd3078")
+		)
+		(pad "2" smd rect
+			(at 0.889 0)
+			(size 1.016 1.016)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "bb3f8234-235f-499f-b6d2-6b609c3aedeb")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/C_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:C_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f0f")
+		(at 126.964000 102.665000 180)
+		(tags "C0402")
+		(property "Reference" "C2"
+			(at -2.1 -0.1 90)
+			(layer "F.SilkS")
+			(uuid "bfe81756-fa32-4c91-85ca-9dafcee55832")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "27pF"
+			(at 0 1.905 90)
+			(layer "F.Fab")
+			(uuid "afc5aa3f-a483-4bb7-a932-39e0290f26ad")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f46e3d5f-37c9-4d7b-af06-42d8b55f5e75")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "39f3d48b-3e28-4811-a96c-0202c40d1a98")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8acdb7")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "75e27d7e-1147-4ba6-8cb7-65d985df04b7")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "742905ca-fb6e-4776-83fe-9fcc7c97d3a7")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ca9d5db3-03df-4e51-931e-cb05f0b5df78")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0a385e74-7e5e-43f1-8c42-f5866aa70cb0")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "33be7a8b-6a82-4bfd-9c67-f7b6515759a4")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d85f51d5-ebac-41d1-9902-a2277d6ac7b1")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4e1b7661-355d-46f7-bb91-71951b312e70")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "492f7e53-cbec-424d-9aec-f66c611fa041")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1f15d293-b287-4bfb-a405-abe1e5b675ae")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9e882702-ce26-46f0-bf79-eb291037d326")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "20dd8e46-9562-46b0-a867-a8ca8e949ec4")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a6f5f42a-5fa6-4634-b0d2-b7c210c994ca")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "918e4fd8-5d8b-43ae-acf5-ea8267eb8804")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1193b8e0-83dd-4c45-bb92-96007c358352")
+		)
+		(pad "1" smd rect
+			(at -0.508 0)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "c05c74cf-6dcb-4258-9cff-71b669d8dc06")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 180)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "b433d5e4-f9e0-4845-b167-df024b26609d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:C_0603_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f22")
+		(at 126.350000 98.100000)
+		(descr "Resistor SMD 0603, reflow soldering, Vishay (see dcrcw.pdf)")
+		(tags "resistor 0603")
+		(property "Reference" "C3"
+			(at -2.27 0.59 0)
+			(layer "F.SilkS")
+			(uuid "c74cc472-1cec-4d24-b416-63036f14783f")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2.2uF"
+			(at 0.127 1.778 0)
+			(layer "F.Fab")
+			(uuid "6584dab3-3d0f-459f-adcd-671dd563f275")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "963df33f-2430-4e51-a1ef-974a5dbe19d8")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7a4bad7c-d2fb-4c07-bf73-cb8993011454")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000055069c71")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.508 0.762)
+			(end 0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5a3eb310-acd4-45f3-93b1-e8cd2d491b0c")
+		)
+		(fp_line
+			(start -0.508 -0.762)
+			(end 0.508 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7c0aedfc-120f-4105-b883-b5a777e1c92d")
+		)
+		(fp_line
+			(start 1.651 0.762)
+			(end 0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "683c5b34-2b55-42ef-afcd-34c76ca9c892")
+		)
+		(fp_line
+			(start 1.651 -0.762)
+			(end 1.651 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "16894053-ef17-4cf2-ad7c-fc8e2d6b7727")
+		)
+		(fp_line
+			(start 0.508 -0.762)
+			(end 1.651 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6185e63d-22f8-4dd8-8292-6a50f4dc0558")
+		)
+		(fp_line
+			(start -0.508 -0.762)
+			(end -1.651 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ad090b28-054b-43f9-a3d3-bb4e3e64b3f3")
+		)
+		(fp_line
+			(start -1.651 0.762)
+			(end -0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a88ac355-08b0-4512-9672-a8caed8ebea6")
+		)
+		(fp_line
+			(start -1.651 -0.762)
+			(end -1.651 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "98a6364c-9f65-4220-9222-5630896822a8")
+		)
+		(fp_line
+			(start 0.762 0.381)
+			(end 0.762 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4a8eddc8-5a72-4f98-a4bf-a9e079c73580")
+		)
+		(fp_line
+			(start 0.762 -0.381)
+			(end 0 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d0d94442-29b2-4c2f-a9df-0806aeebd144")
+		)
+		(fp_line
+			(start 0 -0.381)
+			(end -0.762 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "aa0420b5-baf9-41f6-ab9b-b69921994b55")
+		)
+		(fp_line
+			(start -0.762 0.381)
+			(end 0.762 0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "121f4f4e-ca8e-4529-ba5e-86cec623edf0")
+		)
+		(fp_line
+			(start -0.762 -0.381)
+			(end -0.762 0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d07fd336-c791-49a4-8938-47c68c9cab77")
+		)
+		(pad "1" smd rect
+			(at -0.889 0)
+			(size 1.016 1.016)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/+3.3V")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "e8e0c496-9ab2-499a-8329-6706b727c6ae")
+		)
+		(pad "2" smd rect
+			(at 0.889 0)
+			(size 1.016 1.016)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "1d648374-bc5e-465c-a964-a415515bdd69")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/C_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:C_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f36")
+		(at 127.199000 104.096000 180)
+		(tags "C0402")
+		(property "Reference" "C4"
+			(at -1.102 1.014 180)
+			(layer "F.SilkS")
+			(uuid "bc677c80-53dd-4f08-98e8-31e324557bc0")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "27pF"
+			(at 0 1.905 90)
+			(layer "F.Fab")
+			(uuid "fb7e2869-b4dd-454d-91c0-5e038d2c07c7")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9cd7c0aa-dcaa-4d63-a892-2b1ea78c0a54")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b8b35adf-612d-4b2f-9fb2-0e21e9044d45")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000055069da1")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ce5bc01c-c3f6-4bbd-8329-326a517ffdec")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5bf31d8d-0642-462e-ae9f-79384a944cf3")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0ec4ccfe-5f9a-4f97-8cab-ece0f2cb51d2")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ab51b595-a988-4ac3-9891-cb27f3cdeae2")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "595d0de0-df4f-4e1d-b9fa-aa15908a4dcc")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "39927f66-140c-491a-8935-8a19091cbce6")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ce722752-5145-4955-b190-e6415d2c6648")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7886fb79-8ade-4b2d-8c06-0990ec7145ce")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a1649be7-bd87-4b49-ba90-e64269e5af44")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "df9c04b4-2182-4c85-ba2f-f6b4f0e8ced5")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ef8032a2-af72-40dc-b75d-6cc874e43ce7")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c39a7149-18b6-4678-b71b-dbabebe2af68")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "27f8eda9-143a-4783-b25e-451bf3144a2d")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e498aa95-5328-48f6-b10c-8bd583002cd7")
+		)
+		(pad "1" smd rect
+			(at -0.508 0)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C4-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "f5fa8d41-8b5b-4801-9517-d6be5bcac583")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 180)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "c73c3ff6-d1db-46ee-bb45-94a620fa0541")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_Connectors-FP:WU06SM"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f44")
+		(at 144.650000 98.250000 270)
+		(property "Reference" "CON1"
+			(at -0.2 -1.5 90)
+			(layer "F.SilkS")
+			(uuid "c53fb5c7-5633-441d-8a0a-998e61ec4b18")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "CON6"
+			(at 0 -2.54 90)
+			(layer "F.Fab")
+			(uuid "d6cfb4cb-2294-4406-88a2-5c9df595b9a7")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1f3b2da5-757b-4cb5-920f-c5e5b95c1d70")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a3726cc9-7730-4652-9a5b-271fb1f05a9b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8a1e69")
+		(solder_mask_margin 0.0508)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -4.85 1.1)
+			(end -4.85 -2.1)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "be5041df-1eaa-46f6-842b-a5296b5e7988")
+		)
+		(fp_line
+			(start 4.85 1.1)
+			(end -4.85 1.1)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b68b63bc-ff21-42a3-9c37-766f6afe5b9f")
+		)
+		(fp_line
+			(start -4.85 -2.1)
+			(end 4.85 -2.1)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b78f2cb9-173a-4d48-98b4-8f7c4c266052")
+		)
+		(fp_line
+			(start 4.85 -2.1)
+			(end 4.85 1.1)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f90af397-a07a-4e47-99fe-e9eb2ba869d3")
+		)
+		(pad "1" thru_hole oval
+			(at -3.125 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/U0TXD")
+			(uuid "fb19e8f8-bb34-468e-a684-827edf79d3c8")
+		)
+		(pad "2" thru_hole oval
+			(at -1.875 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/DCOM")
+			(uuid "bd8dc4f4-0243-458a-85ec-719f868c7ae7")
+		)
+		(pad "3" thru_hole oval
+			(at -0.625 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/U0RXD")
+			(uuid "ce5942b5-71d7-41a7-b746-edf7d14af784")
+		)
+		(pad "4" thru_hole oval
+			(at 0.625 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(uuid "8247ece4-cc28-462f-ab3a-db7da1427200")
+		)
+		(pad "5" thru_hole oval
+			(at 1.875 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/+3.3V")
+			(uuid "a0b6b78f-04f7-4f50-b022-0fdfb8f1e207")
+		)
+		(pad "6" thru_hole oval
+			(at 3.125 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/EN")
+			(uuid "d74b4b89-0c94-485f-aee6-07917f8da44c")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/WU06S-Molex_PicoBlade_530470610_1x06_P1.25mm_Vertical.step"
+			(offset
+				(xyz 0 0.5428 2.54)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz -90 0 -180)
+			)
+		)
+	)
+	(footprint "OLIMEX_Transistors-FP:SOT23"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f57")
+		(at 139.000000 99.200000 180)
+		(property "Reference" "Q1"
+			(at -1.6 -1 0)
+			(layer "F.SilkS")
+			(uuid "30552372-aa78-4afe-a1ae-bad929e8edc0")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "BC817-40(SOT23)"
+			(at 3.5052 2.6416 0)
+			(layer "F.Fab")
+			(uuid "db168cae-0535-488f-845c-70f3fa7eb843")
+			(effects
+				(font
+					(size 1.1 1.1)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b621f733-e3cb-412d-a695-7c792c9019ef")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "62f1d14d-5f4f-43fd-a0e5-067b0bea46b1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8a927f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.2032 1.4224)
+			(end -0.635 1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "054f1970-4597-4e19-b95f-a34b81d74d44")
+		)
+		(fp_line
+			(start 0.2032 -1.4224)
+			(end -0.635 -1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "76d37a5a-8c56-429b-8a14-013555262bf9")
+		)
+		(fp_line
+			(start -0.635 0.7112)
+			(end -0.635 1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a7c8b24e-4c33-4b7c-8ee6-2e2fba817abb")
+		)
+		(fp_line
+			(start -0.635 -1.4224)
+			(end -0.635 -0.7112)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "eb6bb575-8fb9-4627-b8dd-fc8f3008364b")
+		)
+		(fp_line
+			(start 1.19888 0.95758)
+			(end 0.82804 0.95758)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "84a83fd2-68b9-4adc-b8a6-f0b98d3a1ac7")
+		)
+		(fp_line
+			(start 1.19126 -0.95504)
+			(end 0.82042 -0.95504)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "563b045a-e592-40a6-a7b7-01700a7b7a1f")
+		)
+		(fp_line
+			(start 0.65278 1.41478)
+			(end -0.65024 1.41478)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2af0f7fc-f454-4a38-b6bd-67850eab4307")
+		)
+		(fp_line
+			(start 0.65278 -1.4097)
+			(end 0.65278 1.4097)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "003e8884-906a-4c4e-b15a-53416a7989b8")
+		)
+		(fp_line
+			(start -0.65024 0.00762)
+			(end -0.65278 1.35636)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e571de33-5e83-4458-978e-67dbd581e61e")
+		)
+		(fp_line
+			(start -0.65024 0.00508)
+			(end -0.65024 -1.41732)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "81afa320-3df0-4309-b0ba-83cf8347800e")
+		)
+		(fp_line
+			(start -0.65532 -1.42494)
+			(end 0.64262 -1.42494)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d218610b-4cf1-43ca-b500-259913ddd589")
+		)
+		(fp_line
+			(start -0.81026 0.00254)
+			(end -1.1811 0.00254)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "30e005f3-24b9-44f7-b2b4-2ce8f59abe2e")
+		)
+		(pad "1" smd rect
+			(at 1.10744 0.94996 180)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(Q1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "021f20be-b6f4-4fa8-a291-aa7de978068f")
+		)
+		(pad "2" smd rect
+			(at 1.10744 -0.9525 180)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/DTR")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "ea771218-fc35-499d-836d-a2e3479bcc16")
+		)
+		(pad "3" smd rect
+			(at -1.10236 0.00254 180)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/DCOM")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "4439e5cf-1444-4745-a6c1-78842dac1b34")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/SOT-23.step"
+			(offset
+				(xyz 0 0 0.5)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz -90 0 90)
+			)
+		)
+	)
+	(footprint "OLIMEX_Transistors-FP:SOT23"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f6a")
+		(at 139.000000 102.400000)
+		(property "Reference" "Q2"
+			(at -1.6 -1.3 0)
+			(layer "F.SilkS")
+			(uuid "50c186ed-bd8b-4770-8d18-a4f47cc5c02f")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "BC817-40(SOT23)"
+			(at 3.5052 2.6416 0)
+			(layer "F.Fab")
+			(uuid "35ce9468-3746-484b-b631-c3a953bc6470")
+			(effects
+				(font
+					(size 1.1 1.1)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "75bad9b6-4c36-414b-aab7-8dafc5179781")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a0d1ff3a-d393-4185-b8da-2edb44288ab4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8ab147")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.2032 1.4224)
+			(end -0.635 1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8227fd38-eb7d-4476-9c5e-c799a490237b")
+		)
+		(fp_line
+			(start 0.2032 -1.4224)
+			(end -0.635 -1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "11ea48f4-d46f-44ad-8346-071dcba4c1e0")
+		)
+		(fp_line
+			(start -0.635 0.7112)
+			(end -0.635 1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6a8dc534-7284-4047-afec-34126ce0e01e")
+		)
+		(fp_line
+			(start -0.635 -1.4224)
+			(end -0.635 -0.7112)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "9e02ec0b-0a02-4920-b274-93a6e4be0072")
+		)
+		(fp_line
+			(start 1.19888 0.95758)
+			(end 0.82804 0.95758)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "65bdb41e-5a9c-441b-a7cf-e9ee88978954")
+		)
+		(fp_line
+			(start 1.19126 -0.95504)
+			(end 0.82042 -0.95504)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2833823c-c443-4d61-9793-094ac615a088")
+		)
+		(fp_line
+			(start 0.65278 1.41478)
+			(end -0.65024 1.41478)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "537ce652-1eab-4333-a5b0-a833749c9e38")
+		)
+		(fp_line
+			(start 0.65278 -1.4097)
+			(end 0.65278 1.4097)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d494fb77-f3ab-4454-a000-f744a1e88e2b")
+		)
+		(fp_line
+			(start -0.65024 0.00762)
+			(end -0.65278 1.35636)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c52ca018-be5d-4685-9892-e0bfe2fa8012")
+		)
+		(fp_line
+			(start -0.65024 0.00508)
+			(end -0.65024 -1.41732)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9a671dea-b970-42a7-83df-d7fc665e21a0")
+		)
+		(fp_line
+			(start -0.65532 -1.42494)
+			(end 0.64262 -1.42494)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "30e3dae2-ccfc-4be2-81b2-2eaf9ab4f38f")
+		)
+		(fp_line
+			(start -0.81026 0.00254)
+			(end -1.1811 0.00254)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "14b865bf-569e-4b98-a03c-7e7211f1b696")
+		)
+		(pad "1" smd rect
+			(at 1.10744 0.94996)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(Q2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "30cf95b6-d203-4aba-a961-9c3e6bfeff9e")
+		)
+		(pad "2" smd rect
+			(at 1.10744 -0.9525)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/RTS")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "c919269f-44c6-4003-8903-606e3fd497c5")
+		)
+		(pad "3" smd rect
+			(at -1.10236 0.00254)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/EN")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "e2653a60-ec3b-438f-be14-0117b6e8cab1")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/SOT-23.step"
+			(offset
+				(xyz 0 0 0.5)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz -90 0 90)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:R_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f7e")
+		(at 141.796000 100.637000 270)
+		(tags "C0402")
+		(property "Reference" "R1"
+			(at 1.47 -0.03 180)
+			(layer "F.SilkS")
+			(uuid "43c5d8c2-77e9-455e-9413-711753d1a614")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1K"
+			(at 0 1.397 90)
+			(layer "F.Fab")
+			(uuid "4e16573c-8803-44c9-b2b2-7a3ba48631d0")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "16d731a1-334c-4a51-8f46-1743cd3c1912")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6a53e361-12ff-44b8-91e9-ec074787355f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8aaad1")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0b61af81-f37e-40c2-941c-317ff79f1cdb")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8f92d0f9-9c23-4545-bad1-3119e3d6c813")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d4669a6b-3770-4b73-9047-80e5368faeff")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "466b2737-ea5e-4e34-b519-6cb176ad02e5")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6bfcebea-3959-4529-aaa4-03a31c6cf75c")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0d997e12-ecd4-404d-a3fb-4de503fe9d8a")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6f9cd834-4e0d-41c3-896e-813f7bf61a21")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c037e704-50c8-4bcd-8f1d-1e673291abf5")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "80572a16-0f2f-420d-9c99-658e66e89806")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "884f799f-01ec-4936-b092-2a0eb10bf9fc")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3d183ce0-640d-4f8b-97b6-24613f2ad491")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "460d783a-99c5-4c5b-a12c-509d1f9cdece")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f85b79fa-34e2-43e4-8c69-b75d7b38eed7")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ee9a41a5-e50b-4e65-857e-723b25faa6b0")
+		)
+		(pad "1" smd rect
+			(at -0.508 0 90)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(Q1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "9e118f2e-37f9-416d-a5c4-181d66f482c5")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 270)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/RTS")
+			(solder_mask_margin 0.0508)
+			(uuid "5ee747f5-3d69-425a-b1f3-c973b2dfd4a8")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:R_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3fa6")
+		(at 131.960000 93.952000 180)
+		(tags "C0402")
+		(property "Reference" "R3"
+			(at -0.5 -1.1 0)
+			(layer "F.SilkS")
+			(uuid "95a4e8f2-e864-4c43-ac13-8db2d560cf62")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100R"
+			(at 0 1.397 0)
+			(layer "F.Fab")
+			(uuid "c909afb5-c5d9-442d-a281-7eeaf260fb43")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "03d19569-2694-4fe2-978e-bbf984f599ac")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b80bc789-8933-40bd-b42b-a8a0ea887849")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8af572")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d028c661-d125-4a92-9135-686be42a4b56")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5bc08d76-a6bf-413d-9031-ce0827300366")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "357ca64d-5770-4143-90c2-044898337931")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "45e4ddc6-a3c3-4da2-85f5-1d236f064f46")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "555327aa-c6e6-4d8b-9ab6-7036623bd761")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "42bc4342-347f-4ebb-979f-0fa9cbd71040")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c79fdf81-c61d-4502-86a0-dac709f43524")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "52118b7c-684b-4c10-954a-7fc6a3c0e8b6")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d0f916b2-e7e1-4855-9047-41a0ac524bb3")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "54ec7a07-84d3-420b-9748-bb15dd379da3")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0f83f417-837d-4efd-b5a2-1ec64cbafffd")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fab12dc0-91ca-4bdf-9288-02a3a6f663cd")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "754005df-e92a-4800-98c6-34557dca8546")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d49b4dbe-d3b8-477c-8719-b4abe481af0c")
+		)
+		(pad "1" smd rect
+			(at -0.508 0)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/U0RXD")
+			(solder_mask_margin 0.0508)
+			(uuid "8256635e-fed3-4354-b293-9c00fc208dc1")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 180)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(R3-Pad2)")
+			(solder_mask_margin 0.0508)
+			(uuid "8f9b214c-93ef-4d04-9357-83d267b717b9")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:R_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3fba")
+		(at 134.553000 94.003000 180)
+		(tags "C0402")
+		(property "Reference" "R4"
+			(at -0.4 -1.1 0)
+			(layer "F.SilkS")
+			(uuid "f367dcc2-bd28-44cd-a54a-66f9d7b68291")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100R"
+			(at 0 1.397 0)
+			(layer "F.Fab")
+			(uuid "8bacdc0a-f150-4a39-83c8-661abcfba510")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "5a9dc1cc-538e-4463-b5c1-d4fa8e7d86f8")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d871c68d-73cd-44b5-b71d-8f1379bc7017")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8aff5c")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0af709b6-4d18-44de-b650-878203f09c91")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "77fdc967-f388-46c7-bac2-6d011d37ee12")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "421a604b-4b19-47fa-8949-8d67a328b99f")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "296ea335-e5ad-4fd5-ad71-1640a5ddbc38")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1a9904b8-9903-4c8c-9627-e066e28dade1")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "21489bf0-9d75-4966-8fdc-76773a4e4f8f")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6d78a26d-f0be-4fc0-85d6-0275576c35a8")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9b50b163-7b4d-4a5a-9a26-286bb1abcf83")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "afdeaac9-d882-4748-96b4-e2593e1d8685")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6cb4f9de-4500-4001-8a0e-87495fbbf28c")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "13387796-3e59-431f-b907-f0d01a22b364")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b38f0052-d14d-4a40-b4d4-28313fa25b79")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d5808c2f-a3b7-4412-a18b-2e7a3dddfdf4")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9756d28b-1115-4fc2-af7f-5fb08b379a86")
+		)
+		(pad "1" smd rect
+			(at -0.508 0)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/U0TXD")
+			(solder_mask_margin 0.0508)
+			(uuid "dce00e07-dafd-4feb-b475-db34afc34981")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 180)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(R4-Pad2)")
+			(solder_mask_margin 0.0508)
+			(uuid "fe65b2de-a32f-4c23-9446-82bba982fa8d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_IC-FP:SSOP-20W"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3fd8")
+		(at 132.300000 98.600000 270)
+		(descr "SSOP 20 pins")
+		(tags "CMS SSOP SMD")
+		(property "Reference" "U1"
+			(at -4.2 -3.5 180)
+			(layer "F.SilkS")
+			(uuid "de496a2e-6a01-4180-8898-0ccee2ff715f")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "CH340H/T"
+			(at 0 5.715 0)
+			(layer "F.Fab")
+			(uuid "41ff27c3-6b39-48d4-85cf-2bf156ab17aa")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c48f918c-f4f5-42c2-b630-5e6576122cf6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2ee7367a-b761-4e72-a29e-82b8ca1beb1c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000055069b04")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -3.81 2.7305)
+			(end -3.81 -2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "68035f87-6cd5-47b7-b246-f7024acd8b7a")
+		)
+		(fp_line
+			(start -3.81 2.7305)
+			(end 3.81 2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "cce7fb09-5dff-4c08-8b7d-e02098d30b6b")
+		)
+		(fp_line
+			(start -3.429 -2.7305)
+			(end -3.429 2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2361d3b6-0cd6-4301-b4f3-f80dedb56e58")
+		)
+		(fp_line
+			(start 3.81 -2.7305)
+			(end -3.81 -2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "dea79ab3-b0bc-445c-92e1-0503c0c4b074")
+		)
+		(fp_line
+			(start 3.81 -2.7305)
+			(end 3.81 2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6e8095af-db2c-4df0-8fb2-a3bccab98e90")
+		)
+		(fp_text user "o"
+			(at -3.81 3.556 0)
+			(layer "F.SilkS")
+			(uuid "aacbeec9-f99b-4d77-8f61-03f07bb0f591")
+			(effects
+				(font
+					(size 1.016 1.016)
+					(thickness 0.254)
+				)
+			)
+		)
+		(pad "1" smd rect
+			(at -2.925 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(solder_mask_margin 0.0508)
+			(uuid "07890969-265c-49e1-9e44-d68402d5e15e")
+		)
+		(pad "2" smd rect
+			(at -2.275 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(solder_mask_margin 0.0508)
+			(uuid "67f28907-1d6d-4c26-ad8b-ddd54daa222c")
+		)
+		(pad "3" smd rect
+			(at -1.625 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(R3-Pad2)")
+			(solder_mask_margin 0.0508)
+			(uuid "6014ba7d-68db-468c-ac25-e0158bbdc081")
+		)
+		(pad "4" smd rect
+			(at -0.975 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(R4-Pad2)")
+			(solder_mask_margin 0.0508)
+			(uuid "61def817-2e70-4a3a-9dca-b66831d4f4a7")
+		)
+		(pad "5" smd rect
+			(at -0.325 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/+3.3V")
+			(solder_mask_margin 0.0508)
+			(uuid "e5483ff9-2a40-4085-a597-084f3fa111e4")
+		)
+		(pad "6" smd rect
+			(at 0.325 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/D_P")
+			(solder_mask_margin 0.0508)
+			(uuid "dda9c363-77d3-4b31-9ae2-bed1c186a6b8")
+		)
+		(pad "7" smd rect
+			(at 0.975 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/D_N")
+			(solder_mask_margin 0.0508)
+			(uuid "3dd486be-3ecc-4342-8924-532bf4142957")
+		)
+		(pad "8" smd rect
+			(at 1.625 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "2b140a09-4a02-4d95-b95f-dcefd8c75a63")
+		)
+		(pad "9" smd rect
+			(at 2.275 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C4-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "666ef700-d49a-4f8a-a999-6a10bb742382")
+		)
+		(pad "10" smd rect
+			(at 2.925 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "22909fde-31e3-491e-85ca-312dc7566451")
+		)
+		(pad "11" smd rect
+			(at 2.925 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad11)")
+			(solder_mask_margin 0.0508)
+			(uuid "4fc06dd2-0c45-406b-892a-f09892b5438a")
+		)
+		(pad "12" smd rect
+			(at 2.275 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad12)")
+			(solder_mask_margin 0.0508)
+			(uuid "ae19993d-4d8a-4cc3-983a-1218d53420cb")
+		)
+		(pad "13" smd rect
+			(at 1.625 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad13)")
+			(solder_mask_margin 0.0508)
+			(uuid "4b6f1dc9-217c-4242-a3cf-bbc59412197e")
+		)
+		(pad "14" smd rect
+			(at 0.975 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad14)")
+			(solder_mask_margin 0.0508)
+			(uuid "64082188-2f6e-4af1-9d61-aad04a336ce4")
+		)
+		(pad "15" smd rect
+			(at 0.325 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/DTR")
+			(solder_mask_margin 0.0508)
+			(uuid "f6319632-c37d-46de-b502-75166d8c5f03")
+		)
+		(pad "16" smd rect
+			(at -0.325 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/RTS")
+			(solder_mask_margin 0.0508)
+			(uuid "dbfc3510-0568-45d9-a9c9-7914c106b9ac")
+		)
+		(pad "17" smd rect
+			(at -0.975 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(solder_mask_margin 0.0508)
+			(uuid "306d12e4-19b9-48a3-8387-785799dc981d")
+		)
+		(pad "18" smd rect
+			(at -1.625 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad18)")
+			(solder_mask_margin 0.0508)
+			(uuid "5b884ccb-faa7-4810-a925-e59756821566")
+		)
+		(pad "19" smd rect
+			(at -2.275 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/+3.3V")
+			(solder_mask_margin 0.0508)
+			(uuid "1d34e49b-8a46-4654-995f-83c66f5cbf39")
+		)
+		(pad "20" smd rect
+			(at -2.925 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad20)")
+			(solder_mask_margin 0.0508)
+			(uuid "fa2243b4-8c94-44ec-9891-647bdb349a3e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/SSOP-20_5.3x7.2mm_P0.65mm.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 -90)
+			)
+		)
+	)
+	(footprint "OLIMEX_Connectors-FP:USB-MICRO_MISB-SWMM-5B_LF"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a4001")
+		(at 117.500000 100.000000 180)
+		(property "Reference" "USB1"
+			(at -4.8 0.9 90)
+			(layer "F.SilkS")
+			(uuid "49c304bc-0e90-413f-ac15-e11b46f84fa4")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "USB-uicro-B"
+			(at 0 6.75 0)
+			(layer "F.Fab")
+			(uuid "f6ce7fb3-95a6-4f77-8aee-68f9d967d88f")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bdaaf03a-c35f-46e5-8ce7-338983ab1ae9")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7806526d-eeb0-4f24-b1a8-d8b28f3ed700")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005506aa9a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 3.5 -4.064)
+			(end 3.5 4.064)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b8231ab5-c092-4217-a913-f50444a515c4")
+		)
+		(fp_line
+			(start 3.429 4.064)
+			(end 2.413 3.683)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "09d6b1cb-0c83-4e0b-997d-ad2c13ead9a7")
+		)
+		(fp_line
+			(start 3.429 -4.064)
+			(end 2.413 -3.683)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "48760d6b-2690-48bc-bd3b-fec690fc94d8")
+		)
+		(fp_line
+			(start 2.4 3.7)
+			(end 1.4 3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "de64ecb8-ae38-405e-bdbd-5c50912a3a1c")
+		)
+		(fp_line
+			(start 2.4 -3.7)
+			(end 2.4 3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "fb5fa81d-1b93-4fe0-8c20-e2e6aef2967e")
+		)
+		(fp_line
+			(start 1.4 -3.7)
+			(end 2.4 -3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "1e28470d-17d2-443e-9b86-8e6dddb6f236")
+		)
+		(fp_line
+			(start -2.1 3.7)
+			(end -0.9 3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "decf7438-feb0-4b7a-9536-2bb8b425d94b")
+		)
+		(fp_line
+			(start -2.1 -3.7)
+			(end -0.9 -3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "9baccd7b-4072-4ab8-8b3c-90f1e87ebfdb")
+		)
+		(fp_line
+			(start -3.6 1.8)
+			(end -3.6 2.8)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "743a2f78-6a67-404e-a07f-d950c966644f")
+		)
+		(fp_line
+			(start -3.6 -2.8)
+			(end -3.6 -1.8)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "22e55154-0703-4094-bd1d-abb7ed125fc1")
+		)
+		(fp_line
+			(start 3.5 3.7)
+			(end -3.6 -3.7)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9a1f64f7-dd2b-4e25-8302-ee9acf3e5990")
+		)
+		(fp_line
+			(start 3.5 3.7)
+			(end -3.62 3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7f548f60-02c7-4682-b0ce-9b4a103f29ca")
+		)
+		(fp_line
+			(start 3.5 -3.7)
+			(end 3.5 3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c6166d67-c0e5-44c2-be50-f2a83cd6437b")
+		)
+		(fp_line
+			(start 3.5 -3.7)
+			(end -3.6 3.7)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ea49c05d-e561-4e59-95a2-7302731ed53c")
+		)
+		(fp_line
+			(start 2.4 3.7)
+			(end 2.4 -3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6955c5d9-b2f1-406f-91db-a82ee674e8ef")
+		)
+		(fp_line
+			(start -3.62 3.7)
+			(end -3.62 -3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d20b1762-9334-44c0-8eed-693a64f24efd")
+		)
+		(fp_line
+			(start -3.62 -3.7)
+			(end 3.5 -3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4f97366d-a610-40ef-a60e-ebc7a58fcd19")
+		)
+		(fp_text user "VBUS"
+			(at -0.5 1.5 0)
+			(layer "F.SilkS")
+			(uuid "59e29b7f-994c-4d5c-8b45-bdf6f55594e2")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "GND"
+			(at -0.9 -1.6 0)
+			(layer "F.SilkS")
+			(uuid "d417b14b-7619-49b0-b8c7-5cb703f3ed30")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "D-"
+			(at -1 0.75 0)
+			(layer "F.SilkS")
+			(uuid "f3c3ec99-e38a-4e54-8391-fafbafffeaa0")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "D+"
+			(at -1 0 0)
+			(layer "F.SilkS")
+			(uuid "43596a4e-6638-4bf5-aca5-99e16d344e98")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "ID"
+			(at -1.25 -0.75 0)
+			(layer "F.SilkS")
+			(uuid "74369b5a-2b46-409b-886b-8a1e34fced14")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "pcb edge"
+			(at 2.1 0 90)
+			(layer "F.Fab")
+			(uuid "2384cac3-eaf9-41af-ae23-8e3f02458a35")
+			(effects
+				(font
+					(size 0.3 0.3)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at -1.9 -2 270)
+			(size 0.6 0.6)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(solder_mask_margin 0.0508)
+			(uuid "d0afb88c-e134-482e-b278-893e3089c3b1")
+		)
+		(pad "" np_thru_hole circle
+			(at -1.9 2 270)
+			(size 0.6 0.6)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(solder_mask_margin 0.0508)
+			(uuid "42a4dd8e-0e82-4028-bba3-4bdb4b37a067")
+		)
+		(pad "0" thru_hole oval
+			(at -3.22 -3.6 270)
+			(size 1.2 1.8)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "f9c3f8b3-51b1-4a46-9834-ff74623a7f85")
+		)
+		(pad "0" thru_hole oval
+			(at -3.22 3.6 270)
+			(size 1.2 1.8)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "b966ad11-f51a-45a6-8e83-9f4ad1d2fe58")
+		)
+		(pad "0" thru_hole oval
+			(at 0.25 -3.6 270)
+			(size 1.2 1.8)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "19e2922c-f59b-4882-b2aa-1f57564800f3")
+		)
+		(pad "0" thru_hole oval
+			(at 0.25 3.6 270)
+			(size 1.2 1.8)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "25d57cbf-b101-4639-b5bf-45fb45a0f4f0")
+		)
+		(pad "0" smd rect
+			(at 1.4 -1.5 270)
+			(size 1.1 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.127)
+			(uuid "ecf1bbb3-2a49-443e-9b15-715e1d25c075")
+		)
+		(pad "0" smd rect
+			(at 1.4 1.5 270)
+			(size 1.1 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.127)
+			(uuid "0fa3c66e-f326-4def-be04-4631b20f9ead")
+		)
+		(pad "1" smd rect
+			(at -3.15 1.3875 270)
+			(size 0.5 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "ded6b8dd-333c-4616-992b-be785699496c")
+		)
+		(pad "2" smd rect
+			(at -3.15 0.65 270)
+			(size 0.325 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/D_N")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.03556)
+			(uuid "eb0e35e8-1943-4845-9e33-c88d6c28986a")
+		)
+		(pad "3" smd rect
+			(at -3.15 0 270)
+			(size 0.325 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/D_P")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.03556)
+			(uuid "060a14c7-77e8-4490-8ae8-7dded28d4cd8")
+		)
+		(pad "4" smd rect
+			(at -3.15 -0.65 270)
+			(size 0.325 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(USB1-Pad4)")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.03556)
+			(uuid "be7ce030-740b-4d93-986d-10e697a77ee0")
+		)
+		(pad "5" smd rect
+			(at -3.15 -1.3875 270)
+			(size 0.5 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "eb963628-6d9e-40f8-9010-b5bb679b47b3")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/usb_micro_4p.stp"
+			(offset
+				(xyz -2.45 0 1.1)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 -90)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:R_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8c45a4")
+		(at 141.908000 103.080000 90)
+		(tags "C0402")
+		(property "Reference" "R2"
+			(at 1.07 -1.58 0)
+			(layer "F.SilkS")
+			(uuid "4796363d-3e81-459f-a212-c43aa52ab3e8")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1K"
+			(at 0 1.397 90)
+			(layer "F.Fab")
+			(uuid "8997ade5-a6c1-4e3f-abb4-e35719c5901f")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "44e33ed6-4445-4806-a41f-123365cfee7b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "aec16f68-2858-4fd8-b150-774caa5d0b6a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8ab138")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6740a799-6bf9-4ad8-860f-cfb7420a758a")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "cb0dd33d-f8e5-4678-a807-963e05815359")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "466e974f-ff64-48ef-82cd-524278169324")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c06452a3-6b10-4682-a506-b13bddc4a16b")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "828ea7b4-fb09-43d7-8505-66eefcf35224")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "98a83e8e-305a-4d38-a866-1e5df6f38783")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "93acd6fb-a6fd-41e8-82c0-507d15d45e6f")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "fd628e01-5142-4d03-b897-2fde269ac67d")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5ba9276b-ae34-4731-9f54-e78304a42feb")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "194aa5bd-bf92-4b13-b97d-3e56826e068d")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "53ecc657-6bf8-4237-8515-b4cb0bf8aae8")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "12400381-8471-49b4-a40c-3a08acb9358d")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "138f7812-9c53-44f1-823c-b3dbbcf5047d")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "aa3608fc-e4a3-46b2-b1a4-6c04a2020aac")
+		)
+		(pad "1" smd rect
+			(at -0.508 0 270)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(Q2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "40bf59e5-1e1a-4369-9f07-8a89731e80eb")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 90)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/DTR")
+			(solder_mask_margin 0.0508)
+			(uuid "f90028d5-92ce-4c2e-8bfb-90e1bfadeacc")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_Other-FP:Fiducial1x3_transp"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8c55cd")
+		(at 141.200000 95.900000)
+		(property "Reference" "Ref*"
+			(at 0 3 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "5a22dbb2-ec0a-40f6-aacb-432ac5b6d21f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "Val**"
+			(at 0 -3 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d3151732-31b9-4d5d-a6c4-dacf550da8c0")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "253f7a3c-5603-42f9-96cf-c9539251fbf5")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9d930eec-c497-4e5d-b53a-a95cfb340f03")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 1.5 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(fill no)
+			(layer "Dwgs.User")
+			(uuid "eec7448f-6827-4289-a4ac-c8840394d472")
+		)
+		(pad "Fid1" connect circle
+			(at 0 0)
+			(size 1 1)
+			(layers "F.Cu" "F.Mask")
+			(solder_mask_margin 0.127)
+			(clearance 1.016)
+			(zone_connect 0)
+			(uuid "a66154ca-f352-4c46-85cc-f8f40e022877")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "OLIMEX_Other-FP:Fiducial1x3_transp"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8c55f6")
+		(at 118.100000 99.900000)
+		(property "Reference" "Ref*"
+			(at 0 3 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "d084a8ae-21ad-49b8-ba12-392d130d8d3e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "Val**"
+			(at 0 -3 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bcd7a0ff-8f2b-461b-bbf7-f38b71b3588b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "895763e0-6dfe-4f7f-a7a5-5a443538985c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "135940cb-574b-49d8-8ed1-4af4bd2c030d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 1.5 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(fill no)
+			(layer "Dwgs.User")
+			(uuid "78d81f2c-791c-4230-a277-0f3baae900db")
+		)
+		(pad "Fid1" connect circle
+			(at 0 0)
+			(size 1 1)
+			(layers "F.Cu" "F.Mask")
+			(solder_mask_margin 0.127)
+			(clearance 1.016)
+			(zone_connect 0)
+			(uuid "2d155a1a-f657-42da-b8d5-213c35dcb349")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "OLIMEX_Connectors-FP:HN1x7"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005e748049")
+		(at 135.700000 92.250000 180)
+		(property "Reference" "CON2"
+			(at -5.461 2.413 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "58891d30-5d6d-4fb8-93f7-76c25927bd03")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Value" "CON6"
+			(at -4.572 -2.286 0)
+			(layer "F.Fab")
+			(uuid "fad69636-4284-4c3b-bea4-d4d5ca63b7a3")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9958741b-1461-4b90-8985-ee30ca2d4677")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "27296a28-bc98-448e-b416-cf185395cabb")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005e6232db")
+		(solder_mask_margin 0.0508)
+		(solder_paste_margin -0.0508)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 8.89 1.016)
+			(end 8.636 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "79f4637d-072b-47c1-9272-c8b2f9ae2cfd")
+		)
+		(fp_line
+			(start 8.89 -1.016)
+			(end 8.89 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5daa2209-be86-4d6a-92c3-1dc736bc2d21")
+		)
+		(fp_line
+			(start 8.636 1.27)
+			(end 6.604 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3fbf136b-d40b-4dce-b683-4a80232d8b71")
+		)
+		(fp_line
+			(start 8.636 -1.27)
+			(end 8.89 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f502c06f-109a-4d36-8690-310ed3d5a2b2")
+		)
+		(fp_line
+			(start 6.604 1.27)
+			(end 6.35 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "85cccb2e-faa0-47a6-b9f2-9efa8846e83f")
+		)
+		(fp_line
+			(start 6.604 -1.27)
+			(end 8.636 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6ae7a2ea-8e42-443d-82c8-17870fc30859")
+		)
+		(fp_line
+			(start 6.35 1.016)
+			(end 6.096 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "28bb1b5d-1acc-42ee-af32-7d1b10e65ebe")
+		)
+		(fp_line
+			(start 6.35 1.016)
+			(end 6.096 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b914cccd-5a67-47db-8b0a-f1804c4666fc")
+		)
+		(fp_line
+			(start 6.35 -1.016)
+			(end 6.604 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b726b044-11ef-4eff-be06-9d1384ae97c7")
+		)
+		(fp_line
+			(start 6.096 1.27)
+			(end 4.064 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2650c47b-8a2f-4d8a-9f60-2cf3d227ab1f")
+		)
+		(fp_line
+			(start 6.096 1.27)
+			(end 4.064 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "94e42917-0247-40a3-a467-b6105e13f8c0")
+		)
+		(fp_line
+			(start 6.096 -1.27)
+			(end 6.35 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "85ecdaa2-5db4-4523-bdfe-22aa4587006b")
+		)
+		(fp_line
+			(start 6.096 -1.27)
+			(end 6.35 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d6acae53-f416-42ef-8fa3-7852b98c6aed")
+		)
+		(fp_line
+			(start 4.064 1.27)
+			(end 3.81 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "49841fc1-c3bf-404b-a538-6184e13171c0")
+		)
+		(fp_line
+			(start 4.064 1.27)
+			(end 3.81 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ecbc9c1f-db5f-4c2f-8d4e-0e3266863a00")
+		)
+		(fp_line
+			(start 4.064 -1.27)
+			(end 6.096 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "23d8321e-e01d-4d03-b916-ea99d9f35184")
+		)
+		(fp_line
+			(start 4.064 -1.27)
+			(end 6.096 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "409003a0-ec5d-4c2b-a17f-e78359a86337")
+		)
+		(fp_line
+			(start 3.81 1.016)
+			(end 3.556 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "38c198d0-4e4b-4717-98b4-5cc9ccd6167b")
+		)
+		(fp_line
+			(start 3.81 -1.016)
+			(end 4.064 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7fe671a2-c011-4c25-a098-9f577313bfde")
+		)
+		(fp_line
+			(start 3.81 -1.016)
+			(end 4.064 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a5be7f77-b184-4b1d-8cb0-8cb0355f4691")
+		)
+		(fp_line
+			(start 3.556 1.27)
+			(end 1.524 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f0090590-9469-4512-80fc-fb6e3a121c53")
+		)
+		(fp_line
+			(start 3.556 -1.27)
+			(end 3.81 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ece75c62-f528-4d97-adc8-499ff6bcc158")
+		)
+		(fp_line
+			(start 1.524 1.27)
+			(end 1.27 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "186c04ff-d713-4a12-9342-9abae5c798be")
+		)
+		(fp_line
+			(start 1.524 -1.27)
+			(end 3.556 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "56493d8f-bab0-4d72-b089-3002bb1b1190")
+		)
+		(fp_line
+			(start 1.27 1.016)
+			(end 1.016 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b6834206-e593-4abc-bec4-14226b22660e")
+		)
+		(fp_line
+			(start 1.27 -1.016)
+			(end 1.524 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f6081fcb-9c10-4178-a92d-e7c0e6de24dc")
+		)
+		(fp_line
+			(start 1.016 1.27)
+			(end -1.016 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "234543ee-7650-4aed-87bf-f8b3558269f0")
+		)
+		(fp_line
+			(start 1.016 -1.27)
+			(end 1.27 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3f602ce5-47d0-4fc9-b75d-80450e14872b")
+		)
+		(fp_line
+			(start -1.016 1.27)
+			(end -1.27 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a7c2185d-92a8-4cd7-9430-a6f32fd63c0b")
+		)
+		(fp_line
+			(start -1.016 -1.27)
+			(end 1.016 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0db1071d-eb09-4b1d-b686-60df08a125e0")
+		)
+		(fp_line
+			(start -1.27 1.016)
+			(end -1.524 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d90ddfca-7a04-45e3-9fab-71fb10427af4")
+		)
+		(fp_line
+			(start -1.27 -1.016)
+			(end -1.016 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2070842e-31b7-43eb-85f7-332b0241b386")
+		)
+		(fp_line
+			(start -1.524 1.27)
+			(end -3.556 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "4a13fdde-8547-411e-a359-22d321903c0d")
+		)
+		(fp_line
+			(start -1.524 -1.27)
+			(end -1.27 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "da42f39c-0634-4821-81d5-65dc3e0ba509")
+		)
+		(fp_line
+			(start -3.556 -1.27)
+			(end -1.524 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "1df38c24-f8b2-4fdc-93ec-ff35366fc9e9")
+		)
+		(fp_line
+			(start -3.81 1.016)
+			(end -3.556 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "085174c4-261a-4cce-86e1-98950547c46d")
+		)
+		(fp_line
+			(start -3.81 -1.016)
+			(end -3.556 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "fddf9c75-ae34-45e0-9a0e-7c3f8f79f0cf")
+		)
+		(fp_line
+			(start -4.064 1.27)
+			(end -3.81 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e4b91edb-ca8c-4791-b26d-80a22666ec4d")
+		)
+		(fp_line
+			(start -4.064 1.27)
+			(end -6.096 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "de460094-b3fc-4b8d-98eb-dfbea00ebf8d")
+		)
+		(fp_line
+			(start -4.064 -1.27)
+			(end -3.81 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b74b8754-7950-42ce-8be2-d94e27f84e83")
+		)
+		(fp_line
+			(start -6.096 1.27)
+			(end -6.35 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6e30ce82-b265-4909-bece-ae66e14b8baf")
+		)
+		(fp_line
+			(start -6.096 -1.27)
+			(end -4.064 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "48213b6f-c99c-4c0e-b9cf-7a18c593f99f")
+		)
+		(fp_line
+			(start -6.35 1.016)
+			(end -6.604 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7e239f8d-1b00-4dbb-8513-147e2f71cec9")
+		)
+		(fp_line
+			(start -6.35 -1.016)
+			(end -6.096 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d80d9371-813f-4a45-9721-e93b966f1f8d")
+		)
+		(fp_line
+			(start -6.604 1.27)
+			(end -8.382 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "22f1d24e-97d0-40d3-bd24-c2f1da841a0e")
+		)
+		(fp_line
+			(start -6.604 -1.27)
+			(end -6.35 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "995aeade-ca59-46f7-9851-3e541c28640e")
+		)
+		(fp_line
+			(start -8.382 1.27)
+			(end -8.89 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6cdfbda3-be39-4d77-a984-8c6f8e708bb1")
+		)
+		(fp_line
+			(start -8.636 1.27)
+			(end -8.89 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "70a204d2-fc99-4d57-87fe-c11459b1aea6")
+		)
+		(fp_line
+			(start -8.636 -1.27)
+			(end -6.604 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e022fbc6-cf7c-4b8a-9fe8-342f846028ce")
+		)
+		(fp_line
+			(start -8.89 -1.016)
+			(end -8.636 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "64b93feb-1f38-4cdc-b26d-403a74daa5b6")
+		)
+		(fp_line
+			(start -8.89 -1.27)
+			(end -8.636 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b1ed7dd7-5bc4-4213-b0f1-f6015dfdf15f")
+		)
+		(fp_line
+			(start -8.89 -1.27)
+			(end -8.89 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6f29ba7f-98ff-44d9-9503-050fdedf6277")
+		)
+		(pad "1" thru_hole rect
+			(at -7.62 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/U0TXD")
+			(uuid "bb3a5c4d-5e88-4c24-b153-cdcb213070c0")
+		)
+		(pad "2" thru_hole circle
+			(at -5.08 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/DCOM")
+			(uuid "3fdee40b-e6f5-44f8-9c78-a400123393b9")
+		)
+		(pad "3" thru_hole circle
+			(at -2.54 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/U0RXD")
+			(uuid "6f689253-4a69-4a17-a489-8ec750194451")
+		)
+		(pad "4" thru_hole circle
+			(at 0 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(uuid "347ec922-89d8-4e0d-ba1c-c78eeaa440e9")
+		)
+		(pad "5" thru_hole circle
+			(at 2.54 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/+3.3V")
+			(uuid "1f546d42-d89a-452d-9134-91f19e7e2e1a")
+		)
+		(pad "6" thru_hole circle
+			(at 5.08 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/EN")
+			(uuid "d657bd9b-1997-4c12-a6d0-9bb0428a2f0d")
+		)
+		(pad "7" thru_hole circle
+			(at 7.62 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(C1-Pad1)")
+			(uuid "cddce539-c821-4b82-b034-e9ffc30ea6b0")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/HN1x6-PinHeader_1x07_P2.54mm_Vertical.step"
+			(offset
+				(xyz 6.35 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 90)
+			)
+		)
+	)
+	(footprint "OLIMEX_Transistors-FP:SOT89"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005e7dd2a7")
+		(at 124.400000 95.000000)
+		(descr "SOT89-3, Housing, Handsoldering,")
+		(tags "SOT89-3, Housing, Handsoldering,")
+		(property "Reference" "U2"
+			(at -0.27 3.31 180)
+			(layer "F.SilkS")
+			(uuid "4d499ddb-9693-4a96-b8ae-98c0aa11141f")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "ME6210-SOT89"
+			(at -0.14986 5.30098 90)
+			(layer "F.Fab")
+			(uuid "09ab069b-133c-44dc-b87f-3000df24a4d8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "87d25ea4-1c99-4745-8bb9-a416916a43b3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "35a933bc-5d93-4a6e-9d30-c1dafea26fd0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005e7df28a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_poly
+			(pts
+				(xy 0.9 -0.1) (xy 0.5 0.9) (xy 0.5 2.3) (xy -0.5 2.3) (xy -0.5 0.9) (xy -0.9 -0.1) (xy -0.9 -2.4)
+				(xy 0.9 -2.4)
+			)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.Cu")
+			(uuid "977551d5-4fec-461a-bbe5-47b5f15f9e0c")
+		)
+		(fp_poly
+			(pts
+				(xy 0.9 -0.1) (xy 0.5 0.9) (xy 0.5 2.3) (xy -0.5 2.3) (xy -0.5 0.9) (xy -0.9 -0.1) (xy -0.9 -2.4)
+				(xy 0.9 -2.4)
+			)
+			(stroke
+				(width 0.2)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.Mask")
+			(uuid "ea372e2b-574f-4f26-bd71-4293918f1ee8")
+		)
+		(fp_line
+			(start -2 2.5)
+			(end -2.2 2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2f01de8b-4ad6-43bf-8b50-a0fd645ef669")
+		)
+		(fp_line
+			(start 2 2.5)
+			(end 2.5 2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "dc65565f-2085-4f61-898f-6caf12c41fe1")
+		)
+		(fp_line
+			(start 2.5 2.5)
+			(end 2.5 2)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "850dcbae-65d7-4efd-8f57-8251cd24eb0f")
+		)
+		(fp_line
+			(start -2.5 2.2)
+			(end -2.5 2)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "63a05f30-b14e-49df-90a8-082b44f672fe")
+		)
+		(fp_line
+			(start -2.5 -2.5)
+			(end -2.5 -2)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8f8ab5de-93e0-4e21-b746-0cd11f6498c7")
+		)
+		(fp_line
+			(start -2 -2.5)
+			(end -2.5 -2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7999a14c-f90f-4e95-9dfb-d035c4b788dd")
+		)
+		(fp_line
+			(start 2 -2.5)
+			(end 2.5 -2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c4940040-c76d-4f2f-b1e9-21e61bdb8fff")
+		)
+		(fp_line
+			(start 2.5 -2.5)
+			(end 2.5 -2)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ec8f83e2-8e46-4509-8221-c2db1fcc6f86")
+		)
+		(fp_circle
+			(center -2.5 2.5)
+			(end -2.3 2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.SilkS")
+			(uuid "1d46db64-e89c-4804-ae00-1472503eef2b")
+		)
+		(fp_poly
+			(pts
+				(xy 0.8 -0.1) (xy 0.4 0.9) (xy 0.4 2.2) (xy -0.4 2.2) (xy -0.4 0.9) (xy -0.8 -0.1) (xy -0.8 -2.3)
+				(xy 0.8 -2.3)
+			)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.Paste")
+			(uuid "2d626057-abb9-44e8-bb1f-5570561ddd73")
+		)
+		(pad "1" smd rect
+			(at -1.5 1.65)
+			(size 0.8 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "da51fbcf-8774-4852-961b-f2ad188274e7")
+		)
+		(pad "2" smd rect
+			(at 0 1.55)
+			(size 0.9 1.5019)
+			(layers "F.Cu")
+			(net "Net-(C1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "6e34de5f-e239-44f9-9f76-e35b6d5e57f0")
+		)
+		(pad "3" smd rect
+			(at 1.5 1.65)
+			(size 0.8 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/+3.3V")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "dbeea0f7-3ac9-4d44-ab36-4ac4fcdbaabe")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/SOT89-1.STEP"
+			(offset
+				(xyz 0 0.1016 0.0254)
+			)
+			(scale
+				(xyz 0.95 1.2 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_Crystal-FP:TSX-3.2x2.5mm_GND(3)"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005e7ddfaf")
+		(at 130.478000 103.527000)
+		(property "Reference" "Y1"
+			(at -1.82 -3.15 180)
+			(layer "F.SilkS")
+			(uuid "03121111-9419-414a-ab71-00c655704de1")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "Q12MHz/20pF/10ppm/4P/3.2x2.5mm"
+			(at 0.127 2.54 90)
+			(layer "F.Fab")
+			(uuid "30809338-aca2-4b26-9958-a85bc63191e9")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4e700320-8d5d-4c1f-a309-b06e5e3864a6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a382fa8e-73e2-4a93-9983-2a809e9bd9d1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005e7f6109")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.254 -1.27)
+			(end -0.254 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "12ef613e-edd9-4c96-9132-5641a499f9ed")
+		)
+		(fp_line
+			(start 0.254 1.27)
+			(end -0.254 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ee1ed1cb-ec57-43b6-b538-d5f108ef3f1f")
+		)
+		(fp_line
+			(start 0.39878 -0.64516)
+			(end 0.39878 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1d269107-a22b-4d0e-967e-5fb2593f1030")
+		)
+		(fp_line
+			(start -0.39878 -0.64516)
+			(end -0.39878 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e7cae2c5-aefe-46ed-8a07-02b0317d2cda")
+		)
+		(fp_line
+			(start 1.59766 -0.17272)
+			(end 1.59766 0.17272)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a54fefdd-c755-497e-86f4-de6bf165292f")
+		)
+		(fp_line
+			(start 0.39878 0)
+			(end 0.89916 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f829dffa-0492-4d78-844c-c070d63ca67b")
+		)
+		(fp_line
+			(start 0.39878 0)
+			(end 0.39878 0.64516)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "80ec3b07-a368-4c7e-9155-4cc9e0a0dfcf")
+		)
+		(fp_line
+			(start -0.39878 0)
+			(end -0.89916 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "644db91b-5b97-49f8-8f33-b2e0af1fbea6")
+		)
+		(fp_line
+			(start -0.39878 0)
+			(end -0.39878 0.64516)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ec5458e9-087e-453c-ae30-d0d95d6e4bb3")
+		)
+		(fp_line
+			(start -1.59766 0.17272)
+			(end -1.59766 -0.17272)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "15718051-8fb3-40fc-b558-f641c3bf422d")
+		)
+		(fp_line
+			(start 0 0.59944)
+			(end 0 -0.59944)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0d9199b6-063e-4796-b7cb-d02333d217d7")
+		)
+		(fp_line
+			(start 1.6 -1.25)
+			(end 1.6 1.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "904f6030-94ec-4f67-a4ca-cb251e0b0f3e")
+		)
+		(fp_line
+			(start -1.6 -1.25)
+			(end 1.6 -1.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ed11ccd0-dc3e-43ab-863e-56f488fdf597")
+		)
+		(fp_line
+			(start 1.6 1.25)
+			(end -1.6 1.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "146fc510-c794-4715-aad5-5b26a26a33e4")
+		)
+		(fp_line
+			(start -1.6 1.25)
+			(end -1.6 -1.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "55e5f80a-4435-48c6-8b47-f295690fa008")
+		)
+		(fp_text user "o"
+			(at -2.04 1.82 90)
+			(layer "F.SilkS")
+			(uuid "1a09e987-9e03-4659-8b42-50fb032f6d1a")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.2)
+				)
+			)
+		)
+		(pad "1" smd rect
+			(at -1.1 0.8)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C4-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "6209d7a9-7bb0-4acc-b02e-ac7c5bc76c93")
+		)
+		(pad "2" smd rect
+			(at 1.1 -0.8)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "e7c91bc7-e432-43a2-8fab-26d60e560920")
+		)
+		(pad "3" smd rect
+			(at -1.1 -0.8)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "9de4951d-d0d3-4f7b-9b70-117d3bd6a461")
+		)
+		(pad "3" smd rect
+			(at 1.1 0.8)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "467b9159-8e10-4a6c-bb2a-dc877dc6adfe")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/QSG5032.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 0.65 0.8 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_LOGOs-FP:LOGO_RECYCLEBIN_1"
+		(locked yes)
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005a3b5201")
+		(at 129.875000 98.250000)
+		(property "Reference" ""
+			(at 2.11 7.12 270)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "753efeb2-895d-45aa-a3f5-a019a6c12f77")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" ""
+			(at 2.85 -1.56 270)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "61f51a22-9847-48fe-b0c9-39b4a8449c96")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "aa66445a-4ded-4c68-a1ec-e1d699ed1294")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9bf17aef-045f-4b12-8321-e0a2f69d807b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 4.62 0.05)
+			(end 0.048 0.05)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "c3a770e4-0b1b-4d1d-ae1e-06ba7d4ab530")
+		)
+		(fp_line
+			(start 0.048 0.05)
+			(end 0.048 0.812)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6c26bd3f-ae0d-4fc0-9145-95e4745eb319")
+		)
+		(fp_line
+			(start 0.0988 0.1516)
+			(end 4.5184 0.1516)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ebdbfdd5-db0e-4670-829a-58624107b96c")
+		)
+		(fp_line
+			(start 4.5184 0.2532)
+			(end 0.1496 0.2532)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "416d01ca-66e9-4362-965a-b27c00734516")
+		)
+		(fp_line
+			(start 4.5692 0.3548)
+			(end 0.1496 0.3548)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "193d7829-0d78-4ccc-a742-04932c66491c")
+		)
+		(fp_line
+			(start 0.0988 0.4564)
+			(end 4.5692 0.4564)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "3b4ad343-af61-4a65-893b-df33af0321d4")
+		)
+		(fp_line
+			(start 4.5692 0.5072)
+			(end 0.1496 0.5072)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9347ed48-f6de-4de8-914b-312a974489da")
+		)
+		(fp_line
+			(start 0.0988 0.6088)
+			(end 4.5184 0.6088)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "cbe419f8-e0bc-451b-8c59-a46d0491a249")
+		)
+		(fp_line
+			(start 0.0988 0.6596)
+			(end 4.5692 0.6596)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1dd4286e-6fe8-4590-8a7b-f862e235184e")
+		)
+		(fp_line
+			(start 4.5692 0.7612)
+			(end 0.1496 0.7612)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6515c522-deca-4fb6-877f-19eb317ad154")
+		)
+		(fp_line
+			(start 4.62 0.812)
+			(end 4.62 0.05)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2b7e78a3-6f23-4153-9481-66e582a4f83a")
+		)
+		(fp_line
+			(start 0.048 0.812)
+			(end 4.62 0.812)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "26f1e023-b1e1-4cbd-8c33-937ee8af69f3")
+		)
+		(fp_line
+			(start 1.905 1.524)
+			(end 1.905 1.778)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "fe076586-8b23-451b-8504-42fec5ea9194")
+		)
+		(fp_line
+			(start 1.397 1.524)
+			(end 1.905 1.524)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "db927824-71a5-4e0d-a955-bfe0252fd876")
+		)
+		(fp_line
+			(start 0.381 1.524)
+			(end 4.445 5.461)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a4d540c3-c41c-4718-8649-f1c203ca2fa0")
+		)
+		(fp_line
+			(start 1.397 1.905)
+			(end 1.397 1.524)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "48d63ecb-85fd-47ee-b604-b22fd709e6df")
+		)
+		(fp_line
+			(start 1.397 1.905)
+			(end 2.794 1.905)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "47254a88-da81-499b-b727-058ca6ef6061")
+		)
+		(fp_line
+			(start 1.397 1.905)
+			(end 1.143 4.953)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5867f6b7-1c33-4eb8-ae18-53cd2c5e2ddb")
+		)
+		(fp_line
+			(start 3.302 2.413)
+			(end 3.429 4.445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4d76ffd7-4730-4ac7-9ea1-74a36dd42db7")
+		)
+		(fp_line
+			(start 3.048 4.191)
+			(end 2.159 4.191)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1c87ecef-aee6-401a-87e9-a2ace319b1a9")
+		)
+		(fp_line
+			(start 2.159 4.191)
+			(end 2.159 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "37c86ad1-a668-4dfb-a370-13eadf8b71c0")
+		)
+		(fp_line
+			(start 2.286 4.445)
+			(end 2.921 4.445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "abe175d4-63eb-4c3e-a45f-b6d3d50a03d0")
+		)
+		(fp_line
+			(start 3.81 4.572)
+			(end 3.81 5.08)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9b849a6f-7d10-4079-859f-47d7af1786dc")
+		)
+		(fp_line
+			(start 3.556 4.572)
+			(end 3.556 4.953)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "19938a1e-8900-4230-b683-6f12522427b5")
+		)
+		(fp_line
+			(start 3.429 4.572)
+			(end 3.81 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "63952aba-e317-476d-b5d3-ae42848e1b60")
+		)
+		(fp_line
+			(start 3.048 4.572)
+			(end 3.048 4.191)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ac62629b-3f4f-4b3a-bd36-817e441ad123")
+		)
+		(fp_line
+			(start 2.159 4.572)
+			(end 3.048 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "31fbe4af-8146-4618-acdd-14c700e1e4be")
+		)
+		(fp_line
+			(start 3.683 4.953)
+			(end 3.683 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "db77199c-da3c-4e7e-b498-2f904c426056")
+		)
+		(fp_line
+			(start 3.556 4.953)
+			(end 3.556 4.826)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4147d352-3a1d-4916-84b8-bbd8ff4feb24")
+		)
+		(fp_line
+			(start 3.556 4.953)
+			(end 3.556 4.826)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d74bec66-733a-4bd0-a131-82bbe45cc860")
+		)
+		(fp_line
+			(start 3.556 4.953)
+			(end 3.683 4.953)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "364bc577-3160-448a-b54b-2908f8175fa4")
+		)
+		(fp_line
+			(start 3.556 5.08)
+			(end 3.683 4.699)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f7d39122-fbfa-451c-a65c-f3de104ec7b5")
+		)
+		(fp_line
+			(start 3.429 5.08)
+			(end 3.429 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "cfb5f6ed-7f32-42a9-a98e-564708830f70")
+		)
+		(fp_line
+			(start 0.889 5.08)
+			(end 3.81 5.08)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a1e6e454-f246-422a-a919-36afb5c15ce8")
+		)
+		(fp_line
+			(start 1.397 5.207)
+			(end 1.397 5.715)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "64091c10-8f5b-4e2f-8557-813aa98d4495")
+		)
+		(fp_line
+			(start 0.254 5.588)
+			(end 4.445 1.397)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "38ef1034-ae58-4456-92e0-258f1ab01929")
+		)
+		(fp_line
+			(start 1.524 5.715)
+			(end 1.524 5.207)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4a762539-7c06-42b2-9e7c-5133172ffd3a")
+		)
+		(fp_line
+			(start 1.397 5.715)
+			(end 1.524 5.715)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0a8b67f5-eca2-44e6-98e0-93d08b42615f")
+		)
+		(fp_line
+			(start 2.54 5.842)
+			(end 2.54 5.969)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6c66aa99-7a32-4dea-b015-42731a214107")
+		)
+		(fp_line
+			(start 2.159 5.842)
+			(end 2.54 5.842)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "06bf3182-dcb3-4ed2-a269-01f65357ba44")
+		)
+		(fp_line
+			(start 2.54 5.969)
+			(end 2.159 5.969)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "606103b9-ec7c-4be7-af04-0f5a64217076")
+		)
+		(fp_line
+			(start 2.159 5.969)
+			(end 2.159 5.842)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2f8533de-5944-40ce-85e9-f5b77b90f26f")
+		)
+		(fp_arc
+			(start 3.429 5.207)
+			(mid 2.286 5.680446)
+			(end 1.143 5.207)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "023b007e-821a-43a5-aac3-723f2cebc903")
+		)
+		(fp_circle
+			(center 3.302 1.905)
+			(end 3.429 1.905)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "02ddb86a-aec8-4afb-b69a-c321b2b8072c")
+		)
+		(fp_circle
+			(center 3.302 1.905)
+			(end 3.683 2.032)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "fbc17b2f-379d-4983-8ce0-e1aa23f184e2")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "OLIMEX_LOGOs-FP:LOGO_PBFREE"
+		(locked yes)
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8c51dd")
+		(at 129.875000 98.250000)
+		(property "Reference" ""
+			(at -0.2794 3.52552 0)
+			(layer "B.SilkS")
+			(uuid "55da5eac-77e6-4e57-bd60-548c9cc732be")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" ""
+			(at 0.05588 -3.15214 0)
+			(layer "B.Fab")
+			(uuid "c86019ce-deb4-4f07-85e8-4ab10d4290a5")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "301a4d4d-73ea-4fb7-9f59-67693b31b3cd")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cef0db74-b8ad-4b02-a043-e207da7a8ff3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.36398 1.47828)
+			(end 1.06934 -0.94234)
+			(stroke
+				(width 0.2)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "082d5993-4bad-4f93-b62c-f027763ec073")
+		)
+		(fp_circle
+			(center -0.2032 0.31496)
+			(end 0.90678 1.73482)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "7c5ef266-0f27-4ed6-9ec9-4d7005304d7a")
+		)
+		(fp_text user "Pb"
+			(at -0.08636 0.33528 0)
+			(layer "B.SilkS")
+			(uuid "d2946751-8ae6-4e6e-b955-1eb81f8bbe09")
+			(effects
+				(font
+					(size 1.7 1.5)
+					(thickness 0.254)
+				)
+				(justify mirror)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(footprint "OLIMEX_LOGOs-FP:OLIMEX_LOGO_TB"
+		(locked yes)
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005e7dd057")
+		(at 129.875000 98.250000)
+		(property "Reference" ""
+			(at -2.4003 3.0607 180)
+			(layer "B.SilkS")
+			(hide yes)
+			(uuid "399d0cef-b3bf-41a9-92f0-fae906f3fada")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" ""
+			(at -1.6637 -3.7084 180)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "5a9754fc-e6ca-425f-b11e-ef9379c56dec")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cd0e1d64-4d73-47da-9a70-d0cdcb15b890")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7860c809-15e2-4b52-af9a-037006db9555")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 7.2644 1.3081)
+			(end 6.4008 0.4144)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7308d41f-5e8b-4541-ac16-38446872acc7")
+		)
+		(fp_line
+			(start 7.2136 -1.3716)
+			(end 6.3754 -0.5588)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ab4d15c6-d809-4979-bd31-7911f42eb225")
+		)
+		(fp_line
+			(start 5.8674 -0.4572)
+			(end 6.4008 -0.4572)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "bf2a81b1-ff11-4c63-a285-f09390059607")
+		)
+		(fp_line
+			(start 5.842 0.3175)
+			(end 6.4008 0.3175)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7fa9ae2e-04e0-46d6-ac9a-bab4a3741ac8")
+		)
+		(fp_line
+			(start 4.8387 1.8288)
+			(end 6.096 0.5842)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "79eadff5-aef5-41de-843d-0efb243000bb")
+		)
+		(fp_line
+			(start 4.7879 1.8288)
+			(end 4.8387 1.8288)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7e63c563-5040-4021-9bf8-69b4816347f6")
+		)
+		(fp_line
+			(start 4.7244 1.4986)
+			(end 5.8166 0.4318)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "fbffb3ab-cb62-4103-a139-39680ebcb461")
+		)
+		(fp_line
+			(start 4.7244 -1.6764)
+			(end 5.8674 -0.5588)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5368f0d4-e2b6-4a6f-ab77-74213bfccd0a")
+		)
+		(fp_line
+			(start 4.191 -0.0762)
+			(end 2.9718 -0.0762)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0db95411-a72f-43bf-add2-d0f38c28b1ef")
+		)
+		(fp_line
+			(start 3.5025 1.4986)
+			(end 4.7244 1.4986)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "11ad56c4-c0ec-42a7-8f24-8b0704d47297")
+		)
+		(fp_line
+			(start 3.4163 1.8288)
+			(end 4.7879 1.8288)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a7ba5318-4d83-439e-ae1b-00e09ed372c2")
+		)
+		(fp_line
+			(start 3.4036 -1.6764)
+			(end 4.7244 -1.6764)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2006bd8d-1b84-4af1-84e6-7e847894503b")
+		)
+		(fp_line
+			(start 2.9718 1.016)
+			(end 3.4544 1.524)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "dad99415-6907-4e8d-945a-3138d6701da1")
+		)
+		(fp_line
+			(start 2.9718 0.9906)
+			(end 2.9718 -1.2446)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "495592f8-620d-410c-a67d-01b8a26348fa")
+		)
+		(fp_line
+			(start 2.9718 -1.2446)
+			(end 3.4036 -1.6764)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "243a1c9a-55c7-4a02-a7df-c78438416b62")
+		)
+		(fp_line
+			(start 2.0447 1.7907)
+			(end 0.7493 1.7907)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0bbd95a3-72d3-498c-8f86-3b5668c8471c")
+		)
+		(fp_line
+			(start 2.0447 1.778)
+			(end 2.0447 1.7907)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9e308bb5-dcbf-4130-90cd-888a87e2f18c")
+		)
+		(fp_line
+			(start 2.0447 -1.2319)
+			(end 2.0447 1.778)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4985d1e2-20c7-48c5-853f-c27e8d0a6fbf")
+		)
+		(fp_line
+			(start 1.8923 1.7145)
+			(end 1.9939 1.7145)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "bf3d020f-0e07-4960-a5eb-1f5d1de17776")
+		)
+		(fp_line
+			(start 1.7145 1.4859)
+			(end 1.7145 -1.1176)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "28409c7b-5c96-463d-a9e6-4cbd0f2d66f9")
+		)
+		(fp_line
+			(start 0.8128 1.4732)
+			(end 1.7018 1.4732)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "30f53825-af9d-439b-aea6-aec4efe42522")
+		)
+		(fp_line
+			(start 0.7493 1.7907)
+			(end 0.7239 1.7907)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b40f334e-9ddb-41ff-aac2-fc22fd496a73")
+		)
+		(fp_line
+			(start 0.7239 1.7907)
+			(end 0.1016 1.2954)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "8bbd251d-593f-4d2e-b867-3c947d3360a1")
+		)
+		(fp_line
+			(start 0.1778 0.9652)
+			(end 0.8128 1.4732)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0bcc8587-fa28-436a-89b0-2609724d2d3f")
+		)
+		(fp_line
+			(start 0.1016 0.1778)
+			(end 0.1016 0.889)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5c5b3092-e670-4250-99d6-191ed3149198")
+		)
+		(fp_line
+			(start -0.5207 1.7907)
+			(end 0.0635 1.3081)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f2281f64-1def-4e76-91ac-cd01bbab5b11")
+		)
+		(fp_line
+			(start -0.6096 1.4732)
+			(end 0 0.9652)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4b599bfe-9525-4940-8894-e2212a1e6a80")
+		)
+		(fp_line
+			(start -1.4478 1.4732)
+			(end -0.6096 1.4732)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "44a8d006-6c3f-4c0e-b79d-45dea3a10784")
+		)
+		(fp_line
+			(start -1.4478 -1.1176)
+			(end -1.4478 1.4732)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f7236fc0-7037-41d2-b032-1a7d009c8983")
+		)
+		(fp_line
+			(start -1.6129 1.7272)
+			(end -1.6891 1.7272)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "3f9da128-984c-4e48-993b-bcd59d315ed7")
+		)
+		(fp_line
+			(start -1.7653 1.7907)
+			(end -0.5207 1.7907)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6e56ee92-0a45-4413-be02-3ff1092ffb5b")
+		)
+		(fp_line
+			(start -1.7653 -1.2065)
+			(end -1.7653 1.778)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6c147495-10a1-4351-8fe7-81cffd9fad56")
+		)
+		(fp_line
+			(start -2.3495 -0.8636)
+			(end -2.3495 1.1557)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9a4dde35-a763-49c4-a8dd-7a25af6febd7")
+		)
+		(fp_line
+			(start -2.3749 -0.8636)
+			(end -2.3495 -0.8636)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b96ddc50-abd4-4d38-bbf2-fe31587e6b5c")
+		)
+		(fp_line
+			(start -2.5019 -0.8001)
+			(end -2.413 -0.8001)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ff7cc0c2-f489-41e4-870e-434dc5bbe659")
+		)
+		(fp_line
+			(start -2.667 1.0414)
+			(end -2.667 -0.5588)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "177ab1fa-d633-4bc2-ac17-a8fc5580fb61")
+		)
+		(fp_line
+			(start -2.8448 -0.8001)
+			(end -2.9083 -0.8001)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "92832d70-509e-46f8-a1ff-35801806468f")
+		)
+		(fp_line
+			(start -2.9845 1.1557)
+			(end -2.9845 -0.8636)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2019161b-7938-4a3b-b97f-712c6bf196a2")
+		)
+		(fp_line
+			(start -2.9845 -0.8636)
+			(end -2.3749 -0.8636)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6f0a261f-15ea-4c5a-aea1-8777333806b4")
+		)
+		(fp_line
+			(start -3.1798 -1.6764)
+			(end -4.1656 -1.6764)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "cd9986b4-d7b8-49d6-ad15-0df447dc76b2")
+		)
+		(fp_line
+			(start -4.1656 -1.6764)
+			(end -4.6228 -1.2192)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a693fe77-aa42-4629-91da-e891d35be80e")
+		)
+		(fp_line
+			(start -4.3053 1.8415)
+			(end -4.3053 -1.1938)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f723620b-68d7-4a21-98a7-1dd100b5986b")
+		)
+		(fp_line
+			(start -4.4831 1.7653)
+			(end -4.3688 1.7653)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "072d03c8-be7e-4595-8ad1-4fd1baa225f4")
+		)
+		(fp_line
+			(start -4.6101 1.8415)
+			(end -4.3053 1.8415)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b9d88d32-c489-4465-aaf7-b4d944d91d1d")
+		)
+		(fp_line
+			(start -4.6228 1.8415)
+			(end -4.9022 1.8415)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "003fd888-0473-413e-adb0-ec76b41d23cd")
+		)
+		(fp_line
+			(start -4.6228 -1.2319)
+			(end -4.6228 1.4986)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "3ccd6512-6f74-44a4-ab18-4e0850f4ef19")
+		)
+		(fp_line
+			(start -4.7879 1.7526)
+			(end -4.8514 1.7653)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "825dc198-b5f4-45ef-bce2-e04fceb0da40")
+		)
+		(fp_line
+			(start -4.9022 1.8415)
+			(end -4.9149 1.8415)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6997c5ff-73c0-4e68-a7ca-05908c330633")
+		)
+		(fp_line
+			(start -4.9149 1.8415)
+			(end -4.9276 1.8415)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "68d2fb7e-a28e-4a6b-b177-f5a33383d8a1")
+		)
+		(fp_line
+			(start -4.9276 1.8415)
+			(end -4.9276 -1.3081)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "bb8ab64c-487e-41ac-a573-8361ed4ae914")
+		)
+		(fp_line
+			(start -5.7785 0.889)
+			(end -5.7785 -1.0414)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6cc2353c-69b8-4cb5-8925-086943a3a4db")
+		)
+		(fp_line
+			(start -5.7912 -1.0795)
+			(end -6.35 -1.6637)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "764e59f0-faf5-4c37-b990-bc276e17cc39")
+		)
+		(fp_line
+			(start -6.4008 1.4986)
+			(end -7.4041 1.4986)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e2dff08a-2d85-44a7-943d-f94c8cf5a2ce")
+		)
+		(fp_line
+			(start -6.4008 1.4859)
+			(end -5.7658 0.8763)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0d753950-3996-428e-81ec-66314582c494")
+		)
+		(fp_line
+			(start -7.4295 -1.6891)
+			(end -6.3881 -1.6891)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f5033879-b547-4084-8f4e-acd91627aa12")
+		)
+		(fp_line
+			(start -7.9883 -1.1303)
+			(end -7.9883 -0.3683)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9395f758-3041-4bf6-84aa-6337782c0ffb")
+		)
+		(fp_line
+			(start -8.001 0.9017)
+			(end -7.493 1.4097)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7e9d2c26-0243-45d9-af68-6c93ef6d7611")
+		)
+		(fp_line
+			(start -8.001 0.8509)
+			(end -8.001 0.6096)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a9d3cb7a-69e6-46b9-ac38-56b5505b7b98")
+		)
+		(fp_line
+			(start -8.001 -1.1176)
+			(end -7.4168 -1.6891)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7cf3b0f5-b8e4-4286-b8e3-76e0f3dca45a")
+		)
+		(fp_circle
+			(center 7.6327 1.6637)
+			(end 7.9375 1.8542)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "d0264f73-a328-4455-b0be-4f7bc426f55e")
+		)
+		(fp_circle
+			(center 7.5438 -1.7272)
+			(end 7.8359 -1.5748)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "d767a115-1994-4ee4-8439-2ec82c4ba899")
+		)
+		(fp_circle
+			(center 4.699 -0.0762)
+			(end 4.9657 0.1651)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "45116d00-6592-447c-b577-427ad201fbf5")
+		)
+		(fp_circle
+			(center 1.7145 -1.6383)
+			(end 1.9304 -1.3462)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "33d2b6ff-d344-47b5-9917-aca2749f42e0")
+		)
+		(fp_circle
+			(center 0.1016 -0.3556)
+			(end 0.3302 -0.0635)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "17205aa1-2969-4cc9-840c-620cc306a641")
+		)
+		(fp_circle
+			(center -1.4351 -1.6256)
+			(end -1.1938 -1.3589)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "4570dae9-6c63-46d4-a24f-74028d866a95")
+		)
+		(fp_circle
+			(center -2.6543 1.5748)
+			(end -2.54 1.9304)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "127a5504-a5f9-4ce1-a0c2-aeb10dd0b07d")
+		)
+		(fp_circle
+			(center -2.667 -1.651)
+			(end -2.4638 -1.3462)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "608b5b14-5718-4e71-9517-71a024a265e8")
+		)
+		(fp_circle
+			(center -7.9883 0.127)
+			(end -7.6708 0.2413)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "910ec872-6da5-44fd-a998-cb3af4919baf")
+		)
+		(embedded_fonts no)
+	)
+	(gr_line
+		(start 114 91)
+		(end 145.75 91)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "c98b8739-5517-49c0-94ff-7449c2e1f124")
+	)
+	(gr_line
+		(start 114 105.5)
+		(end 114 91)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "9fd60985-4559-4d03-995f-538746ddb926")
+	)
+	(gr_line
+		(start 145.75 91)
+		(end 145.75 105.5)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "958a9bf3-dbc9-40cf-9a79-578932c7906e")
+	)
+	(gr_line
+		(start 145.75 105.5)
+		(end 114 105.5)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "608edb87-fa2c-450e-b965-d0fd974fd824")
+	)
+	(embedded_fonts no)
+)

--- a/tests/fixtures/run25/esp_prog_lap3.kicad_prl
+++ b/tests/fixtures/run25/esp_prog_lap3.kicad_prl
@@ -1,0 +1,105 @@
+{
+  "board": {
+    "active_layer": 0,
+    "active_layer_preset": "",
+    "auto_track_width": true,
+    "hidden_netclasses": [],
+    "hidden_nets": [],
+    "high_contrast_mode": 0,
+    "net_color_mode": 1,
+    "opacity": {
+      "images": 0.6,
+      "pads": 1.0,
+      "shapes": 1.0,
+      "tracks": 1.0,
+      "vias": 1.0,
+      "zones": 0.6
+    },
+    "prototype_zone_fills": false,
+    "selection_filter": {
+      "dimensions": true,
+      "footprints": true,
+      "graphics": true,
+      "keepouts": true,
+      "lockedItems": false,
+      "otherItems": true,
+      "pads": true,
+      "text": true,
+      "tracks": true,
+      "vias": true,
+      "zones": true
+    },
+    "visible_items": [
+      "vias",
+      "footprint_text",
+      "footprint_anchors",
+      "ratsnest",
+      "grid",
+      "footprints_front",
+      "footprints_back",
+      "footprint_values",
+      "footprint_references",
+      "tracks",
+      "drc_errors",
+      "drawing_sheet",
+      "bitmaps",
+      "pads",
+      "zones",
+      "drc_warnings",
+      "drc_exclusions",
+      "locked_item_shadows",
+      "conflict_shadows",
+      "shapes",
+      "board_outline_area",
+      "ly_points"
+    ],
+    "visible_layers": "ffffffff_ffffffff_ffffffff_ffffffff",
+    "zone_display_mode": 0
+  },
+  "git": {
+    "integration_disabled": false,
+    "repo_type": "",
+    "repo_username": "",
+    "ssh_key": ""
+  },
+  "meta": {
+    "filename": "seed1.kicad_prl",
+    "version": 5
+  },
+  "net_inspector_panel": {
+    "col_hidden": [],
+    "col_order": [],
+    "col_widths": [],
+    "custom_group_rules": [],
+    "expanded_rows": [],
+    "filter_by_net_name": true,
+    "filter_by_netclass": true,
+    "filter_text": "",
+    "group_by_constraint": false,
+    "group_by_netclass": false,
+    "show_time_domain_details": false,
+    "show_unconnected_nets": false,
+    "show_zero_pad_nets": false,
+    "sort_ascending": true,
+    "sorting_column": -1
+  },
+  "open_jobsets": [],
+  "project": {
+    "files": []
+  },
+  "schematic": {
+    "hierarchy_collapsed": [],
+    "selection_filter": {
+      "graphics": true,
+      "images": true,
+      "labels": true,
+      "lockedItems": false,
+      "otherItems": true,
+      "pins": true,
+      "ruleAreas": true,
+      "symbols": true,
+      "text": true,
+      "wires": true
+    }
+  }
+}

--- a/tests/fixtures/run25/esp_prog_lap3.kicad_pro
+++ b/tests/fixtures/run25/esp_prog_lap3.kicad_pro
@@ -1,0 +1,61 @@
+{
+  "board": {
+    "design_settings": {
+      "rules": {
+        "min_clearance": 0.15,
+        "min_hole_clearance": 0.15,
+        "min_hole_to_hole": 0.25,
+        "min_copper_edge_clearance": 0.3,
+        "min_track_width": 0.15,
+        "min_via_diameter": 0.45,
+        "min_through_hole_diameter": 0.25,
+        "min_via_drill": 0.25
+      },
+      "rule_severities": {}
+    }
+  },
+  "meta": {
+    "filename": "board.kicad_pro",
+    "version": 1
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12,
+        "clearance": 0.15,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": 0.2,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.2,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "priority": 2147483647,
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.15,
+        "via_diameter": 0.45,
+        "via_drill": 0.25,
+        "wire_width": 6
+      }
+    ],
+    "meta": {
+      "version": 0
+    }
+  },
+  "kicad_routing_tools": {
+    "floor_provenance": {
+      "authored_by": "run25 orchestrator, before any placement/routing tool ran (brief step 1, #441)",
+      "floors": {
+        "clearance": 0.15,
+        "track_width": 0.15,
+        "via_diameter": 0.45,
+        "via_drill": 0.25,
+        "hole_to_hole": 0.25,
+        "copper_edge": 0.3
+      },
+      "note": "fix_kicad_drc_settings capped min_clearance and the Default class at the 0.0508 mm pad override found on C1/C3/Q1/Q2/U2; both hand-raised to the declared 0.15 floor (KiCad floors a pad override at rules.min_clearance, so 0.15 is what every checker grades). Class draw defaults set to the declared sizes.",
+      "escalation": "board"
+    }
+  }
+}

--- a/tests/fixtures/run25/esp_prog_lap5.kicad_pcb
+++ b/tests/fixtures/run25/esp_prog_lap5.kicad_pcb
@@ -1,0 +1,5791 @@
+(kicad_pcb
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(general
+		(thickness 1.6)
+		(legacy_teardrops no)
+	)
+	(paper "A4")
+	(layers
+		(0 "F.Cu" signal)
+		(2 "B.Cu" signal)
+		(9 "F.Adhes" user)
+		(11 "B.Adhes" user)
+		(13 "F.Paste" user)
+		(15 "B.Paste" user)
+		(5 "F.SilkS" user)
+		(7 "B.SilkS" user)
+		(1 "F.Mask" user)
+		(3 "B.Mask" user)
+		(17 "Dwgs.User" user)
+		(19 "Cmts.User" user)
+		(21 "Eco1.User" user)
+		(23 "Eco2.User" user)
+		(25 "Edge.Cuts" user)
+		(27 "Margin" user)
+		(31 "F.CrtYd" user)
+		(29 "B.CrtYd" user)
+		(35 "F.Fab" user)
+		(33 "B.Fab" user)
+	)
+	(setup
+		(pad_to_mask_clearance 0.0508)
+		(solder_mask_min_width 0.0508)
+		(pad_to_paste_clearance -0.0508)
+		(allow_soldermask_bridges_in_footprints no)
+		(tenting
+			(front yes)
+			(back yes)
+		)
+		(covering
+			(front no)
+			(back no)
+		)
+		(plugging
+			(front no)
+			(back no)
+		)
+		(capping no)
+		(filling no)
+		(aux_axis_origin 114 105.5)
+		(pcbplotparams
+			(layerselection 0x00000000_00000000_55555555_575575ff)
+			(plot_on_all_layers_selection 0x00000000_00000000_00000000_00000000)
+			(disableapertmacros no)
+			(usegerberextensions no)
+			(usegerberattributes no)
+			(usegerberadvancedattributes no)
+			(creategerberjobfile no)
+			(dashed_line_dash_ratio 12)
+			(dashed_line_gap_ratio 3)
+			(svgprecision 4)
+			(plotframeref no)
+			(mode 1)
+			(useauxorigin no)
+			(pdf_front_fp_property_popups yes)
+			(pdf_back_fp_property_popups yes)
+			(pdf_metadata yes)
+			(pdf_single_document no)
+			(dxfpolygonmode yes)
+			(dxfimperialunits yes)
+			(dxfusepcbnewfont yes)
+			(psnegative no)
+			(psa4output no)
+			(plot_black_and_white yes)
+			(sketchpadsonfab no)
+			(plotpadnumbers no)
+			(hidednponfab no)
+			(sketchdnponfab yes)
+			(crossoutdnponfab yes)
+			(subtractmaskfromsilk no)
+			(outputformat 1)
+			(mirror no)
+			(drillshape 0)
+			(scaleselection 1)
+			(outputdirectory "gerbers/")
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:C_0603_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3efb")
+		(at 123.250000 98.100000)
+		(descr "Resistor SMD 0603, reflow soldering, Vishay (see dcrcw.pdf)")
+		(tags "resistor 0603")
+		(property "Reference" "C1"
+			(at 0.02 1.42 90)
+			(layer "F.SilkS")
+			(uuid "f75a27fd-d1c4-458f-8b68-56b483dc9e19")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2.2uF"
+			(at 0.127 1.778 90)
+			(layer "F.Fab")
+			(uuid "72de1e9a-e38b-4467-8c50-032e9cd51554")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1852f3c8-e8cc-47e0-b367-8611cc6f47b5")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6d88cc1b-1f4b-472c-9c5e-19af7292f099")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000055069cf9")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.508 -0.762)
+			(end 0.508 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "35ea92c1-9e3b-4387-aa21-b42022e5b828")
+		)
+		(fp_line
+			(start -0.508 0.762)
+			(end 0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "785854c6-f55d-4a27-80f7-1af3aaa9866d")
+		)
+		(fp_line
+			(start 1.651 -0.762)
+			(end 1.651 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d9de512a-6634-4766-b8c2-61fcb9e8fca9")
+		)
+		(fp_line
+			(start 0.508 -0.762)
+			(end 1.651 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "692ad022-7a42-4c15-b38a-24353cee65ed")
+		)
+		(fp_line
+			(start -0.508 -0.762)
+			(end -1.651 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1ddd5c01-ccc6-4201-ab2b-10ffcd50d633")
+		)
+		(fp_line
+			(start -1.651 -0.762)
+			(end -1.651 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c3158be1-8f7d-45f7-817c-d3c1451f270e")
+		)
+		(fp_line
+			(start 1.651 0.762)
+			(end 0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0776f5ac-0e9e-463d-a90e-bbc33109bf83")
+		)
+		(fp_line
+			(start -1.651 0.762)
+			(end -0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6331247c-8849-4ade-90f0-f2e2e262a0d3")
+		)
+		(fp_line
+			(start 0.762 -0.381)
+			(end 0 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7b34b4c4-07b8-447e-bb1a-55abdda3902e")
+		)
+		(fp_line
+			(start 0 -0.381)
+			(end -0.762 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4f29cb63-5415-4a1a-95e1-7e2dc701541b")
+		)
+		(fp_line
+			(start -0.762 -0.381)
+			(end -0.762 0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "29c2be3d-d493-46ec-8913-4e58dcfb8f7e")
+		)
+		(fp_line
+			(start 0.762 0.381)
+			(end 0.762 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d2012f09-e8e3-4b76-b29f-2416acbd1872")
+		)
+		(fp_line
+			(start -0.762 0.381)
+			(end 0.762 0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b0f6cd93-e2fc-4dff-8413-e11a8d411b8a")
+		)
+		(pad "1" smd rect
+			(at -0.889 0)
+			(size 1.016 1.016)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "c9fe2374-c58b-407e-90b5-0df5c3cd3078")
+		)
+		(pad "2" smd rect
+			(at 0.889 0)
+			(size 1.016 1.016)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "bb3f8234-235f-499f-b6d2-6b609c3aedeb")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/C_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:C_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f0f")
+		(at 126.964000 102.665000 180)
+		(tags "C0402")
+		(property "Reference" "C2"
+			(at -2.1 -0.1 90)
+			(layer "F.SilkS")
+			(uuid "bfe81756-fa32-4c91-85ca-9dafcee55832")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "27pF"
+			(at 0 1.905 90)
+			(layer "F.Fab")
+			(uuid "afc5aa3f-a483-4bb7-a932-39e0290f26ad")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f46e3d5f-37c9-4d7b-af06-42d8b55f5e75")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "39f3d48b-3e28-4811-a96c-0202c40d1a98")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8acdb7")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "75e27d7e-1147-4ba6-8cb7-65d985df04b7")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "742905ca-fb6e-4776-83fe-9fcc7c97d3a7")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ca9d5db3-03df-4e51-931e-cb05f0b5df78")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0a385e74-7e5e-43f1-8c42-f5866aa70cb0")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "33be7a8b-6a82-4bfd-9c67-f7b6515759a4")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d85f51d5-ebac-41d1-9902-a2277d6ac7b1")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4e1b7661-355d-46f7-bb91-71951b312e70")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "492f7e53-cbec-424d-9aec-f66c611fa041")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1f15d293-b287-4bfb-a405-abe1e5b675ae")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9e882702-ce26-46f0-bf79-eb291037d326")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "20dd8e46-9562-46b0-a867-a8ca8e949ec4")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a6f5f42a-5fa6-4634-b0d2-b7c210c994ca")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "918e4fd8-5d8b-43ae-acf5-ea8267eb8804")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1193b8e0-83dd-4c45-bb92-96007c358352")
+		)
+		(pad "1" smd rect
+			(at -0.508 0)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "c05c74cf-6dcb-4258-9cff-71b669d8dc06")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 180)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "b433d5e4-f9e0-4845-b167-df024b26609d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:C_0603_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f22")
+		(at 126.350000 98.100000)
+		(descr "Resistor SMD 0603, reflow soldering, Vishay (see dcrcw.pdf)")
+		(tags "resistor 0603")
+		(property "Reference" "C3"
+			(at -2.27 0.59 0)
+			(layer "F.SilkS")
+			(uuid "c74cc472-1cec-4d24-b416-63036f14783f")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2.2uF"
+			(at 0.127 1.778 0)
+			(layer "F.Fab")
+			(uuid "6584dab3-3d0f-459f-adcd-671dd563f275")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "963df33f-2430-4e51-a1ef-974a5dbe19d8")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7a4bad7c-d2fb-4c07-bf73-cb8993011454")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000055069c71")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.508 0.762)
+			(end 0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5a3eb310-acd4-45f3-93b1-e8cd2d491b0c")
+		)
+		(fp_line
+			(start -0.508 -0.762)
+			(end 0.508 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7c0aedfc-120f-4105-b883-b5a777e1c92d")
+		)
+		(fp_line
+			(start 1.651 0.762)
+			(end 0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "683c5b34-2b55-42ef-afcd-34c76ca9c892")
+		)
+		(fp_line
+			(start 1.651 -0.762)
+			(end 1.651 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "16894053-ef17-4cf2-ad7c-fc8e2d6b7727")
+		)
+		(fp_line
+			(start 0.508 -0.762)
+			(end 1.651 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6185e63d-22f8-4dd8-8292-6a50f4dc0558")
+		)
+		(fp_line
+			(start -0.508 -0.762)
+			(end -1.651 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ad090b28-054b-43f9-a3d3-bb4e3e64b3f3")
+		)
+		(fp_line
+			(start -1.651 0.762)
+			(end -0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a88ac355-08b0-4512-9672-a8caed8ebea6")
+		)
+		(fp_line
+			(start -1.651 -0.762)
+			(end -1.651 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "98a6364c-9f65-4220-9222-5630896822a8")
+		)
+		(fp_line
+			(start 0.762 0.381)
+			(end 0.762 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4a8eddc8-5a72-4f98-a4bf-a9e079c73580")
+		)
+		(fp_line
+			(start 0.762 -0.381)
+			(end 0 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d0d94442-29b2-4c2f-a9df-0806aeebd144")
+		)
+		(fp_line
+			(start 0 -0.381)
+			(end -0.762 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "aa0420b5-baf9-41f6-ab9b-b69921994b55")
+		)
+		(fp_line
+			(start -0.762 0.381)
+			(end 0.762 0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "121f4f4e-ca8e-4529-ba5e-86cec623edf0")
+		)
+		(fp_line
+			(start -0.762 -0.381)
+			(end -0.762 0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d07fd336-c791-49a4-8938-47c68c9cab77")
+		)
+		(pad "1" smd rect
+			(at -0.889 0)
+			(size 1.016 1.016)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/+3.3V")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "e8e0c496-9ab2-499a-8329-6706b727c6ae")
+		)
+		(pad "2" smd rect
+			(at 0.889 0)
+			(size 1.016 1.016)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "1d648374-bc5e-465c-a964-a415515bdd69")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/C_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:C_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f36")
+		(at 127.199000 104.096000 180)
+		(tags "C0402")
+		(property "Reference" "C4"
+			(at -1.102 1.014 180)
+			(layer "F.SilkS")
+			(uuid "bc677c80-53dd-4f08-98e8-31e324557bc0")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "27pF"
+			(at 0 1.905 90)
+			(layer "F.Fab")
+			(uuid "fb7e2869-b4dd-454d-91c0-5e038d2c07c7")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9cd7c0aa-dcaa-4d63-a892-2b1ea78c0a54")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b8b35adf-612d-4b2f-9fb2-0e21e9044d45")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000055069da1")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ce5bc01c-c3f6-4bbd-8329-326a517ffdec")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5bf31d8d-0642-462e-ae9f-79384a944cf3")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0ec4ccfe-5f9a-4f97-8cab-ece0f2cb51d2")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ab51b595-a988-4ac3-9891-cb27f3cdeae2")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "595d0de0-df4f-4e1d-b9fa-aa15908a4dcc")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "39927f66-140c-491a-8935-8a19091cbce6")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ce722752-5145-4955-b190-e6415d2c6648")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7886fb79-8ade-4b2d-8c06-0990ec7145ce")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a1649be7-bd87-4b49-ba90-e64269e5af44")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "df9c04b4-2182-4c85-ba2f-f6b4f0e8ced5")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ef8032a2-af72-40dc-b75d-6cc874e43ce7")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c39a7149-18b6-4678-b71b-dbabebe2af68")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "27f8eda9-143a-4783-b25e-451bf3144a2d")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e498aa95-5328-48f6-b10c-8bd583002cd7")
+		)
+		(pad "1" smd rect
+			(at -0.508 0)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C4-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "f5fa8d41-8b5b-4801-9517-d6be5bcac583")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 180)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "c73c3ff6-d1db-46ee-bb45-94a620fa0541")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_Connectors-FP:WU06SM"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f44")
+		(at 144.650000 98.800000 270)
+		(property "Reference" "CON1"
+			(at -0.2 -1.5 90)
+			(layer "F.SilkS")
+			(uuid "c53fb5c7-5633-441d-8a0a-998e61ec4b18")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "CON6"
+			(at 0 -2.54 90)
+			(layer "F.Fab")
+			(uuid "d6cfb4cb-2294-4406-88a2-5c9df595b9a7")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1f3b2da5-757b-4cb5-920f-c5e5b95c1d70")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a3726cc9-7730-4652-9a5b-271fb1f05a9b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8a1e69")
+		(solder_mask_margin 0.0508)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -4.85 1.1)
+			(end -4.85 -2.1)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "be5041df-1eaa-46f6-842b-a5296b5e7988")
+		)
+		(fp_line
+			(start 4.85 1.1)
+			(end -4.85 1.1)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b68b63bc-ff21-42a3-9c37-766f6afe5b9f")
+		)
+		(fp_line
+			(start -4.85 -2.1)
+			(end 4.85 -2.1)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b78f2cb9-173a-4d48-98b4-8f7c4c266052")
+		)
+		(fp_line
+			(start 4.85 -2.1)
+			(end 4.85 1.1)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f90af397-a07a-4e47-99fe-e9eb2ba869d3")
+		)
+		(pad "1" thru_hole oval
+			(at -3.125 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/U0TXD")
+			(uuid "fb19e8f8-bb34-468e-a684-827edf79d3c8")
+		)
+		(pad "2" thru_hole oval
+			(at -1.875 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/DCOM")
+			(uuid "bd8dc4f4-0243-458a-85ec-719f868c7ae7")
+		)
+		(pad "3" thru_hole oval
+			(at -0.625 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/U0RXD")
+			(uuid "ce5942b5-71d7-41a7-b746-edf7d14af784")
+		)
+		(pad "4" thru_hole oval
+			(at 0.625 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(uuid "8247ece4-cc28-462f-ab3a-db7da1427200")
+		)
+		(pad "5" thru_hole oval
+			(at 1.875 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/+3.3V")
+			(uuid "a0b6b78f-04f7-4f50-b022-0fdfb8f1e207")
+		)
+		(pad "6" thru_hole oval
+			(at 3.125 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/EN")
+			(uuid "d74b4b89-0c94-485f-aee6-07917f8da44c")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/WU06S-Molex_PicoBlade_530470610_1x06_P1.25mm_Vertical.step"
+			(offset
+				(xyz 0 0.5428 2.54)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz -90 0 -180)
+			)
+		)
+	)
+	(footprint "OLIMEX_Transistors-FP:SOT23"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f57")
+		(at 139.000000 99.200000 180)
+		(property "Reference" "Q1"
+			(at -1.6 -1 0)
+			(layer "F.SilkS")
+			(uuid "30552372-aa78-4afe-a1ae-bad929e8edc0")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "BC817-40(SOT23)"
+			(at 3.5052 2.6416 0)
+			(layer "F.Fab")
+			(uuid "db168cae-0535-488f-845c-70f3fa7eb843")
+			(effects
+				(font
+					(size 1.1 1.1)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b621f733-e3cb-412d-a695-7c792c9019ef")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "62f1d14d-5f4f-43fd-a0e5-067b0bea46b1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8a927f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.2032 1.4224)
+			(end -0.635 1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "054f1970-4597-4e19-b95f-a34b81d74d44")
+		)
+		(fp_line
+			(start 0.2032 -1.4224)
+			(end -0.635 -1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "76d37a5a-8c56-429b-8a14-013555262bf9")
+		)
+		(fp_line
+			(start -0.635 0.7112)
+			(end -0.635 1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a7c8b24e-4c33-4b7c-8ee6-2e2fba817abb")
+		)
+		(fp_line
+			(start -0.635 -1.4224)
+			(end -0.635 -0.7112)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "eb6bb575-8fb9-4627-b8dd-fc8f3008364b")
+		)
+		(fp_line
+			(start 1.19888 0.95758)
+			(end 0.82804 0.95758)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "84a83fd2-68b9-4adc-b8a6-f0b98d3a1ac7")
+		)
+		(fp_line
+			(start 1.19126 -0.95504)
+			(end 0.82042 -0.95504)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "563b045a-e592-40a6-a7b7-01700a7b7a1f")
+		)
+		(fp_line
+			(start 0.65278 1.41478)
+			(end -0.65024 1.41478)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2af0f7fc-f454-4a38-b6bd-67850eab4307")
+		)
+		(fp_line
+			(start 0.65278 -1.4097)
+			(end 0.65278 1.4097)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "003e8884-906a-4c4e-b15a-53416a7989b8")
+		)
+		(fp_line
+			(start -0.65024 0.00762)
+			(end -0.65278 1.35636)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e571de33-5e83-4458-978e-67dbd581e61e")
+		)
+		(fp_line
+			(start -0.65024 0.00508)
+			(end -0.65024 -1.41732)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "81afa320-3df0-4309-b0ba-83cf8347800e")
+		)
+		(fp_line
+			(start -0.65532 -1.42494)
+			(end 0.64262 -1.42494)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d218610b-4cf1-43ca-b500-259913ddd589")
+		)
+		(fp_line
+			(start -0.81026 0.00254)
+			(end -1.1811 0.00254)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "30e005f3-24b9-44f7-b2b4-2ce8f59abe2e")
+		)
+		(pad "1" smd rect
+			(at 1.10744 0.94996 180)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(Q1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "021f20be-b6f4-4fa8-a291-aa7de978068f")
+		)
+		(pad "2" smd rect
+			(at 1.10744 -0.9525 180)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/DTR")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "ea771218-fc35-499d-836d-a2e3479bcc16")
+		)
+		(pad "3" smd rect
+			(at -1.10236 0.00254 180)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/DCOM")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "4439e5cf-1444-4745-a6c1-78842dac1b34")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/SOT-23.step"
+			(offset
+				(xyz 0 0 0.5)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz -90 0 90)
+			)
+		)
+	)
+	(footprint "OLIMEX_Transistors-FP:SOT23"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f6a")
+		(at 139.000000 102.400000)
+		(property "Reference" "Q2"
+			(at -1.6 -1.3 0)
+			(layer "F.SilkS")
+			(uuid "50c186ed-bd8b-4770-8d18-a4f47cc5c02f")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "BC817-40(SOT23)"
+			(at 3.5052 2.6416 0)
+			(layer "F.Fab")
+			(uuid "35ce9468-3746-484b-b631-c3a953bc6470")
+			(effects
+				(font
+					(size 1.1 1.1)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "75bad9b6-4c36-414b-aab7-8dafc5179781")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a0d1ff3a-d393-4185-b8da-2edb44288ab4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8ab147")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.2032 1.4224)
+			(end -0.635 1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8227fd38-eb7d-4476-9c5e-c799a490237b")
+		)
+		(fp_line
+			(start 0.2032 -1.4224)
+			(end -0.635 -1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "11ea48f4-d46f-44ad-8346-071dcba4c1e0")
+		)
+		(fp_line
+			(start -0.635 0.7112)
+			(end -0.635 1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6a8dc534-7284-4047-afec-34126ce0e01e")
+		)
+		(fp_line
+			(start -0.635 -1.4224)
+			(end -0.635 -0.7112)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "9e02ec0b-0a02-4920-b274-93a6e4be0072")
+		)
+		(fp_line
+			(start 1.19888 0.95758)
+			(end 0.82804 0.95758)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "65bdb41e-5a9c-441b-a7cf-e9ee88978954")
+		)
+		(fp_line
+			(start 1.19126 -0.95504)
+			(end 0.82042 -0.95504)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2833823c-c443-4d61-9793-094ac615a088")
+		)
+		(fp_line
+			(start 0.65278 1.41478)
+			(end -0.65024 1.41478)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "537ce652-1eab-4333-a5b0-a833749c9e38")
+		)
+		(fp_line
+			(start 0.65278 -1.4097)
+			(end 0.65278 1.4097)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d494fb77-f3ab-4454-a000-f744a1e88e2b")
+		)
+		(fp_line
+			(start -0.65024 0.00762)
+			(end -0.65278 1.35636)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c52ca018-be5d-4685-9892-e0bfe2fa8012")
+		)
+		(fp_line
+			(start -0.65024 0.00508)
+			(end -0.65024 -1.41732)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9a671dea-b970-42a7-83df-d7fc665e21a0")
+		)
+		(fp_line
+			(start -0.65532 -1.42494)
+			(end 0.64262 -1.42494)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "30e3dae2-ccfc-4be2-81b2-2eaf9ab4f38f")
+		)
+		(fp_line
+			(start -0.81026 0.00254)
+			(end -1.1811 0.00254)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "14b865bf-569e-4b98-a03c-7e7211f1b696")
+		)
+		(pad "1" smd rect
+			(at 1.10744 0.94996)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(Q2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "30cf95b6-d203-4aba-a961-9c3e6bfeff9e")
+		)
+		(pad "2" smd rect
+			(at 1.10744 -0.9525)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/RTS")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "c919269f-44c6-4003-8903-606e3fd497c5")
+		)
+		(pad "3" smd rect
+			(at -1.10236 0.00254)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/EN")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "e2653a60-ec3b-438f-be14-0117b6e8cab1")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/SOT-23.step"
+			(offset
+				(xyz 0 0 0.5)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz -90 0 90)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:R_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f7e")
+		(at 141.796000 100.637000 270)
+		(tags "C0402")
+		(property "Reference" "R1"
+			(at 1.47 -0.03 180)
+			(layer "F.SilkS")
+			(uuid "43c5d8c2-77e9-455e-9413-711753d1a614")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1K"
+			(at 0 1.397 90)
+			(layer "F.Fab")
+			(uuid "4e16573c-8803-44c9-b2b2-7a3ba48631d0")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "16d731a1-334c-4a51-8f46-1743cd3c1912")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6a53e361-12ff-44b8-91e9-ec074787355f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8aaad1")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0b61af81-f37e-40c2-941c-317ff79f1cdb")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8f92d0f9-9c23-4545-bad1-3119e3d6c813")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d4669a6b-3770-4b73-9047-80e5368faeff")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "466b2737-ea5e-4e34-b519-6cb176ad02e5")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6bfcebea-3959-4529-aaa4-03a31c6cf75c")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0d997e12-ecd4-404d-a3fb-4de503fe9d8a")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6f9cd834-4e0d-41c3-896e-813f7bf61a21")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c037e704-50c8-4bcd-8f1d-1e673291abf5")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "80572a16-0f2f-420d-9c99-658e66e89806")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "884f799f-01ec-4936-b092-2a0eb10bf9fc")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3d183ce0-640d-4f8b-97b6-24613f2ad491")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "460d783a-99c5-4c5b-a12c-509d1f9cdece")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f85b79fa-34e2-43e4-8c69-b75d7b38eed7")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ee9a41a5-e50b-4e65-857e-723b25faa6b0")
+		)
+		(pad "1" smd rect
+			(at -0.508 0 90)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(Q1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "9e118f2e-37f9-416d-a5c4-181d66f482c5")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 270)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/RTS")
+			(solder_mask_margin 0.0508)
+			(uuid "5ee747f5-3d69-425a-b1f3-c973b2dfd4a8")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:R_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3fa6")
+		(at 131.960000 93.952000 180)
+		(tags "C0402")
+		(property "Reference" "R3"
+			(at -0.5 -1.1 0)
+			(layer "F.SilkS")
+			(uuid "95a4e8f2-e864-4c43-ac13-8db2d560cf62")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100R"
+			(at 0 1.397 0)
+			(layer "F.Fab")
+			(uuid "c909afb5-c5d9-442d-a281-7eeaf260fb43")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "03d19569-2694-4fe2-978e-bbf984f599ac")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b80bc789-8933-40bd-b42b-a8a0ea887849")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8af572")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d028c661-d125-4a92-9135-686be42a4b56")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5bc08d76-a6bf-413d-9031-ce0827300366")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "357ca64d-5770-4143-90c2-044898337931")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "45e4ddc6-a3c3-4da2-85f5-1d236f064f46")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "555327aa-c6e6-4d8b-9ab6-7036623bd761")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "42bc4342-347f-4ebb-979f-0fa9cbd71040")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c79fdf81-c61d-4502-86a0-dac709f43524")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "52118b7c-684b-4c10-954a-7fc6a3c0e8b6")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d0f916b2-e7e1-4855-9047-41a0ac524bb3")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "54ec7a07-84d3-420b-9748-bb15dd379da3")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0f83f417-837d-4efd-b5a2-1ec64cbafffd")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fab12dc0-91ca-4bdf-9288-02a3a6f663cd")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "754005df-e92a-4800-98c6-34557dca8546")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d49b4dbe-d3b8-477c-8719-b4abe481af0c")
+		)
+		(pad "1" smd rect
+			(at -0.508 0)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/U0RXD")
+			(solder_mask_margin 0.0508)
+			(uuid "8256635e-fed3-4354-b293-9c00fc208dc1")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 180)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(R3-Pad2)")
+			(solder_mask_margin 0.0508)
+			(uuid "8f9b214c-93ef-4d04-9357-83d267b717b9")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:R_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3fba")
+		(at 134.553000 94.003000 180)
+		(tags "C0402")
+		(property "Reference" "R4"
+			(at -0.4 -1.1 0)
+			(layer "F.SilkS")
+			(uuid "f367dcc2-bd28-44cd-a54a-66f9d7b68291")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100R"
+			(at 0 1.397 0)
+			(layer "F.Fab")
+			(uuid "8bacdc0a-f150-4a39-83c8-661abcfba510")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "5a9dc1cc-538e-4463-b5c1-d4fa8e7d86f8")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d871c68d-73cd-44b5-b71d-8f1379bc7017")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8aff5c")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0af709b6-4d18-44de-b650-878203f09c91")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "77fdc967-f388-46c7-bac2-6d011d37ee12")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "421a604b-4b19-47fa-8949-8d67a328b99f")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "296ea335-e5ad-4fd5-ad71-1640a5ddbc38")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1a9904b8-9903-4c8c-9627-e066e28dade1")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "21489bf0-9d75-4966-8fdc-76773a4e4f8f")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6d78a26d-f0be-4fc0-85d6-0275576c35a8")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9b50b163-7b4d-4a5a-9a26-286bb1abcf83")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "afdeaac9-d882-4748-96b4-e2593e1d8685")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6cb4f9de-4500-4001-8a0e-87495fbbf28c")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "13387796-3e59-431f-b907-f0d01a22b364")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b38f0052-d14d-4a40-b4d4-28313fa25b79")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d5808c2f-a3b7-4412-a18b-2e7a3dddfdf4")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9756d28b-1115-4fc2-af7f-5fb08b379a86")
+		)
+		(pad "1" smd rect
+			(at -0.508 0)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/U0TXD")
+			(solder_mask_margin 0.0508)
+			(uuid "dce00e07-dafd-4feb-b475-db34afc34981")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 180)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(R4-Pad2)")
+			(solder_mask_margin 0.0508)
+			(uuid "fe65b2de-a32f-4c23-9446-82bba982fa8d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_IC-FP:SSOP-20W"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3fd8")
+		(at 132.300000 98.600000 270)
+		(descr "SSOP 20 pins")
+		(tags "CMS SSOP SMD")
+		(property "Reference" "U1"
+			(at -4.2 -3.5 180)
+			(layer "F.SilkS")
+			(uuid "de496a2e-6a01-4180-8898-0ccee2ff715f")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "CH340H/T"
+			(at 0 5.715 0)
+			(layer "F.Fab")
+			(uuid "41ff27c3-6b39-48d4-85cf-2bf156ab17aa")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c48f918c-f4f5-42c2-b630-5e6576122cf6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2ee7367a-b761-4e72-a29e-82b8ca1beb1c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000055069b04")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -3.81 2.7305)
+			(end -3.81 -2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "68035f87-6cd5-47b7-b246-f7024acd8b7a")
+		)
+		(fp_line
+			(start -3.81 2.7305)
+			(end 3.81 2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "cce7fb09-5dff-4c08-8b7d-e02098d30b6b")
+		)
+		(fp_line
+			(start -3.429 -2.7305)
+			(end -3.429 2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2361d3b6-0cd6-4301-b4f3-f80dedb56e58")
+		)
+		(fp_line
+			(start 3.81 -2.7305)
+			(end -3.81 -2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "dea79ab3-b0bc-445c-92e1-0503c0c4b074")
+		)
+		(fp_line
+			(start 3.81 -2.7305)
+			(end 3.81 2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6e8095af-db2c-4df0-8fb2-a3bccab98e90")
+		)
+		(fp_text user "o"
+			(at -3.81 3.556 0)
+			(layer "F.SilkS")
+			(uuid "aacbeec9-f99b-4d77-8f61-03f07bb0f591")
+			(effects
+				(font
+					(size 1.016 1.016)
+					(thickness 0.254)
+				)
+			)
+		)
+		(pad "1" smd rect
+			(at -2.925 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(solder_mask_margin 0.0508)
+			(uuid "07890969-265c-49e1-9e44-d68402d5e15e")
+		)
+		(pad "2" smd rect
+			(at -2.275 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(solder_mask_margin 0.0508)
+			(uuid "67f28907-1d6d-4c26-ad8b-ddd54daa222c")
+		)
+		(pad "3" smd rect
+			(at -1.625 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(R3-Pad2)")
+			(solder_mask_margin 0.0508)
+			(uuid "6014ba7d-68db-468c-ac25-e0158bbdc081")
+		)
+		(pad "4" smd rect
+			(at -0.975 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(R4-Pad2)")
+			(solder_mask_margin 0.0508)
+			(uuid "61def817-2e70-4a3a-9dca-b66831d4f4a7")
+		)
+		(pad "5" smd rect
+			(at -0.325 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/+3.3V")
+			(solder_mask_margin 0.0508)
+			(uuid "e5483ff9-2a40-4085-a597-084f3fa111e4")
+		)
+		(pad "6" smd rect
+			(at 0.325 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/D_P")
+			(solder_mask_margin 0.0508)
+			(uuid "dda9c363-77d3-4b31-9ae2-bed1c186a6b8")
+		)
+		(pad "7" smd rect
+			(at 0.975 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/D_N")
+			(solder_mask_margin 0.0508)
+			(uuid "3dd486be-3ecc-4342-8924-532bf4142957")
+		)
+		(pad "8" smd rect
+			(at 1.625 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "2b140a09-4a02-4d95-b95f-dcefd8c75a63")
+		)
+		(pad "9" smd rect
+			(at 2.275 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C4-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "666ef700-d49a-4f8a-a999-6a10bb742382")
+		)
+		(pad "10" smd rect
+			(at 2.925 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "22909fde-31e3-491e-85ca-312dc7566451")
+		)
+		(pad "11" smd rect
+			(at 2.925 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad11)")
+			(solder_mask_margin 0.0508)
+			(uuid "4fc06dd2-0c45-406b-892a-f09892b5438a")
+		)
+		(pad "12" smd rect
+			(at 2.275 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad12)")
+			(solder_mask_margin 0.0508)
+			(uuid "ae19993d-4d8a-4cc3-983a-1218d53420cb")
+		)
+		(pad "13" smd rect
+			(at 1.625 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad13)")
+			(solder_mask_margin 0.0508)
+			(uuid "4b6f1dc9-217c-4242-a3cf-bbc59412197e")
+		)
+		(pad "14" smd rect
+			(at 0.975 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad14)")
+			(solder_mask_margin 0.0508)
+			(uuid "64082188-2f6e-4af1-9d61-aad04a336ce4")
+		)
+		(pad "15" smd rect
+			(at 0.325 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/DTR")
+			(solder_mask_margin 0.0508)
+			(uuid "f6319632-c37d-46de-b502-75166d8c5f03")
+		)
+		(pad "16" smd rect
+			(at -0.325 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/RTS")
+			(solder_mask_margin 0.0508)
+			(uuid "dbfc3510-0568-45d9-a9c9-7914c106b9ac")
+		)
+		(pad "17" smd rect
+			(at -0.975 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(solder_mask_margin 0.0508)
+			(uuid "306d12e4-19b9-48a3-8387-785799dc981d")
+		)
+		(pad "18" smd rect
+			(at -1.625 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad18)")
+			(solder_mask_margin 0.0508)
+			(uuid "5b884ccb-faa7-4810-a925-e59756821566")
+		)
+		(pad "19" smd rect
+			(at -2.275 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/+3.3V")
+			(solder_mask_margin 0.0508)
+			(uuid "1d34e49b-8a46-4654-995f-83c66f5cbf39")
+		)
+		(pad "20" smd rect
+			(at -2.925 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad20)")
+			(solder_mask_margin 0.0508)
+			(uuid "fa2243b4-8c94-44ec-9891-647bdb349a3e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/SSOP-20_5.3x7.2mm_P0.65mm.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 -90)
+			)
+		)
+	)
+	(footprint "OLIMEX_Connectors-FP:USB-MICRO_MISB-SWMM-5B_LF"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a4001")
+		(at 117.500000 100.000000 180)
+		(property "Reference" "USB1"
+			(at -4.8 0.9 90)
+			(layer "F.SilkS")
+			(uuid "49c304bc-0e90-413f-ac15-e11b46f84fa4")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "USB-uicro-B"
+			(at 0 6.75 0)
+			(layer "F.Fab")
+			(uuid "f6ce7fb3-95a6-4f77-8aee-68f9d967d88f")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bdaaf03a-c35f-46e5-8ce7-338983ab1ae9")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7806526d-eeb0-4f24-b1a8-d8b28f3ed700")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005506aa9a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 3.5 -4.064)
+			(end 3.5 4.064)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b8231ab5-c092-4217-a913-f50444a515c4")
+		)
+		(fp_line
+			(start 3.429 4.064)
+			(end 2.413 3.683)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "09d6b1cb-0c83-4e0b-997d-ad2c13ead9a7")
+		)
+		(fp_line
+			(start 3.429 -4.064)
+			(end 2.413 -3.683)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "48760d6b-2690-48bc-bd3b-fec690fc94d8")
+		)
+		(fp_line
+			(start 2.4 3.7)
+			(end 1.4 3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "de64ecb8-ae38-405e-bdbd-5c50912a3a1c")
+		)
+		(fp_line
+			(start 2.4 -3.7)
+			(end 2.4 3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "fb5fa81d-1b93-4fe0-8c20-e2e6aef2967e")
+		)
+		(fp_line
+			(start 1.4 -3.7)
+			(end 2.4 -3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "1e28470d-17d2-443e-9b86-8e6dddb6f236")
+		)
+		(fp_line
+			(start -2.1 3.7)
+			(end -0.9 3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "decf7438-feb0-4b7a-9536-2bb8b425d94b")
+		)
+		(fp_line
+			(start -2.1 -3.7)
+			(end -0.9 -3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "9baccd7b-4072-4ab8-8b3c-90f1e87ebfdb")
+		)
+		(fp_line
+			(start -3.6 1.8)
+			(end -3.6 2.8)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "743a2f78-6a67-404e-a07f-d950c966644f")
+		)
+		(fp_line
+			(start -3.6 -2.8)
+			(end -3.6 -1.8)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "22e55154-0703-4094-bd1d-abb7ed125fc1")
+		)
+		(fp_line
+			(start 3.5 3.7)
+			(end -3.6 -3.7)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9a1f64f7-dd2b-4e25-8302-ee9acf3e5990")
+		)
+		(fp_line
+			(start 3.5 3.7)
+			(end -3.62 3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7f548f60-02c7-4682-b0ce-9b4a103f29ca")
+		)
+		(fp_line
+			(start 3.5 -3.7)
+			(end 3.5 3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c6166d67-c0e5-44c2-be50-f2a83cd6437b")
+		)
+		(fp_line
+			(start 3.5 -3.7)
+			(end -3.6 3.7)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ea49c05d-e561-4e59-95a2-7302731ed53c")
+		)
+		(fp_line
+			(start 2.4 3.7)
+			(end 2.4 -3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6955c5d9-b2f1-406f-91db-a82ee674e8ef")
+		)
+		(fp_line
+			(start -3.62 3.7)
+			(end -3.62 -3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d20b1762-9334-44c0-8eed-693a64f24efd")
+		)
+		(fp_line
+			(start -3.62 -3.7)
+			(end 3.5 -3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4f97366d-a610-40ef-a60e-ebc7a58fcd19")
+		)
+		(fp_text user "VBUS"
+			(at -0.5 1.5 0)
+			(layer "F.SilkS")
+			(uuid "59e29b7f-994c-4d5c-8b45-bdf6f55594e2")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "GND"
+			(at -0.9 -1.6 0)
+			(layer "F.SilkS")
+			(uuid "d417b14b-7619-49b0-b8c7-5cb703f3ed30")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "D-"
+			(at -1 0.75 0)
+			(layer "F.SilkS")
+			(uuid "f3c3ec99-e38a-4e54-8391-fafbafffeaa0")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "D+"
+			(at -1 0 0)
+			(layer "F.SilkS")
+			(uuid "43596a4e-6638-4bf5-aca5-99e16d344e98")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "ID"
+			(at -1.25 -0.75 0)
+			(layer "F.SilkS")
+			(uuid "74369b5a-2b46-409b-886b-8a1e34fced14")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "pcb edge"
+			(at 2.1 0 90)
+			(layer "F.Fab")
+			(uuid "2384cac3-eaf9-41af-ae23-8e3f02458a35")
+			(effects
+				(font
+					(size 0.3 0.3)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at -1.9 -2 270)
+			(size 0.6 0.6)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(solder_mask_margin 0.0508)
+			(uuid "d0afb88c-e134-482e-b278-893e3089c3b1")
+		)
+		(pad "" np_thru_hole circle
+			(at -1.9 2 270)
+			(size 0.6 0.6)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(solder_mask_margin 0.0508)
+			(uuid "42a4dd8e-0e82-4028-bba3-4bdb4b37a067")
+		)
+		(pad "0" thru_hole oval
+			(at -3.22 -3.6 270)
+			(size 1.2 1.8)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "f9c3f8b3-51b1-4a46-9834-ff74623a7f85")
+		)
+		(pad "0" thru_hole oval
+			(at -3.22 3.6 270)
+			(size 1.2 1.8)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "b966ad11-f51a-45a6-8e83-9f4ad1d2fe58")
+		)
+		(pad "0" thru_hole oval
+			(at 0.25 -3.6 270)
+			(size 1.2 1.8)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "19e2922c-f59b-4882-b2aa-1f57564800f3")
+		)
+		(pad "0" thru_hole oval
+			(at 0.25 3.6 270)
+			(size 1.2 1.8)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "25d57cbf-b101-4639-b5bf-45fb45a0f4f0")
+		)
+		(pad "0" smd rect
+			(at 1.4 -1.5 270)
+			(size 1.1 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.127)
+			(uuid "ecf1bbb3-2a49-443e-9b15-715e1d25c075")
+		)
+		(pad "0" smd rect
+			(at 1.4 1.5 270)
+			(size 1.1 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.127)
+			(uuid "0fa3c66e-f326-4def-be04-4631b20f9ead")
+		)
+		(pad "1" smd rect
+			(at -3.15 1.3875 270)
+			(size 0.5 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "ded6b8dd-333c-4616-992b-be785699496c")
+		)
+		(pad "2" smd rect
+			(at -3.15 0.65 270)
+			(size 0.325 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/D_N")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.03556)
+			(uuid "eb0e35e8-1943-4845-9e33-c88d6c28986a")
+		)
+		(pad "3" smd rect
+			(at -3.15 0 270)
+			(size 0.325 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/D_P")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.03556)
+			(uuid "060a14c7-77e8-4490-8ae8-7dded28d4cd8")
+		)
+		(pad "4" smd rect
+			(at -3.15 -0.65 270)
+			(size 0.325 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(USB1-Pad4)")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.03556)
+			(uuid "be7ce030-740b-4d93-986d-10e697a77ee0")
+		)
+		(pad "5" smd rect
+			(at -3.15 -1.3875 270)
+			(size 0.5 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "eb963628-6d9e-40f8-9010-b5bb679b47b3")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/usb_micro_4p.stp"
+			(offset
+				(xyz -2.45 0 1.1)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 -90)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:R_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8c45a4")
+		(at 141.908000 103.080000 90)
+		(tags "C0402")
+		(property "Reference" "R2"
+			(at 1.07 -1.58 0)
+			(layer "F.SilkS")
+			(uuid "4796363d-3e81-459f-a212-c43aa52ab3e8")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1K"
+			(at 0 1.397 90)
+			(layer "F.Fab")
+			(uuid "8997ade5-a6c1-4e3f-abb4-e35719c5901f")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "44e33ed6-4445-4806-a41f-123365cfee7b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "aec16f68-2858-4fd8-b150-774caa5d0b6a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8ab138")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6740a799-6bf9-4ad8-860f-cfb7420a758a")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "cb0dd33d-f8e5-4678-a807-963e05815359")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "466e974f-ff64-48ef-82cd-524278169324")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c06452a3-6b10-4682-a506-b13bddc4a16b")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "828ea7b4-fb09-43d7-8505-66eefcf35224")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "98a83e8e-305a-4d38-a866-1e5df6f38783")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "93acd6fb-a6fd-41e8-82c0-507d15d45e6f")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "fd628e01-5142-4d03-b897-2fde269ac67d")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5ba9276b-ae34-4731-9f54-e78304a42feb")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "194aa5bd-bf92-4b13-b97d-3e56826e068d")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "53ecc657-6bf8-4237-8515-b4cb0bf8aae8")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "12400381-8471-49b4-a40c-3a08acb9358d")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "138f7812-9c53-44f1-823c-b3dbbcf5047d")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "aa3608fc-e4a3-46b2-b1a4-6c04a2020aac")
+		)
+		(pad "1" smd rect
+			(at -0.508 0 270)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(Q2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "40bf59e5-1e1a-4369-9f07-8a89731e80eb")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 90)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/DTR")
+			(solder_mask_margin 0.0508)
+			(uuid "f90028d5-92ce-4c2e-8bfb-90e1bfadeacc")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_Other-FP:Fiducial1x3_transp"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8c55cd")
+		(at 141.200000 95.900000)
+		(property "Reference" "Ref*"
+			(at 0 3 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "5a22dbb2-ec0a-40f6-aacb-432ac5b6d21f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "Val**"
+			(at 0 -3 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d3151732-31b9-4d5d-a6c4-dacf550da8c0")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "253f7a3c-5603-42f9-96cf-c9539251fbf5")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9d930eec-c497-4e5d-b53a-a95cfb340f03")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 1.5 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(fill no)
+			(layer "Dwgs.User")
+			(uuid "eec7448f-6827-4289-a4ac-c8840394d472")
+		)
+		(pad "Fid1" connect circle
+			(at 0 0)
+			(size 1 1)
+			(layers "F.Cu" "F.Mask")
+			(solder_mask_margin 0.127)
+			(clearance 1.016)
+			(zone_connect 0)
+			(uuid "a66154ca-f352-4c46-85cc-f8f40e022877")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "OLIMEX_Other-FP:Fiducial1x3_transp"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8c55f6")
+		(at 118.100000 99.900000)
+		(property "Reference" "Ref*"
+			(at 0 3 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "d084a8ae-21ad-49b8-ba12-392d130d8d3e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "Val**"
+			(at 0 -3 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bcd7a0ff-8f2b-461b-bbf7-f38b71b3588b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "895763e0-6dfe-4f7f-a7a5-5a443538985c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "135940cb-574b-49d8-8ed1-4af4bd2c030d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 1.5 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(fill no)
+			(layer "Dwgs.User")
+			(uuid "78d81f2c-791c-4230-a277-0f3baae900db")
+		)
+		(pad "Fid1" connect circle
+			(at 0 0)
+			(size 1 1)
+			(layers "F.Cu" "F.Mask")
+			(solder_mask_margin 0.127)
+			(clearance 1.016)
+			(zone_connect 0)
+			(uuid "2d155a1a-f657-42da-b8d5-213c35dcb349")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "OLIMEX_Connectors-FP:HN1x7"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005e748049")
+		(at 135.950000 92.250000 180)
+		(property "Reference" "CON2"
+			(at -5.461 2.413 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "58891d30-5d6d-4fb8-93f7-76c25927bd03")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Value" "CON6"
+			(at -4.572 -2.286 0)
+			(layer "F.Fab")
+			(uuid "fad69636-4284-4c3b-bea4-d4d5ca63b7a3")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9958741b-1461-4b90-8985-ee30ca2d4677")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "27296a28-bc98-448e-b416-cf185395cabb")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005e6232db")
+		(solder_mask_margin 0.0508)
+		(solder_paste_margin -0.0508)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 8.89 1.016)
+			(end 8.636 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "79f4637d-072b-47c1-9272-c8b2f9ae2cfd")
+		)
+		(fp_line
+			(start 8.89 -1.016)
+			(end 8.89 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5daa2209-be86-4d6a-92c3-1dc736bc2d21")
+		)
+		(fp_line
+			(start 8.636 1.27)
+			(end 6.604 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3fbf136b-d40b-4dce-b683-4a80232d8b71")
+		)
+		(fp_line
+			(start 8.636 -1.27)
+			(end 8.89 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f502c06f-109a-4d36-8690-310ed3d5a2b2")
+		)
+		(fp_line
+			(start 6.604 1.27)
+			(end 6.35 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "85cccb2e-faa0-47a6-b9f2-9efa8846e83f")
+		)
+		(fp_line
+			(start 6.604 -1.27)
+			(end 8.636 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6ae7a2ea-8e42-443d-82c8-17870fc30859")
+		)
+		(fp_line
+			(start 6.35 1.016)
+			(end 6.096 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "28bb1b5d-1acc-42ee-af32-7d1b10e65ebe")
+		)
+		(fp_line
+			(start 6.35 1.016)
+			(end 6.096 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b914cccd-5a67-47db-8b0a-f1804c4666fc")
+		)
+		(fp_line
+			(start 6.35 -1.016)
+			(end 6.604 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b726b044-11ef-4eff-be06-9d1384ae97c7")
+		)
+		(fp_line
+			(start 6.096 1.27)
+			(end 4.064 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2650c47b-8a2f-4d8a-9f60-2cf3d227ab1f")
+		)
+		(fp_line
+			(start 6.096 1.27)
+			(end 4.064 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "94e42917-0247-40a3-a467-b6105e13f8c0")
+		)
+		(fp_line
+			(start 6.096 -1.27)
+			(end 6.35 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "85ecdaa2-5db4-4523-bdfe-22aa4587006b")
+		)
+		(fp_line
+			(start 6.096 -1.27)
+			(end 6.35 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d6acae53-f416-42ef-8fa3-7852b98c6aed")
+		)
+		(fp_line
+			(start 4.064 1.27)
+			(end 3.81 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "49841fc1-c3bf-404b-a538-6184e13171c0")
+		)
+		(fp_line
+			(start 4.064 1.27)
+			(end 3.81 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ecbc9c1f-db5f-4c2f-8d4e-0e3266863a00")
+		)
+		(fp_line
+			(start 4.064 -1.27)
+			(end 6.096 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "23d8321e-e01d-4d03-b916-ea99d9f35184")
+		)
+		(fp_line
+			(start 4.064 -1.27)
+			(end 6.096 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "409003a0-ec5d-4c2b-a17f-e78359a86337")
+		)
+		(fp_line
+			(start 3.81 1.016)
+			(end 3.556 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "38c198d0-4e4b-4717-98b4-5cc9ccd6167b")
+		)
+		(fp_line
+			(start 3.81 -1.016)
+			(end 4.064 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7fe671a2-c011-4c25-a098-9f577313bfde")
+		)
+		(fp_line
+			(start 3.81 -1.016)
+			(end 4.064 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a5be7f77-b184-4b1d-8cb0-8cb0355f4691")
+		)
+		(fp_line
+			(start 3.556 1.27)
+			(end 1.524 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f0090590-9469-4512-80fc-fb6e3a121c53")
+		)
+		(fp_line
+			(start 3.556 -1.27)
+			(end 3.81 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ece75c62-f528-4d97-adc8-499ff6bcc158")
+		)
+		(fp_line
+			(start 1.524 1.27)
+			(end 1.27 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "186c04ff-d713-4a12-9342-9abae5c798be")
+		)
+		(fp_line
+			(start 1.524 -1.27)
+			(end 3.556 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "56493d8f-bab0-4d72-b089-3002bb1b1190")
+		)
+		(fp_line
+			(start 1.27 1.016)
+			(end 1.016 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b6834206-e593-4abc-bec4-14226b22660e")
+		)
+		(fp_line
+			(start 1.27 -1.016)
+			(end 1.524 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f6081fcb-9c10-4178-a92d-e7c0e6de24dc")
+		)
+		(fp_line
+			(start 1.016 1.27)
+			(end -1.016 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "234543ee-7650-4aed-87bf-f8b3558269f0")
+		)
+		(fp_line
+			(start 1.016 -1.27)
+			(end 1.27 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3f602ce5-47d0-4fc9-b75d-80450e14872b")
+		)
+		(fp_line
+			(start -1.016 1.27)
+			(end -1.27 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a7c2185d-92a8-4cd7-9430-a6f32fd63c0b")
+		)
+		(fp_line
+			(start -1.016 -1.27)
+			(end 1.016 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0db1071d-eb09-4b1d-b686-60df08a125e0")
+		)
+		(fp_line
+			(start -1.27 1.016)
+			(end -1.524 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d90ddfca-7a04-45e3-9fab-71fb10427af4")
+		)
+		(fp_line
+			(start -1.27 -1.016)
+			(end -1.016 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2070842e-31b7-43eb-85f7-332b0241b386")
+		)
+		(fp_line
+			(start -1.524 1.27)
+			(end -3.556 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "4a13fdde-8547-411e-a359-22d321903c0d")
+		)
+		(fp_line
+			(start -1.524 -1.27)
+			(end -1.27 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "da42f39c-0634-4821-81d5-65dc3e0ba509")
+		)
+		(fp_line
+			(start -3.556 -1.27)
+			(end -1.524 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "1df38c24-f8b2-4fdc-93ec-ff35366fc9e9")
+		)
+		(fp_line
+			(start -3.81 1.016)
+			(end -3.556 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "085174c4-261a-4cce-86e1-98950547c46d")
+		)
+		(fp_line
+			(start -3.81 -1.016)
+			(end -3.556 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "fddf9c75-ae34-45e0-9a0e-7c3f8f79f0cf")
+		)
+		(fp_line
+			(start -4.064 1.27)
+			(end -3.81 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e4b91edb-ca8c-4791-b26d-80a22666ec4d")
+		)
+		(fp_line
+			(start -4.064 1.27)
+			(end -6.096 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "de460094-b3fc-4b8d-98eb-dfbea00ebf8d")
+		)
+		(fp_line
+			(start -4.064 -1.27)
+			(end -3.81 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b74b8754-7950-42ce-8be2-d94e27f84e83")
+		)
+		(fp_line
+			(start -6.096 1.27)
+			(end -6.35 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6e30ce82-b265-4909-bece-ae66e14b8baf")
+		)
+		(fp_line
+			(start -6.096 -1.27)
+			(end -4.064 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "48213b6f-c99c-4c0e-b9cf-7a18c593f99f")
+		)
+		(fp_line
+			(start -6.35 1.016)
+			(end -6.604 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7e239f8d-1b00-4dbb-8513-147e2f71cec9")
+		)
+		(fp_line
+			(start -6.35 -1.016)
+			(end -6.096 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d80d9371-813f-4a45-9721-e93b966f1f8d")
+		)
+		(fp_line
+			(start -6.604 1.27)
+			(end -8.382 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "22f1d24e-97d0-40d3-bd24-c2f1da841a0e")
+		)
+		(fp_line
+			(start -6.604 -1.27)
+			(end -6.35 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "995aeade-ca59-46f7-9851-3e541c28640e")
+		)
+		(fp_line
+			(start -8.382 1.27)
+			(end -8.89 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6cdfbda3-be39-4d77-a984-8c6f8e708bb1")
+		)
+		(fp_line
+			(start -8.636 1.27)
+			(end -8.89 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "70a204d2-fc99-4d57-87fe-c11459b1aea6")
+		)
+		(fp_line
+			(start -8.636 -1.27)
+			(end -6.604 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e022fbc6-cf7c-4b8a-9fe8-342f846028ce")
+		)
+		(fp_line
+			(start -8.89 -1.016)
+			(end -8.636 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "64b93feb-1f38-4cdc-b26d-403a74daa5b6")
+		)
+		(fp_line
+			(start -8.89 -1.27)
+			(end -8.636 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b1ed7dd7-5bc4-4213-b0f1-f6015dfdf15f")
+		)
+		(fp_line
+			(start -8.89 -1.27)
+			(end -8.89 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6f29ba7f-98ff-44d9-9503-050fdedf6277")
+		)
+		(pad "1" thru_hole rect
+			(at -7.62 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/U0TXD")
+			(uuid "bb3a5c4d-5e88-4c24-b153-cdcb213070c0")
+		)
+		(pad "2" thru_hole circle
+			(at -5.08 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/DCOM")
+			(uuid "3fdee40b-e6f5-44f8-9c78-a400123393b9")
+		)
+		(pad "3" thru_hole circle
+			(at -2.54 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/U0RXD")
+			(uuid "6f689253-4a69-4a17-a489-8ec750194451")
+		)
+		(pad "4" thru_hole circle
+			(at 0 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(uuid "347ec922-89d8-4e0d-ba1c-c78eeaa440e9")
+		)
+		(pad "5" thru_hole circle
+			(at 2.54 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/+3.3V")
+			(uuid "1f546d42-d89a-452d-9134-91f19e7e2e1a")
+		)
+		(pad "6" thru_hole circle
+			(at 5.08 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/EN")
+			(uuid "d657bd9b-1997-4c12-a6d0-9bb0428a2f0d")
+		)
+		(pad "7" thru_hole circle
+			(at 7.62 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(C1-Pad1)")
+			(uuid "cddce539-c821-4b82-b034-e9ffc30ea6b0")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/HN1x6-PinHeader_1x07_P2.54mm_Vertical.step"
+			(offset
+				(xyz 6.35 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 90)
+			)
+		)
+	)
+	(footprint "OLIMEX_Transistors-FP:SOT89"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005e7dd2a7")
+		(at 124.400000 95.000000)
+		(descr "SOT89-3, Housing, Handsoldering,")
+		(tags "SOT89-3, Housing, Handsoldering,")
+		(property "Reference" "U2"
+			(at -0.27 3.31 180)
+			(layer "F.SilkS")
+			(uuid "4d499ddb-9693-4a96-b8ae-98c0aa11141f")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "ME6210-SOT89"
+			(at -0.14986 5.30098 90)
+			(layer "F.Fab")
+			(uuid "09ab069b-133c-44dc-b87f-3000df24a4d8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "87d25ea4-1c99-4745-8bb9-a416916a43b3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "35a933bc-5d93-4a6e-9d30-c1dafea26fd0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005e7df28a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_poly
+			(pts
+				(xy 0.9 -0.1) (xy 0.5 0.9) (xy 0.5 2.3) (xy -0.5 2.3) (xy -0.5 0.9) (xy -0.9 -0.1) (xy -0.9 -2.4)
+				(xy 0.9 -2.4)
+			)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.Cu")
+			(uuid "977551d5-4fec-461a-bbe5-47b5f15f9e0c")
+		)
+		(fp_poly
+			(pts
+				(xy 0.9 -0.1) (xy 0.5 0.9) (xy 0.5 2.3) (xy -0.5 2.3) (xy -0.5 0.9) (xy -0.9 -0.1) (xy -0.9 -2.4)
+				(xy 0.9 -2.4)
+			)
+			(stroke
+				(width 0.2)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.Mask")
+			(uuid "ea372e2b-574f-4f26-bd71-4293918f1ee8")
+		)
+		(fp_line
+			(start -2 2.5)
+			(end -2.2 2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2f01de8b-4ad6-43bf-8b50-a0fd645ef669")
+		)
+		(fp_line
+			(start 2 2.5)
+			(end 2.5 2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "dc65565f-2085-4f61-898f-6caf12c41fe1")
+		)
+		(fp_line
+			(start 2.5 2.5)
+			(end 2.5 2)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "850dcbae-65d7-4efd-8f57-8251cd24eb0f")
+		)
+		(fp_line
+			(start -2.5 2.2)
+			(end -2.5 2)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "63a05f30-b14e-49df-90a8-082b44f672fe")
+		)
+		(fp_line
+			(start -2.5 -2.5)
+			(end -2.5 -2)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8f8ab5de-93e0-4e21-b746-0cd11f6498c7")
+		)
+		(fp_line
+			(start -2 -2.5)
+			(end -2.5 -2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7999a14c-f90f-4e95-9dfb-d035c4b788dd")
+		)
+		(fp_line
+			(start 2 -2.5)
+			(end 2.5 -2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c4940040-c76d-4f2f-b1e9-21e61bdb8fff")
+		)
+		(fp_line
+			(start 2.5 -2.5)
+			(end 2.5 -2)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ec8f83e2-8e46-4509-8221-c2db1fcc6f86")
+		)
+		(fp_circle
+			(center -2.5 2.5)
+			(end -2.3 2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.SilkS")
+			(uuid "1d46db64-e89c-4804-ae00-1472503eef2b")
+		)
+		(fp_poly
+			(pts
+				(xy 0.8 -0.1) (xy 0.4 0.9) (xy 0.4 2.2) (xy -0.4 2.2) (xy -0.4 0.9) (xy -0.8 -0.1) (xy -0.8 -2.3)
+				(xy 0.8 -2.3)
+			)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.Paste")
+			(uuid "2d626057-abb9-44e8-bb1f-5570561ddd73")
+		)
+		(pad "1" smd rect
+			(at -1.5 1.65)
+			(size 0.8 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "da51fbcf-8774-4852-961b-f2ad188274e7")
+		)
+		(pad "2" smd rect
+			(at 0 1.55)
+			(size 0.9 1.5019)
+			(layers "F.Cu")
+			(net "Net-(C1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "6e34de5f-e239-44f9-9f76-e35b6d5e57f0")
+		)
+		(pad "3" smd rect
+			(at 1.5 1.65)
+			(size 0.8 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/+3.3V")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "dbeea0f7-3ac9-4d44-ab36-4ac4fcdbaabe")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/SOT89-1.STEP"
+			(offset
+				(xyz 0 0.1016 0.0254)
+			)
+			(scale
+				(xyz 0.95 1.2 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_Crystal-FP:TSX-3.2x2.5mm_GND(3)"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005e7ddfaf")
+		(at 130.478000 103.527000)
+		(property "Reference" "Y1"
+			(at -1.82 -3.15 180)
+			(layer "F.SilkS")
+			(uuid "03121111-9419-414a-ab71-00c655704de1")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "Q12MHz/20pF/10ppm/4P/3.2x2.5mm"
+			(at 0.127 2.54 90)
+			(layer "F.Fab")
+			(uuid "30809338-aca2-4b26-9958-a85bc63191e9")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4e700320-8d5d-4c1f-a309-b06e5e3864a6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a382fa8e-73e2-4a93-9983-2a809e9bd9d1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005e7f6109")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.254 -1.27)
+			(end -0.254 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "12ef613e-edd9-4c96-9132-5641a499f9ed")
+		)
+		(fp_line
+			(start 0.254 1.27)
+			(end -0.254 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ee1ed1cb-ec57-43b6-b538-d5f108ef3f1f")
+		)
+		(fp_line
+			(start 0.39878 -0.64516)
+			(end 0.39878 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1d269107-a22b-4d0e-967e-5fb2593f1030")
+		)
+		(fp_line
+			(start -0.39878 -0.64516)
+			(end -0.39878 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e7cae2c5-aefe-46ed-8a07-02b0317d2cda")
+		)
+		(fp_line
+			(start 1.59766 -0.17272)
+			(end 1.59766 0.17272)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a54fefdd-c755-497e-86f4-de6bf165292f")
+		)
+		(fp_line
+			(start 0.39878 0)
+			(end 0.89916 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f829dffa-0492-4d78-844c-c070d63ca67b")
+		)
+		(fp_line
+			(start 0.39878 0)
+			(end 0.39878 0.64516)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "80ec3b07-a368-4c7e-9155-4cc9e0a0dfcf")
+		)
+		(fp_line
+			(start -0.39878 0)
+			(end -0.89916 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "644db91b-5b97-49f8-8f33-b2e0af1fbea6")
+		)
+		(fp_line
+			(start -0.39878 0)
+			(end -0.39878 0.64516)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ec5458e9-087e-453c-ae30-d0d95d6e4bb3")
+		)
+		(fp_line
+			(start -1.59766 0.17272)
+			(end -1.59766 -0.17272)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "15718051-8fb3-40fc-b558-f641c3bf422d")
+		)
+		(fp_line
+			(start 0 0.59944)
+			(end 0 -0.59944)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0d9199b6-063e-4796-b7cb-d02333d217d7")
+		)
+		(fp_line
+			(start 1.6 -1.25)
+			(end 1.6 1.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "904f6030-94ec-4f67-a4ca-cb251e0b0f3e")
+		)
+		(fp_line
+			(start -1.6 -1.25)
+			(end 1.6 -1.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ed11ccd0-dc3e-43ab-863e-56f488fdf597")
+		)
+		(fp_line
+			(start 1.6 1.25)
+			(end -1.6 1.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "146fc510-c794-4715-aad5-5b26a26a33e4")
+		)
+		(fp_line
+			(start -1.6 1.25)
+			(end -1.6 -1.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "55e5f80a-4435-48c6-8b47-f295690fa008")
+		)
+		(fp_text user "o"
+			(at -2.04 1.82 90)
+			(layer "F.SilkS")
+			(uuid "1a09e987-9e03-4659-8b42-50fb032f6d1a")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.2)
+				)
+			)
+		)
+		(pad "1" smd rect
+			(at -1.1 0.8)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C4-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "6209d7a9-7bb0-4acc-b02e-ac7c5bc76c93")
+		)
+		(pad "2" smd rect
+			(at 1.1 -0.8)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "e7c91bc7-e432-43a2-8fab-26d60e560920")
+		)
+		(pad "3" smd rect
+			(at -1.1 -0.8)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "9de4951d-d0d3-4f7b-9b70-117d3bd6a461")
+		)
+		(pad "3" smd rect
+			(at 1.1 0.8)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "467b9159-8e10-4a6c-bb2a-dc877dc6adfe")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/QSG5032.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 0.65 0.8 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_LOGOs-FP:LOGO_RECYCLEBIN_1"
+		(locked yes)
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005a3b5201")
+		(at 129.875000 98.250000)
+		(property "Reference" ""
+			(at 2.11 7.12 270)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "753efeb2-895d-45aa-a3f5-a019a6c12f77")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" ""
+			(at 2.85 -1.56 270)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "61f51a22-9847-48fe-b0c9-39b4a8449c96")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "aa66445a-4ded-4c68-a1ec-e1d699ed1294")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9bf17aef-045f-4b12-8321-e0a2f69d807b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 4.62 0.05)
+			(end 0.048 0.05)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "c3a770e4-0b1b-4d1d-ae1e-06ba7d4ab530")
+		)
+		(fp_line
+			(start 0.048 0.05)
+			(end 0.048 0.812)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6c26bd3f-ae0d-4fc0-9145-95e4745eb319")
+		)
+		(fp_line
+			(start 0.0988 0.1516)
+			(end 4.5184 0.1516)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ebdbfdd5-db0e-4670-829a-58624107b96c")
+		)
+		(fp_line
+			(start 4.5184 0.2532)
+			(end 0.1496 0.2532)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "416d01ca-66e9-4362-965a-b27c00734516")
+		)
+		(fp_line
+			(start 4.5692 0.3548)
+			(end 0.1496 0.3548)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "193d7829-0d78-4ccc-a742-04932c66491c")
+		)
+		(fp_line
+			(start 0.0988 0.4564)
+			(end 4.5692 0.4564)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "3b4ad343-af61-4a65-893b-df33af0321d4")
+		)
+		(fp_line
+			(start 4.5692 0.5072)
+			(end 0.1496 0.5072)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9347ed48-f6de-4de8-914b-312a974489da")
+		)
+		(fp_line
+			(start 0.0988 0.6088)
+			(end 4.5184 0.6088)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "cbe419f8-e0bc-451b-8c59-a46d0491a249")
+		)
+		(fp_line
+			(start 0.0988 0.6596)
+			(end 4.5692 0.6596)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1dd4286e-6fe8-4590-8a7b-f862e235184e")
+		)
+		(fp_line
+			(start 4.5692 0.7612)
+			(end 0.1496 0.7612)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6515c522-deca-4fb6-877f-19eb317ad154")
+		)
+		(fp_line
+			(start 4.62 0.812)
+			(end 4.62 0.05)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2b7e78a3-6f23-4153-9481-66e582a4f83a")
+		)
+		(fp_line
+			(start 0.048 0.812)
+			(end 4.62 0.812)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "26f1e023-b1e1-4cbd-8c33-937ee8af69f3")
+		)
+		(fp_line
+			(start 1.905 1.524)
+			(end 1.905 1.778)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "fe076586-8b23-451b-8504-42fec5ea9194")
+		)
+		(fp_line
+			(start 1.397 1.524)
+			(end 1.905 1.524)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "db927824-71a5-4e0d-a955-bfe0252fd876")
+		)
+		(fp_line
+			(start 0.381 1.524)
+			(end 4.445 5.461)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a4d540c3-c41c-4718-8649-f1c203ca2fa0")
+		)
+		(fp_line
+			(start 1.397 1.905)
+			(end 1.397 1.524)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "48d63ecb-85fd-47ee-b604-b22fd709e6df")
+		)
+		(fp_line
+			(start 1.397 1.905)
+			(end 2.794 1.905)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "47254a88-da81-499b-b727-058ca6ef6061")
+		)
+		(fp_line
+			(start 1.397 1.905)
+			(end 1.143 4.953)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5867f6b7-1c33-4eb8-ae18-53cd2c5e2ddb")
+		)
+		(fp_line
+			(start 3.302 2.413)
+			(end 3.429 4.445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4d76ffd7-4730-4ac7-9ea1-74a36dd42db7")
+		)
+		(fp_line
+			(start 3.048 4.191)
+			(end 2.159 4.191)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1c87ecef-aee6-401a-87e9-a2ace319b1a9")
+		)
+		(fp_line
+			(start 2.159 4.191)
+			(end 2.159 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "37c86ad1-a668-4dfb-a370-13eadf8b71c0")
+		)
+		(fp_line
+			(start 2.286 4.445)
+			(end 2.921 4.445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "abe175d4-63eb-4c3e-a45f-b6d3d50a03d0")
+		)
+		(fp_line
+			(start 3.81 4.572)
+			(end 3.81 5.08)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9b849a6f-7d10-4079-859f-47d7af1786dc")
+		)
+		(fp_line
+			(start 3.556 4.572)
+			(end 3.556 4.953)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "19938a1e-8900-4230-b683-6f12522427b5")
+		)
+		(fp_line
+			(start 3.429 4.572)
+			(end 3.81 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "63952aba-e317-476d-b5d3-ae42848e1b60")
+		)
+		(fp_line
+			(start 3.048 4.572)
+			(end 3.048 4.191)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ac62629b-3f4f-4b3a-bd36-817e441ad123")
+		)
+		(fp_line
+			(start 2.159 4.572)
+			(end 3.048 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "31fbe4af-8146-4618-acdd-14c700e1e4be")
+		)
+		(fp_line
+			(start 3.683 4.953)
+			(end 3.683 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "db77199c-da3c-4e7e-b498-2f904c426056")
+		)
+		(fp_line
+			(start 3.556 4.953)
+			(end 3.556 4.826)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4147d352-3a1d-4916-84b8-bbd8ff4feb24")
+		)
+		(fp_line
+			(start 3.556 4.953)
+			(end 3.556 4.826)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d74bec66-733a-4bd0-a131-82bbe45cc860")
+		)
+		(fp_line
+			(start 3.556 4.953)
+			(end 3.683 4.953)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "364bc577-3160-448a-b54b-2908f8175fa4")
+		)
+		(fp_line
+			(start 3.556 5.08)
+			(end 3.683 4.699)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f7d39122-fbfa-451c-a65c-f3de104ec7b5")
+		)
+		(fp_line
+			(start 3.429 5.08)
+			(end 3.429 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "cfb5f6ed-7f32-42a9-a98e-564708830f70")
+		)
+		(fp_line
+			(start 0.889 5.08)
+			(end 3.81 5.08)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a1e6e454-f246-422a-a919-36afb5c15ce8")
+		)
+		(fp_line
+			(start 1.397 5.207)
+			(end 1.397 5.715)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "64091c10-8f5b-4e2f-8557-813aa98d4495")
+		)
+		(fp_line
+			(start 0.254 5.588)
+			(end 4.445 1.397)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "38ef1034-ae58-4456-92e0-258f1ab01929")
+		)
+		(fp_line
+			(start 1.524 5.715)
+			(end 1.524 5.207)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4a762539-7c06-42b2-9e7c-5133172ffd3a")
+		)
+		(fp_line
+			(start 1.397 5.715)
+			(end 1.524 5.715)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0a8b67f5-eca2-44e6-98e0-93d08b42615f")
+		)
+		(fp_line
+			(start 2.54 5.842)
+			(end 2.54 5.969)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6c66aa99-7a32-4dea-b015-42731a214107")
+		)
+		(fp_line
+			(start 2.159 5.842)
+			(end 2.54 5.842)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "06bf3182-dcb3-4ed2-a269-01f65357ba44")
+		)
+		(fp_line
+			(start 2.54 5.969)
+			(end 2.159 5.969)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "606103b9-ec7c-4be7-af04-0f5a64217076")
+		)
+		(fp_line
+			(start 2.159 5.969)
+			(end 2.159 5.842)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2f8533de-5944-40ce-85e9-f5b77b90f26f")
+		)
+		(fp_arc
+			(start 3.429 5.207)
+			(mid 2.286 5.680446)
+			(end 1.143 5.207)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "023b007e-821a-43a5-aac3-723f2cebc903")
+		)
+		(fp_circle
+			(center 3.302 1.905)
+			(end 3.429 1.905)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "02ddb86a-aec8-4afb-b69a-c321b2b8072c")
+		)
+		(fp_circle
+			(center 3.302 1.905)
+			(end 3.683 2.032)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "fbc17b2f-379d-4983-8ce0-e1aa23f184e2")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "OLIMEX_LOGOs-FP:LOGO_PBFREE"
+		(locked yes)
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8c51dd")
+		(at 129.875000 98.250000)
+		(property "Reference" ""
+			(at -0.2794 3.52552 0)
+			(layer "B.SilkS")
+			(uuid "55da5eac-77e6-4e57-bd60-548c9cc732be")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" ""
+			(at 0.05588 -3.15214 0)
+			(layer "B.Fab")
+			(uuid "c86019ce-deb4-4f07-85e8-4ab10d4290a5")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "301a4d4d-73ea-4fb7-9f59-67693b31b3cd")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cef0db74-b8ad-4b02-a043-e207da7a8ff3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.36398 1.47828)
+			(end 1.06934 -0.94234)
+			(stroke
+				(width 0.2)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "082d5993-4bad-4f93-b62c-f027763ec073")
+		)
+		(fp_circle
+			(center -0.2032 0.31496)
+			(end 0.90678 1.73482)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "7c5ef266-0f27-4ed6-9ec9-4d7005304d7a")
+		)
+		(fp_text user "Pb"
+			(at -0.08636 0.33528 0)
+			(layer "B.SilkS")
+			(uuid "d2946751-8ae6-4e6e-b955-1eb81f8bbe09")
+			(effects
+				(font
+					(size 1.7 1.5)
+					(thickness 0.254)
+				)
+				(justify mirror)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(footprint "OLIMEX_LOGOs-FP:OLIMEX_LOGO_TB"
+		(locked yes)
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005e7dd057")
+		(at 129.875000 98.250000)
+		(property "Reference" ""
+			(at -2.4003 3.0607 180)
+			(layer "B.SilkS")
+			(hide yes)
+			(uuid "399d0cef-b3bf-41a9-92f0-fae906f3fada")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" ""
+			(at -1.6637 -3.7084 180)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "5a9754fc-e6ca-425f-b11e-ef9379c56dec")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cd0e1d64-4d73-47da-9a70-d0cdcb15b890")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7860c809-15e2-4b52-af9a-037006db9555")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 7.2644 1.3081)
+			(end 6.4008 0.4144)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7308d41f-5e8b-4541-ac16-38446872acc7")
+		)
+		(fp_line
+			(start 7.2136 -1.3716)
+			(end 6.3754 -0.5588)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ab4d15c6-d809-4979-bd31-7911f42eb225")
+		)
+		(fp_line
+			(start 5.8674 -0.4572)
+			(end 6.4008 -0.4572)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "bf2a81b1-ff11-4c63-a285-f09390059607")
+		)
+		(fp_line
+			(start 5.842 0.3175)
+			(end 6.4008 0.3175)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7fa9ae2e-04e0-46d6-ac9a-bab4a3741ac8")
+		)
+		(fp_line
+			(start 4.8387 1.8288)
+			(end 6.096 0.5842)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "79eadff5-aef5-41de-843d-0efb243000bb")
+		)
+		(fp_line
+			(start 4.7879 1.8288)
+			(end 4.8387 1.8288)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7e63c563-5040-4021-9bf8-69b4816347f6")
+		)
+		(fp_line
+			(start 4.7244 1.4986)
+			(end 5.8166 0.4318)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "fbffb3ab-cb62-4103-a139-39680ebcb461")
+		)
+		(fp_line
+			(start 4.7244 -1.6764)
+			(end 5.8674 -0.5588)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5368f0d4-e2b6-4a6f-ab77-74213bfccd0a")
+		)
+		(fp_line
+			(start 4.191 -0.0762)
+			(end 2.9718 -0.0762)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0db95411-a72f-43bf-add2-d0f38c28b1ef")
+		)
+		(fp_line
+			(start 3.5025 1.4986)
+			(end 4.7244 1.4986)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "11ad56c4-c0ec-42a7-8f24-8b0704d47297")
+		)
+		(fp_line
+			(start 3.4163 1.8288)
+			(end 4.7879 1.8288)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a7ba5318-4d83-439e-ae1b-00e09ed372c2")
+		)
+		(fp_line
+			(start 3.4036 -1.6764)
+			(end 4.7244 -1.6764)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2006bd8d-1b84-4af1-84e6-7e847894503b")
+		)
+		(fp_line
+			(start 2.9718 1.016)
+			(end 3.4544 1.524)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "dad99415-6907-4e8d-945a-3138d6701da1")
+		)
+		(fp_line
+			(start 2.9718 0.9906)
+			(end 2.9718 -1.2446)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "495592f8-620d-410c-a67d-01b8a26348fa")
+		)
+		(fp_line
+			(start 2.9718 -1.2446)
+			(end 3.4036 -1.6764)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "243a1c9a-55c7-4a02-a7df-c78438416b62")
+		)
+		(fp_line
+			(start 2.0447 1.7907)
+			(end 0.7493 1.7907)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0bbd95a3-72d3-498c-8f86-3b5668c8471c")
+		)
+		(fp_line
+			(start 2.0447 1.778)
+			(end 2.0447 1.7907)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9e308bb5-dcbf-4130-90cd-888a87e2f18c")
+		)
+		(fp_line
+			(start 2.0447 -1.2319)
+			(end 2.0447 1.778)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4985d1e2-20c7-48c5-853f-c27e8d0a6fbf")
+		)
+		(fp_line
+			(start 1.8923 1.7145)
+			(end 1.9939 1.7145)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "bf3d020f-0e07-4960-a5eb-1f5d1de17776")
+		)
+		(fp_line
+			(start 1.7145 1.4859)
+			(end 1.7145 -1.1176)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "28409c7b-5c96-463d-a9e6-4cbd0f2d66f9")
+		)
+		(fp_line
+			(start 0.8128 1.4732)
+			(end 1.7018 1.4732)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "30f53825-af9d-439b-aea6-aec4efe42522")
+		)
+		(fp_line
+			(start 0.7493 1.7907)
+			(end 0.7239 1.7907)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b40f334e-9ddb-41ff-aac2-fc22fd496a73")
+		)
+		(fp_line
+			(start 0.7239 1.7907)
+			(end 0.1016 1.2954)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "8bbd251d-593f-4d2e-b867-3c947d3360a1")
+		)
+		(fp_line
+			(start 0.1778 0.9652)
+			(end 0.8128 1.4732)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0bcc8587-fa28-436a-89b0-2609724d2d3f")
+		)
+		(fp_line
+			(start 0.1016 0.1778)
+			(end 0.1016 0.889)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5c5b3092-e670-4250-99d6-191ed3149198")
+		)
+		(fp_line
+			(start -0.5207 1.7907)
+			(end 0.0635 1.3081)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f2281f64-1def-4e76-91ac-cd01bbab5b11")
+		)
+		(fp_line
+			(start -0.6096 1.4732)
+			(end 0 0.9652)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4b599bfe-9525-4940-8894-e2212a1e6a80")
+		)
+		(fp_line
+			(start -1.4478 1.4732)
+			(end -0.6096 1.4732)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "44a8d006-6c3f-4c0e-b79d-45dea3a10784")
+		)
+		(fp_line
+			(start -1.4478 -1.1176)
+			(end -1.4478 1.4732)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f7236fc0-7037-41d2-b032-1a7d009c8983")
+		)
+		(fp_line
+			(start -1.6129 1.7272)
+			(end -1.6891 1.7272)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "3f9da128-984c-4e48-993b-bcd59d315ed7")
+		)
+		(fp_line
+			(start -1.7653 1.7907)
+			(end -0.5207 1.7907)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6e56ee92-0a45-4413-be02-3ff1092ffb5b")
+		)
+		(fp_line
+			(start -1.7653 -1.2065)
+			(end -1.7653 1.778)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6c147495-10a1-4351-8fe7-81cffd9fad56")
+		)
+		(fp_line
+			(start -2.3495 -0.8636)
+			(end -2.3495 1.1557)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9a4dde35-a763-49c4-a8dd-7a25af6febd7")
+		)
+		(fp_line
+			(start -2.3749 -0.8636)
+			(end -2.3495 -0.8636)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b96ddc50-abd4-4d38-bbf2-fe31587e6b5c")
+		)
+		(fp_line
+			(start -2.5019 -0.8001)
+			(end -2.413 -0.8001)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ff7cc0c2-f489-41e4-870e-434dc5bbe659")
+		)
+		(fp_line
+			(start -2.667 1.0414)
+			(end -2.667 -0.5588)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "177ab1fa-d633-4bc2-ac17-a8fc5580fb61")
+		)
+		(fp_line
+			(start -2.8448 -0.8001)
+			(end -2.9083 -0.8001)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "92832d70-509e-46f8-a1ff-35801806468f")
+		)
+		(fp_line
+			(start -2.9845 1.1557)
+			(end -2.9845 -0.8636)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2019161b-7938-4a3b-b97f-712c6bf196a2")
+		)
+		(fp_line
+			(start -2.9845 -0.8636)
+			(end -2.3749 -0.8636)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6f0a261f-15ea-4c5a-aea1-8777333806b4")
+		)
+		(fp_line
+			(start -3.1798 -1.6764)
+			(end -4.1656 -1.6764)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "cd9986b4-d7b8-49d6-ad15-0df447dc76b2")
+		)
+		(fp_line
+			(start -4.1656 -1.6764)
+			(end -4.6228 -1.2192)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a693fe77-aa42-4629-91da-e891d35be80e")
+		)
+		(fp_line
+			(start -4.3053 1.8415)
+			(end -4.3053 -1.1938)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f723620b-68d7-4a21-98a7-1dd100b5986b")
+		)
+		(fp_line
+			(start -4.4831 1.7653)
+			(end -4.3688 1.7653)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "072d03c8-be7e-4595-8ad1-4fd1baa225f4")
+		)
+		(fp_line
+			(start -4.6101 1.8415)
+			(end -4.3053 1.8415)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b9d88d32-c489-4465-aaf7-b4d944d91d1d")
+		)
+		(fp_line
+			(start -4.6228 1.8415)
+			(end -4.9022 1.8415)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "003fd888-0473-413e-adb0-ec76b41d23cd")
+		)
+		(fp_line
+			(start -4.6228 -1.2319)
+			(end -4.6228 1.4986)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "3ccd6512-6f74-44a4-ab18-4e0850f4ef19")
+		)
+		(fp_line
+			(start -4.7879 1.7526)
+			(end -4.8514 1.7653)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "825dc198-b5f4-45ef-bce2-e04fceb0da40")
+		)
+		(fp_line
+			(start -4.9022 1.8415)
+			(end -4.9149 1.8415)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6997c5ff-73c0-4e68-a7ca-05908c330633")
+		)
+		(fp_line
+			(start -4.9149 1.8415)
+			(end -4.9276 1.8415)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "68d2fb7e-a28e-4a6b-b177-f5a33383d8a1")
+		)
+		(fp_line
+			(start -4.9276 1.8415)
+			(end -4.9276 -1.3081)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "bb8ab64c-487e-41ac-a573-8361ed4ae914")
+		)
+		(fp_line
+			(start -5.7785 0.889)
+			(end -5.7785 -1.0414)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6cc2353c-69b8-4cb5-8925-086943a3a4db")
+		)
+		(fp_line
+			(start -5.7912 -1.0795)
+			(end -6.35 -1.6637)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "764e59f0-faf5-4c37-b990-bc276e17cc39")
+		)
+		(fp_line
+			(start -6.4008 1.4986)
+			(end -7.4041 1.4986)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e2dff08a-2d85-44a7-943d-f94c8cf5a2ce")
+		)
+		(fp_line
+			(start -6.4008 1.4859)
+			(end -5.7658 0.8763)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0d753950-3996-428e-81ec-66314582c494")
+		)
+		(fp_line
+			(start -7.4295 -1.6891)
+			(end -6.3881 -1.6891)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f5033879-b547-4084-8f4e-acd91627aa12")
+		)
+		(fp_line
+			(start -7.9883 -1.1303)
+			(end -7.9883 -0.3683)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9395f758-3041-4bf6-84aa-6337782c0ffb")
+		)
+		(fp_line
+			(start -8.001 0.9017)
+			(end -7.493 1.4097)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7e9d2c26-0243-45d9-af68-6c93ef6d7611")
+		)
+		(fp_line
+			(start -8.001 0.8509)
+			(end -8.001 0.6096)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a9d3cb7a-69e6-46b9-ac38-56b5505b7b98")
+		)
+		(fp_line
+			(start -8.001 -1.1176)
+			(end -7.4168 -1.6891)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7cf3b0f5-b8e4-4286-b8e3-76e0f3dca45a")
+		)
+		(fp_circle
+			(center 7.6327 1.6637)
+			(end 7.9375 1.8542)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "d0264f73-a328-4455-b0be-4f7bc426f55e")
+		)
+		(fp_circle
+			(center 7.5438 -1.7272)
+			(end 7.8359 -1.5748)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "d767a115-1994-4ee4-8439-2ec82c4ba899")
+		)
+		(fp_circle
+			(center 4.699 -0.0762)
+			(end 4.9657 0.1651)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "45116d00-6592-447c-b577-427ad201fbf5")
+		)
+		(fp_circle
+			(center 1.7145 -1.6383)
+			(end 1.9304 -1.3462)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "33d2b6ff-d344-47b5-9917-aca2749f42e0")
+		)
+		(fp_circle
+			(center 0.1016 -0.3556)
+			(end 0.3302 -0.0635)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "17205aa1-2969-4cc9-840c-620cc306a641")
+		)
+		(fp_circle
+			(center -1.4351 -1.6256)
+			(end -1.1938 -1.3589)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "4570dae9-6c63-46d4-a24f-74028d866a95")
+		)
+		(fp_circle
+			(center -2.6543 1.5748)
+			(end -2.54 1.9304)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "127a5504-a5f9-4ce1-a0c2-aeb10dd0b07d")
+		)
+		(fp_circle
+			(center -2.667 -1.651)
+			(end -2.4638 -1.3462)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "608b5b14-5718-4e71-9517-71a024a265e8")
+		)
+		(fp_circle
+			(center -7.9883 0.127)
+			(end -7.6708 0.2413)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "910ec872-6da5-44fd-a998-cb3af4919baf")
+		)
+		(embedded_fonts no)
+	)
+	(gr_line
+		(start 114 91)
+		(end 145.75 91)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "c98b8739-5517-49c0-94ff-7449c2e1f124")
+	)
+	(gr_line
+		(start 114 105.5)
+		(end 114 91)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "9fd60985-4559-4d03-995f-538746ddb926")
+	)
+	(gr_line
+		(start 145.75 91)
+		(end 145.75 105.5)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "958a9bf3-dbc9-40cf-9a79-578932c7906e")
+	)
+	(gr_line
+		(start 145.75 105.5)
+		(end 114 105.5)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "608edb87-fa2c-450e-b965-d0fd974fd824")
+	)
+	(embedded_fonts no)
+)

--- a/tests/fixtures/run25/esp_prog_lap5.kicad_prl
+++ b/tests/fixtures/run25/esp_prog_lap5.kicad_prl
@@ -1,0 +1,105 @@
+{
+  "board": {
+    "active_layer": 0,
+    "active_layer_preset": "",
+    "auto_track_width": true,
+    "hidden_netclasses": [],
+    "hidden_nets": [],
+    "high_contrast_mode": 0,
+    "net_color_mode": 1,
+    "opacity": {
+      "images": 0.6,
+      "pads": 1.0,
+      "shapes": 1.0,
+      "tracks": 1.0,
+      "vias": 1.0,
+      "zones": 0.6
+    },
+    "prototype_zone_fills": false,
+    "selection_filter": {
+      "dimensions": true,
+      "footprints": true,
+      "graphics": true,
+      "keepouts": true,
+      "lockedItems": false,
+      "otherItems": true,
+      "pads": true,
+      "text": true,
+      "tracks": true,
+      "vias": true,
+      "zones": true
+    },
+    "visible_items": [
+      "vias",
+      "footprint_text",
+      "footprint_anchors",
+      "ratsnest",
+      "grid",
+      "footprints_front",
+      "footprints_back",
+      "footprint_values",
+      "footprint_references",
+      "tracks",
+      "drc_errors",
+      "drawing_sheet",
+      "bitmaps",
+      "pads",
+      "zones",
+      "drc_warnings",
+      "drc_exclusions",
+      "locked_item_shadows",
+      "conflict_shadows",
+      "shapes",
+      "board_outline_area",
+      "ly_points"
+    ],
+    "visible_layers": "ffffffff_ffffffff_ffffffff_ffffffff",
+    "zone_display_mode": 0
+  },
+  "git": {
+    "integration_disabled": false,
+    "repo_type": "",
+    "repo_username": "",
+    "ssh_key": ""
+  },
+  "meta": {
+    "filename": "seed1.kicad_prl",
+    "version": 5
+  },
+  "net_inspector_panel": {
+    "col_hidden": [],
+    "col_order": [],
+    "col_widths": [],
+    "custom_group_rules": [],
+    "expanded_rows": [],
+    "filter_by_net_name": true,
+    "filter_by_netclass": true,
+    "filter_text": "",
+    "group_by_constraint": false,
+    "group_by_netclass": false,
+    "show_time_domain_details": false,
+    "show_unconnected_nets": false,
+    "show_zero_pad_nets": false,
+    "sort_ascending": true,
+    "sorting_column": -1
+  },
+  "open_jobsets": [],
+  "project": {
+    "files": []
+  },
+  "schematic": {
+    "hierarchy_collapsed": [],
+    "selection_filter": {
+      "graphics": true,
+      "images": true,
+      "labels": true,
+      "lockedItems": false,
+      "otherItems": true,
+      "pins": true,
+      "ruleAreas": true,
+      "symbols": true,
+      "text": true,
+      "wires": true
+    }
+  }
+}

--- a/tests/fixtures/run25/esp_prog_lap5.kicad_pro
+++ b/tests/fixtures/run25/esp_prog_lap5.kicad_pro
@@ -1,0 +1,61 @@
+{
+  "board": {
+    "design_settings": {
+      "rules": {
+        "min_clearance": 0.15,
+        "min_hole_clearance": 0.15,
+        "min_hole_to_hole": 0.25,
+        "min_copper_edge_clearance": 0.3,
+        "min_track_width": 0.15,
+        "min_via_diameter": 0.45,
+        "min_through_hole_diameter": 0.25,
+        "min_via_drill": 0.25
+      },
+      "rule_severities": {}
+    }
+  },
+  "meta": {
+    "filename": "board.kicad_pro",
+    "version": 1
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12,
+        "clearance": 0.15,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": 0.2,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.2,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "priority": 2147483647,
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.15,
+        "via_diameter": 0.45,
+        "via_drill": 0.25,
+        "wire_width": 6
+      }
+    ],
+    "meta": {
+      "version": 0
+    }
+  },
+  "kicad_routing_tools": {
+    "floor_provenance": {
+      "authored_by": "run25 orchestrator, before any placement/routing tool ran (brief step 1, #441)",
+      "floors": {
+        "clearance": 0.15,
+        "track_width": 0.15,
+        "via_diameter": 0.45,
+        "via_drill": 0.25,
+        "hole_to_hole": 0.25,
+        "copper_edge": 0.3
+      },
+      "note": "fix_kicad_drc_settings capped min_clearance and the Default class at the 0.0508 mm pad override found on C1/C3/Q1/Q2/U2; both hand-raised to the declared 0.15 floor (KiCad floors a pad override at rules.min_clearance, so 0.15 is what every checker grades). Class draw defaults set to the declared sizes.",
+      "escalation": "board"
+    }
+  }
+}

--- a/tests/mutate_837.py
+++ b/tests/mutate_837.py
@@ -45,7 +45,14 @@ FLOOR = os.path.join(_ROOT, 'py_placer', 'placement', 'floorplan.py')
 OPTS = os.path.join(_ROOT, 'py_placer', 'placement', 'options.py')
 CA = os.path.join(_ROOT, 'py_tools', 'check_assembly.py')
 CC = os.path.join(_ROOT, 'py_tools', 'check_capacity.py')
-TARGETS = {'le': LEG, 'fp': FLOOR, 'op': OPTS, 'ca': CA, 'cc': CC}
+#: #896. The body model. Its rows land here rather than in a battery of their
+#: own because they are witnessed by the same assembly gates as everything
+#: above -- `grade_body_overlap` reads the model and `check_assembly` prints
+#: it -- and a second runner would be a second copy of the contract stated in
+#: this file's docstring.
+BODY = os.path.join(_ROOT, 'py_placer', 'placement', 'body.py')
+TARGETS = {'le': LEG, 'fp': FLOOR, 'op': OPTS, 'ca': CA, 'cc': CC,
+           'bo': BODY}
 
 CEN = os.path.join(_TESTS, 'test_837_assembly_sides.py')
 CAP = os.path.join(_TESTS, 'test_capacity_options.py')
@@ -58,7 +65,13 @@ CLI = os.path.join(_TESTS, 'test_549_floorplan_cli.py')
 #: cannot.
 FFC = os.path.join(_TESTS, 'test_878_far_face_currency.py')
 
-BASELINE = (CEN, CAP, SCH, CLI, FFC)
+#: #896. The body-model witness: the run-25 acceptance numbers with their
+#: source pair, both silk refusals, and two corpus-wide monotonicity claims.
+#: In BASELINE because a battery whose witness is already red scores every row
+#: KILLED and exits 0.
+BOD = os.path.join(_TESTS, 'test_896_body_model.py')
+
+BASELINE = (CEN, CAP, SCH, CLI, FFC, BOD)
 
 ROWS = [
     # ------------------------------------------------- the census's two rules
@@ -110,6 +123,70 @@ ROWS = [
      "            zero_pad[side].append(ref)\n",
      "            zero_pad[side].append(ref) if side == 'B' else None\n",
      (CEN,), 'KILLED'),
+
+    # ------------------------------------------------------ #896 body model
+    # The silk rung itself. Without it the six esp_prog parts that draw no
+    # .Fab -- the connector housings, the SSOP, the SOT89 -- have no body at
+    # all, which is the state the issue was filed about.
+    ('the-silk-rung-does-not-exist', 'bo',
+     "    elif silk is not None:\n        if pads is None:",
+     "    elif False:\n        if pads is None:",
+     (BOD,), 'KILLED'),
+
+    # Rule 1. Silk is a pair of clipped side ticks, not an outline, so taken
+    # bare it SHRINKS parts. Neither the acceptance numbers nor the occupancy
+    # arm can see that -- CON1/CON2/U2's silk already contains their pad
+    # field, and occupancy unions with the pads again regardless -- so only
+    # `test_a_silk_body_is_never_smaller_than_its_pads` watches it. That arm
+    # exists BECAUSE this row SURVIVED the first run of this battery.
+    ('the-silk-rung-does-not-union-with-the-pads', 'bo',
+     "            body = _union(silk, pads)",
+     "            body = silk",
+     (BOD,), 'KILLED'),
+
+    # Rule 2. Allowing a pad-less footprint a silk body put 5 corpus pairs
+    # above the run-23 blocking floors, and all five were logos.
+    ('a-pad-less-footprint-may-claim-a-silk-body', 'bo',
+     "        if pads is None:\n            # Rule 2:",
+     "        if False:\n            # Rule 2:",
+     (BOD,), 'KILLED'),
+
+    # The tick-mark test, inverted: it would accept exactly the fragments it
+    # exists to refuse and refuse the outlines it exists to accept.
+    ('the-tick-mark-test-is-inverted', 'bo',
+     "            if _contained(silk, pads):",
+     "            if not _contained(silk, pads):",
+     (BOD,), 'KILLED'),
+
+    # The two ladders re-merged. A courtyard is a body PLUS an assembly margin
+    # plus any shell overhang, and run-6 calibrated the courtyard channel and
+    # the fab channel apart for exactly that reason. esp_prog cannot witness
+    # this at all (no part on it draws a courtyard), which is why the witness
+    # sweeps the corpus for parts drawing both.
+    ('the-courtyard-joins-the-drawn-ladder', 'bo',
+     "    if fab is not None:\n        drawn_local, drawn_source = fab, SOURCE_FAB",
+     "    _c0 = _for_side(courtyard_sides, side)\n"
+     "    if _c0 is not None:\n"
+     "        drawn_local, drawn_source = _c0, SOURCE_COURTYARD\n"
+     "    elif fab is not None:\n"
+     "        drawn_local, drawn_source = fab, SOURCE_FAB",
+     (BOD,), 'KILLED'),
+
+    # Occupancy stops being monotone. Unmutated, this line is what keeps three
+    # ulx3s and two esp_prog run-23 findings alive: a .Fab body is routinely
+    # narrower than the pads it sits between (ulx3s AUDIO1 0.59x).
+    ('occupancy-stops-unioning-with-the-pads', 'bo',
+     "    occupancy = (body_local if pads is None else _union(body_local, pads))",
+     "    occupancy = body_local",
+     (BOD,), 'KILLED'),
+
+    # A silk body must never GATE. esp_prog's R1 clears U2's real body by
+    # 2.1mm and reads 89% contained inside U2's silk square, which without
+    # this exclusion gates the board NOT BUILDABLE.
+    ('a-silk-body-may-gate-containment', 'le',
+     "                            and not _silk_drawn_pair(p)]",
+     "                            ]",
+     (BOD,), 'KILLED'),
 
     # ------------------------------------------------------------- the rule
     # `ctx.sev` hard-defaults to ERROR. Nothing in the engine can move a part

--- a/tests/test_431_render_placement.py
+++ b/tests/test_431_render_placement.py
@@ -435,8 +435,12 @@ def test_json_out_writes_a_file_with_instrument_and_checklist():
         # cross-side stack census
         # one. Re-stated rather than relaxed to a subset, because a subset
         # check is what would have let the drift through in the first place.
-        assert set(cl) == {'a_off_outline', 'b_pad_clearance_pairs',
+        assert set(cl) == {'a_off_outline',
+                           'b_pad_clearance_pairs',
                            'b_body_overlap_pairs',
+                           # #896: the tightest drawn-body seam and the
+                           # per-part source mix it was measured on.
+                           'b_body_seam', 'b_body_sources',
                            'b_courtyard_advisory_pairs',
                            'b_courtyard_blocking_pairs',
                            'b_courtyard_census_error',

--- a/tests/test_709_arrangement_census.py
+++ b/tests/test_709_arrangement_census.py
@@ -78,10 +78,22 @@ def t_area_weighting_and_the_count_control_disagree():
     # fiducial has almost no courtyard). The issue's finding is unchanged and
     # in fact slightly sharper: the count form still points the wrong way, now
     # by 14x rather than 11x.
-    report('esp_prog: the area form is ~1.1% of span',
-           abs(area_x - 0.011) < 0.004, 'got %.4f' % area_x)
-    report('esp_prog: the count control is ~14.9% of span',
-           abs(count_x - 0.149) < 0.008, 'got %.4f' % count_x)
+    # RE-RECORDED AGAIN for #896. The AREA form is weighted by each part's
+    # extent, and that extent stopped being a pad bounding box on a board
+    # whose library draws no courtyards: esp_prog's parts now carry their
+    # drawn .Fab and silk bodies, so the area-weighted centroid moved
+    # 0.0107 -> 0.0205 while the COUNT form barely moved (0.1494 -> 0.1515),
+    # which is what a weighting change should do.
+    #
+    # The issue's finding survives and the number that carries it is stated
+    # rather than hidden: the separation is now 7.4x, not 14x. It narrowed
+    # because the area form grew, not because the count form shrank -- the
+    # two are still different statistics pointing different ways, which is
+    # the whole claim, but a reader is owed the direction of travel.
+    report('esp_prog: the area form is ~2.1% of span',
+           abs(area_x - 0.021) < 0.004, 'got %.4f' % area_x)
+    report('esp_prog: the count control is ~15.2% of span',
+           abs(count_x - 0.152) < 0.008, 'got %.4f' % count_x)
     report('the two forms differ by more than 4x -- they are NOT the same '
            'statistic', count_x > 4 * area_x, '%.4f vs %.4f' % (count_x, area_x))
     report('the weight is declared, not implied',

--- a/tests/test_709_cold_windows.py
+++ b/tests/test_709_cold_windows.py
@@ -148,26 +148,54 @@ def t_cold_means_no_copper_not_just_no_demand():
 
 
 def t_the_issue_s_own_sentence():
-    """A7: "an empty band south of CON2's eastern half", as a band.
+    """A7: a cold region is found as a BAND, not merged into a blob.
 
-    8-connected labelling merges this region into the blob beside it and the
+    8-connected labelling merges such a region into the blob beside it and the
     band disappears; ranking by window count buries it. Both go red here.
+
+    RE-RECORDED at #896, and the reason is the point. This used to assert the
+    issue's literal sentence -- "an empty band south of CON2's eastern half",
+    bounded by CON1 and CON2 -- and a region "immediately beside U2" at
+    x 133..137. Both were measured when every esp_prog part graded at its PAD
+    BOUNDING BOX, because that library draws no courtyards. With the parts'
+    drawn bodies the space is not there:
+
+        CON1   pads (142.65, 96.38)-(144.15, 103.62)
+               body (142.30, 95.15)-(145.50, 104.85)
+        CON2   pads (127.66,  92.11)-(144.68,  93.89)
+               body (127.28,  91.73)-(145.06,  94.27)
+
+    The gap between CON2's underside and CON1's top is 0.88mm of real board,
+    not the 2.49mm the pad boxes implied -- the rest is connector plastic, and
+    offering a router a lane through it is exactly the kind of claim #709
+    exists to make trustworthy. So the CON1/CON2 band is not re-recorded with
+    new numbers; it is gone, and correctly.
+
+    The "beside U2" region went the same way, but that one deserves a caveat
+    rather than a clean conscience: U2's OLIMEX SOT89 draws its silk as four
+    corner brackets 5.2mm apart around a ~4.5mm part, so its body is
+    OVERSTATED and some of the space it now claims is real. That is why a
+    silk-sourced body never gates anywhere in the toolchain -- see
+    `placement/body.py`. It is a disclosure, not a defect, and the arm below
+    no longer asserts a region that exists only under one geometry.
+
+    What survives is the STRUCTURAL claim, which is what A7 was actually for:
+    the census finds a cold region on this board, and reports it as a band
+    with a real rectangle rather than as a blob.
     """
     doc, _hot = census('esp_prog')
     regions = doc['cold_regions']
-    hit = [r for r in regions if 'CON2' in r['refs'] and 'CON1' in r['refs']]
-    report('a cold region is bounded by CON1 and CON2', bool(hit),
+    report('esp_prog still yields a cold region at all', bool(regions),
            '%d regions, refs %s' % (len(regions), [r['refs'] for r in regions]))
-    if hit:
-        r = hit[0]
-        report('  ...and it is a BAND, not a blob (fill >= 0.9)',
-               (r['fill'] or 0) >= 0.9, 'fill %s' % r['fill'])
+    if regions:
+        r = max(regions, key=lambda x: (x['band_mm'][0] * x['band_mm'][1]))
+        report('  ...bounded by the parts around it, which are NAMED',
+               len(r['refs']) >= 2, str(r['refs']))
+        report('  ...and it is a BAND, not a blob (fill >= 0.7)',
+               (r['fill'] or 0) >= 0.7, 'fill %s' % r['fill'])
         report('  ...whose band rect is a real rectangle of windows',
                r['band_mm'][0] > 0 and r['band_mm'][1] > 0,
                str(r['band_mm']))
-    beside_u2 = [r for r in regions if r['bbox'][0] >= 133 and r['bbox'][2] <= 137]
-    report('a cold region sits immediately beside U2', bool(beside_u2),
-           str([r['bbox'] for r in regions]))
 
 
 def t_area_accounting_never_exceeds_the_region():

--- a/tests/test_891_board_context.py
+++ b/tests/test_891_board_context.py
@@ -1,0 +1,248 @@
+"""#891: the component-context sheet says the things it exists to say.
+
+The headline row is the one run 25 needed and did not have: whether a
+differential pair's polarity order CROSSES between the two parts carrying it.
+Two boards are asserted deliberately, because they answer differently and the
+difference is the point --
+
+    kicad_files/esp_prog.kicad_pcb        UNDETERMINED
+    tests/fixtures/run25/..._lap5         CROSSED
+
+On the tracked board U1 sits at rotation 0, so its /D_P and /D_N pads share a y
+while the channel to USB1 runs along x: both project to one point on the
+channel axis and the order is not a fact about the board. On run 25's lap 5, U1
+is at 270 and the two orders genuinely cross. An earlier draft of this tool
+reported AGREES for the first case, which is a wrong answer dressed as a
+measurement -- so the UNDETERMINED row is asserted as hard as the CROSSED one.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path[:0] = [os.path.join(ROOT, 'py_router'),
+                os.path.join(ROOT, 'py_placer'),
+                os.path.join(ROOT, 'py_tools')]
+sys.path.insert(0, HERE)
+
+RUN_ALL_TIMEOUT = 1200
+
+FAILURES = []
+TOOL = os.path.join(ROOT, 'py_tools', 'board_context.py')
+TRACKED = os.path.join(ROOT, 'kicad_files', 'esp_prog.kicad_pcb')
+LAP5 = os.path.join(ROOT, 'tests', 'fixtures', 'run25',
+                    'esp_prog_lap5.kicad_pcb')
+
+
+def check(name, cond, detail=''):
+    if cond:
+        print(f'  PASS: {name}')
+    else:
+        FAILURES.append(f'{name}{(" -- " + detail) if detail else ""}')
+        print(f'  FAIL: {name} -- {detail}')
+
+
+def _run(board, *extra):
+    import run_utils
+    argv = [sys.executable, '-X', 'utf8', TOOL, board, *extra]
+    return subprocess.run(argv, capture_output=True, text=True,
+                          env=run_utils.tool_env(), timeout=900)
+
+
+def _doc(board, *extra):
+    r = _run(board, '--json', *extra)
+    if r.returncode != 0:
+        raise AssertionError(f'board_context failed on {board}: '
+                             f'{r.stderr[-800:]}')
+    return json.loads(r.stdout), r
+
+
+def test_json_is_parseable_from_char_zero():
+    """The trap this tool was born into.
+
+    `cli_banner` is the famous one, but it is not the only writer to stdout:
+    `parser.warn_missing_courtyards` prints from inside the quench, and
+    esp_prog has 18 courtyard-less parts. An arm that only checked "does the
+    document contain the right keys" would have passed on a build whose stdout
+    could not be parsed at all.
+    """
+    r = _run(TRACKED, '--json')
+    check('--json exits 0', r.returncode == 0, r.stderr[-300:])
+    try:
+        doc = json.loads(r.stdout)
+        check('--json stdout parses from char 0', True)
+    except Exception as exc:                                 # noqa: BLE001
+        check('--json stdout parses from char 0', False,
+              f'{type(exc).__name__}: {exc}; first 80 chars '
+              f'{r.stdout[:80]!r}')
+        return
+    check('the courtyard warning went to stderr, not into the document',
+          'WARNING' in r.stderr and 'WARNING' not in r.stdout)
+    check('the document names its schema and board',
+          doc.get('schema') and doc.get('board') == 'esp_prog.kicad_pcb',
+          str(doc.get('board')))
+
+
+def test_the_usb_pair_row():
+    """THE row, on both boards, with the reason each reads as it does."""
+    tracked, _ = _doc(TRACKED)
+    lap5, _ = _doc(LAP5)
+
+    def pair_row(doc):
+        rows = (doc.get('pin_order') or {}).get('rows') or []
+        for r in rows:
+            if {r['a'], r['b']} == {'U1', 'USB1'} \
+                    and str(r.get('scope', '')).startswith('pair'):
+                return r
+        return None
+
+    a, b = pair_row(tracked), pair_row(lap5)
+    check('the tracked board has a pair-scoped U1<->USB1 row', a is not None,
+          'no row; the pair scope is the whole point of this sheet')
+    check('run 25 lap 5 has a pair-scoped U1<->USB1 row', b is not None)
+    if a:
+        check('tracked: UNDETERMINED (U1 at rot 0 puts /D_P and /D_N at one '
+              'y, so both project to one point on the channel axis)',
+              a['verdict'].startswith('UNDETERMINED') and a['ties'] > 0,
+              f"verdict {a['verdict']!r} ties {a.get('ties')}")
+    if b:
+        check('lap 5: CROSSED (U1 at rot 270; the parity that decided run '
+              "25's only open clause)",
+              b['verdict'] == 'CROSSED' and b['inversions'] == 1
+              and b['ties'] == 0, f'row {b}')
+
+
+def test_the_pair_scope_attributes_what_the_interface_blends():
+    """The argument for `only_nets`, stated as it actually measures.
+
+    An earlier draft of this test claimed the interface row says AGREES on
+    lap 5 while the pair row says CROSSED. That is FALSE and the test caught
+    it: measured, both scopes reach the same VERDICT on both boards --
+
+        tracked   pair nets=2 inv=0 ties=1   interface nets=3 inv=0 ties=2
+        lap 5     pair nets=2 inv=1 ties=0   interface nets=3 inv=3 ties=0
+
+    What the pair scope actually buys is ATTRIBUTION. `inversions` is a lower
+    bound on forced crossings, and the interface number blends three nets into
+    one figure: 3 on lap 5. The pair scope says exactly 1 of those is the
+    declared /D_P//D_N pair, which is the part a mirror or a via hop would fix
+    and rotation would not. A reader given only "3" cannot tell whether the
+    pair is implicated at all.
+
+    (The verdicts agree here only because `ties` was added at the same time.
+    Before it, the tracked board's interface row read AGREES on a question
+    with no answer -- which is the failure mode the original claim described,
+    correctly, about the old code.)
+    """
+    doc, _ = _doc(LAP5)
+    rows = (doc.get('pin_order') or {}).get('rows') or []
+    iface = [r for r in rows if {r['a'], r['b']} == {'U1', 'USB1'}
+             and r.get('scope') == 'interface']
+    pair = [r for r in rows if {r['a'], r['b']} == {'U1', 'USB1'}
+            and str(r.get('scope', '')).startswith('pair')]
+    check('lap 5 carries both scopes for U1<->USB1',
+          len(iface) == 1 and len(pair) == 1,
+          f'{len(iface)} interface, {len(pair)} pair')
+    if iface and pair:
+        check('the interface row sees more nets than the pair row',
+              iface[0]['nets'] > pair[0]['nets'],
+              f"{iface[0]['nets']} vs {pair[0]['nets']}")
+        check('the interface BLENDS more crossings than the pair is '
+              'responsible for (3 vs 1 on lap 5) -- attribution is what the '
+              'pair scope buys',
+              iface[0]['inversions'] > pair[0]['inversions'] > 0,
+              f"interface {iface[0]['inversions']}, "
+              f"pair {pair[0]['inversions']}")
+
+
+def test_every_derived_fact_names_its_source():
+    """#711's rule, applied here: no claim without a channel it came from."""
+    doc, _ = _doc(TRACKED)
+    missing = [p['ref'] for p in doc['parts']
+               if not (p.get('role') or {}).get('source')]
+    check('every part carries a role source', missing == [],
+          f'{len(missing)}: {missing[:5]}')
+    check('every part carries a body source',
+          all(p.get('body_source') for p in doc['parts']))
+    check('the sheet declares where each column comes from',
+          len(doc.get('sources') or {}) >= 6, str(sorted(doc.get('sources',
+                                                                {}))))
+    # `unknown` must be REACHABLE, or the honesty rule is decorative: esp_prog
+    # carries three OLIMEX logo blocks with no reference convention at all.
+    unknown = [p['ref'] for p in doc['parts']
+               if p['role']['role'] == 'unknown']
+    check('"unknown" is a value this sheet actually produces', unknown != [],
+          'no part reported unknown; the rule is untested if nothing hits it')
+
+
+def test_the_body_column_is_the_896_model():
+    """Not a fourth body ladder: the sources the sheet reports must be the
+    model's own, per part."""
+    from kicad_parser import parse_kicad_pcb
+    from placement.body import board_bodies
+    doc, _ = _doc(TRACKED)
+    bodies = board_bodies(parse_kicad_pcb(TRACKED), TRACKED)
+    wrong = [(p['ref'], p['body_source'],
+              getattr(bodies.get(p['ref']), 'source', None))
+             for p in doc['parts']
+             if p['ref'] in bodies
+             and p['body_source'] != bodies[p['ref']].source]
+    check('every body source on the sheet is placement.body\'s own',
+          wrong == [], f'{len(wrong)}: {wrong[:5]}')
+    srcs = {p['body_source'] for p in doc['parts']}
+    check('esp_prog exercises more than one rung', len(srcs) >= 3, str(srcs))
+
+
+def test_panels_are_written_and_referenced():
+    with tempfile.TemporaryDirectory() as td:
+        out = os.path.join(td, 'panels')
+        doc, _ = _doc(TRACKED, '--panels', out)
+        check('panels were written', (doc.get('panels_written') or 0) > 0,
+              f"written={doc.get('panels_written')} "
+              f"error={doc.get('panels_error')}")
+        refd = [p for p in doc['parts'] if p.get('panel')]
+        check('the parts reference them', len(refd) > 0)
+        check('every referenced panel exists on disk',
+              all(os.path.isfile(p['panel']) for p in refd),
+              str([p['panel'] for p in refd
+                   if not os.path.isfile(p['panel'])][:3]))
+
+
+def test_md_is_a_sheet_a_reader_can_use():
+    r = _run(TRACKED, '--md')
+    check('--md exits 0', r.returncode == 0, r.stderr[-300:])
+    text = r.stdout
+    for want in ('# Component context', '## Pin-order agreement', '## Parts',
+                 '## Sources', 'pair /D_P//D_N'):
+        check(f'the sheet carries {want!r}', want in text)
+
+
+TESTS = [test_json_is_parseable_from_char_zero,
+         test_the_usb_pair_row,
+         test_the_pair_scope_attributes_what_the_interface_blends,
+         test_every_derived_fact_names_its_source,
+         test_the_body_column_is_the_896_model,
+         test_panels_are_written_and_referenced,
+         test_md_is_a_sheet_a_reader_can_use]
+
+
+def main():
+    for t in TESTS:
+        print(f'--- {t.__name__}')
+        try:
+            t()
+        except Exception as exc:                             # noqa: BLE001
+            check(f'{t.__name__} ran to completion', False,
+                  f'{type(exc).__name__}: {exc}')
+    print(f"\n{'FAIL' if FAILURES else 'PASS'}: #891 board context, "
+          f"{len(FAILURES)} failure(s)")
+    for f in FAILURES:
+        print(f'  - {f}')
+    return 1 if FAILURES else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_891_board_context.py
+++ b/tests/test_891_board_context.py
@@ -158,6 +158,39 @@ def test_the_pair_scope_attributes_what_the_interface_blends():
               f"pair {pair[0]['inversions']}")
 
 
+def test_the_mating_face_column():
+    """#891 names USB1 explicitly, and the measurement disagrees with half of
+    the claim -- which is worth an arm rather than a quiet omission.
+
+    The issue's acceptance reads "USB1's mating face reads W with overhang >
+    0". The face is W. The overhang is ZERO on both esp_prog boards: USB1's
+    body starts at x 114.000 and the outline's west edge IS 114.000, so the
+    receptacle is flush, not overhanging. Asserted as flush, because a test
+    that quietly relaxed to `>= 0` would let a real overhang regression
+    through, and one that asserted `> 0` would be asserting something the
+    board does not say.
+
+    The number also depends on WHICH rect is measured, which is why this
+    column reads the body model: `connector_edge_facts` measures
+    `model.rect`, the quench's pad-box ladder, and USB1's pad box sits 0.49mm
+    INSIDE the west edge while its drawn body reaches it.
+    """
+    for board, name in ((TRACKED, 'tracked'), (LAP5, 'lap 5')):
+        doc, _ = _doc(board)
+        row = next((p['mating'] for p in doc['parts']
+                    if p['ref'] == 'USB1' and p.get('mating')), None)
+        check(f'{name}: USB1 carries a mating row', row is not None)
+        if row:
+            check(f'{name}: USB1 mates through the W edge',
+                  row['edge'] == 'W', str(row))
+            check(f'{name}: flush, not overhanging (body x0 == outline x0)',
+                  row['overhang_mm'] == 0.0 and row['dist_mm'] == 0.0,
+                  str(row))
+            check(f'{name}: and the row says which geometry it measured',
+                  row.get('basis') in ('courtyard', 'fab', 'silk',
+                                       'pad_bbox'), str(row))
+
+
 def test_every_derived_fact_names_its_source():
     """#711's rule, applied here: no claim without a channel it came from."""
     doc, _ = _doc(TRACKED)
@@ -223,6 +256,7 @@ def test_md_is_a_sheet_a_reader_can_use():
 TESTS = [test_json_is_parseable_from_char_zero,
          test_the_usb_pair_row,
          test_the_pair_scope_attributes_what_the_interface_blends,
+         test_the_mating_face_column,
          test_every_derived_fact_names_its_source,
          test_the_body_column_is_the_896_model,
          test_panels_are_written_and_referenced,

--- a/tests/test_896_body_model.py
+++ b/tests/test_896_body_model.py
@@ -1,0 +1,244 @@
+"""#896: one body model -- the ladders, the refusals, and the run-25 numbers.
+
+The acceptance rows come from `wk/run25`'s lap 3 and lap 5, staged into
+`tests/fixtures/run25/` (`wk/` is gitignored, so a test reading it there would
+be green-while-covering-nothing on every other machine). Each row is here
+because it is a case where one rung of the ladder CHANGES the answer, not
+because it was convenient to assert.
+
+The three signed numbers were measured by hand, by an adversarial reviewer
+writing its own geometry during run 25, before any of this code existed
+(JOURNAL_placement.md entries at lap 3 and lap 5). They are the reason the
+issue exists, and reproducing them is what says the model reads the same
+geometry a human read.
+"""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path[:0] = [os.path.join(ROOT, 'py_router'),
+                os.path.join(ROOT, 'py_placer'),
+                os.path.join(ROOT, 'py_tools')]
+sys.path.insert(0, HERE)
+
+RUN_ALL_TIMEOUT = 900
+RUN_ALL_FAST_OK = True
+
+FAILURES = []
+
+
+def check(name, cond, detail=''):
+    if cond:
+        print(f'  PASS: {name}')
+    else:
+        FAILURES.append(f'{name}{(" -- " + detail) if detail else ""}')
+        print(f'  FAIL: {name} -- {detail}')
+
+
+def fixture(stem):
+    return os.path.join(ROOT, 'tests', 'fixtures', 'run25',
+                        f'esp_prog_{stem}.kicad_pcb')
+
+
+def _pcb(path):
+    from kicad_parser import parse_kicad_pcb
+    return parse_kicad_pcb(path)
+
+
+def _bodies(path):
+    from placement.body import board_bodies
+    return board_bodies(_pcb(path), path)
+
+
+def _board_rect(fp, local):
+    from placement.legality import rotate_local_bounds
+    x0, y0, x1, y1 = rotate_local_bounds(*local, fp.rotation or 0.0)
+    return (fp.x + x0, fp.y + y0, fp.x + x1, fp.y + y1)
+
+
+# The rows. Each: (lap, ref_a, ref_b, expected_gap_mm, source_a, source_b, why)
+#
+# `wk/run25/esp_prog/JOURNAL_placement.md` records the first two at lap 3
+# ("CON1 housing top 93.400 vs CON2 body bottom 93.520 = -0.120mm";
+# "CON2 body west 126.810 vs U2 body east 126.900 = -0.090mm") and the third at
+# lap 5 ("U1 body end 102.410 overlaps Y1 body top 102.277 by 0.133mm").
+ACCEPTANCE = [
+    ('lap3', 'CON1', 'CON2', -0.1200, 'silk', 'silk',
+     'two hand-drawn OLIMEX connector housings; neither draws .Fab, so silk '
+     'is the only body either has'),
+    ('lap3', 'CON2', 'U2', -0.0900, 'silk', 'silk',
+     'header plastic into the SOT89 marking'),
+    ('lap5', 'U1', 'Y1', -0.1330, 'silk', 'fab',
+     'THE mixed-source row: U1 draws no .Fab and falls to silk, Y1 draws one '
+     'and does not. A single-rung model gets this pair wrong whichever rung '
+     'it picks.'),
+]
+
+
+def test_acceptance_numbers():
+    """The three collisions run 25 paid two laps to find."""
+    from placement.legality import rect_gap
+    for lap, ra, rb, want, sa, sb, why in ACCEPTANCE:
+        path = fixture(lap)
+        pcb = _pcb(path)
+        bodies = _bodies(path)
+        ga, gb = bodies[ra], bodies[rb]
+        rect_a = _board_rect(pcb.footprints[ra], ga.drawn_local)
+        rect_b = _board_rect(pcb.footprints[rb], gb.drawn_local)
+        got = round(rect_gap(rect_a, rect_b), 4)
+        check(f'{lap} {ra}<->{rb} = {want:+.4f}mm', got == want,
+              f'got {got:+.4f} ({why})')
+        check(f'{lap} {ra}<->{rb} sources {sa}/{sb}',
+              (ga.drawn_source, gb.drawn_source) == (sa, sb),
+              f'got {ga.drawn_source}/{gb.drawn_source}')
+
+
+def test_the_channel_reports_them():
+    """Not just the model: `grade_body_overlap`'s own drawn-body channel.
+
+    The model could be right and the instrument still blind -- which is
+    precisely what #896 is about, since the fab channel HAD the right idea and
+    a one-rung ladder.
+    """
+    from placement.legality import grade_body_overlap
+    for lap in ('lap3', 'lap5'):
+        path = fixture(lap)
+        g = grade_body_overlap(_pcb(path), 0.15, pcb_file=path)
+        got = {(q.a, q.b): q.depth_mm for q in g['pairs'] if q.kind == 'fab'}
+        for l2, ra, rb, want, _sa, _sb, _why in ACCEPTANCE:
+            if l2 != lap:
+                continue
+            key = (min(ra, rb), max(ra, rb))
+            check(f'{lap} channel reports {ra}<->{rb}', key in got,
+                  f'pairs present: {sorted(got)}')
+            if key in got:
+                check(f'{lap} {ra}<->{rb} depth {abs(want)}',
+                      abs(got[key] - abs(want)) < 5e-4,
+                      f'got depth {got[key]}')
+
+
+def test_no_offset_is_applied_to_silk():
+    """The issue proposes expanding silk by "~0.2 mm on OLIMEX". Refuted by
+    its own acceptance numbers, and the refutation is asserted rather than
+    left in a comment: with a 0.2mm expansion on both parts the three numbers
+    become roughly -0.52 / -0.49 / -0.53.
+
+    This is a CHANGE DETECTOR. If someone adds an expansion constant, the
+    numbers above already move -- but this states the magnitude, so the diff
+    has to argue with it rather than re-record three literals.
+    """
+    from placement.legality import rect_gap
+    lap, ra, rb, want = 'lap3', 'CON1', 'CON2', -0.1200
+    path = fixture(lap)
+    pcb = _pcb(path)
+    bodies = _bodies(path)
+
+    def grown(ref, by):
+        g = bodies[ref]
+        x0, y0, x1, y1 = g.drawn_local
+        return _board_rect(pcb.footprints[ref],
+                           (x0 - by, y0 - by, x1 + by, y1 + by))
+    got = round(rect_gap(grown(ra, 0.2), grown(rb, 0.2)), 4)
+    check('a 0.2mm silk expansion would break the issue\'s own numbers',
+          abs(got - (want - 0.4)) < 1e-6,
+          f'expanded gap {got:+.4f}, unexpanded {want:+.4f}')
+
+
+def test_silk_is_refused_where_it_is_not_a_body():
+    """Two refusals, both measured on this board.
+
+    Q1/Q2 are SOT23s whose silk is a pair of ticks INSIDE the pad field: taken
+    bare it would shrink them from a 3.610 x 2.902mm pad box to 0.838 x 2.845,
+    which is the unsafe direction. The three reference-less blocks are OLIMEX
+    logos with no pads at all -- decoration, not parts to collide with.
+    """
+    path = fixture('lap3')
+    bodies = _bodies(path)
+    pcb = _pcb(path)
+    for ref in ('Q1', 'Q2'):
+        g = bodies[ref]
+        check(f'{ref} silk refused as a tick mark',
+              g.silk_rejected and g.drawn_source == 'none'
+              and g.source == 'pad_bbox',
+              f'silk_rejected={g.silk_rejected} drawn={g.drawn_source} '
+              f'source={g.source}')
+    padless = [r for r, fp in pcb.footprints.items() if not (fp.pads or ())]
+    check('the board carries pad-less blocks to refuse', len(padless) >= 3,
+          f'{len(padless)} found')
+    for ref in padless:
+        g = bodies[ref]
+        check(f'{ref} (pad-less) claims no silk body',
+              g.drawn_source != 'silk', f'drawn={g.drawn_source}')
+
+
+def test_occupancy_never_shrinks_below_the_pads():
+    """The rect the grading chain consumes is monotone.
+
+    A .Fab body is routinely NARROWER than the pads it sits between, so a
+    model handing the bare body to an occupancy consumer silently removes
+    findings -- measured over the corpus, three on ulx3s and two on esp_prog
+    before this was fixed.
+    """
+    from placement.utility import compute_footprint_bbox_local
+    import run_utils
+    boards = run_utils.corpus_boards()
+    check('corpus is not empty', len(boards) >= 22, f'{len(boards)} boards')
+    shrunk = []
+    checked = 0
+    for b in boards:
+        pcb = _pcb(b)
+        for ref, g in _bodies(b).items():
+            fp = pcb.footprints.get(ref)
+            if fp is None or not (fp.pads or ()) or g.occupancy_local is None:
+                continue
+            try:
+                pads = compute_footprint_bbox_local(fp)
+            except Exception:                                # noqa: BLE001
+                continue
+            checked += 1
+            o = g.occupancy_local
+            if (o[0] > pads[0] + 1e-9 or o[1] > pads[1] + 1e-9
+                    or o[2] < pads[2] - 1e-9 or o[3] < pads[3] - 1e-9):
+                shrunk.append((os.path.basename(b), ref, g.source))
+    check('something was checked', checked > 500, f'{checked} parts')
+    check('no occupancy rect is smaller than its own pad bbox',
+          shrunk == [], f'{len(shrunk)}: {shrunk[:5]}')
+
+
+def test_seam_is_signed_and_named():
+    """A seam and a collision are ONE number, and it says what it rests on."""
+    from placement.legality import grade_body_overlap
+    g3 = grade_body_overlap(_pcb(fixture('lap3')), 0.15,
+                            pcb_file=fixture('lap3'))
+    seam = g3.get('body_seam')
+    check('lap3 reports a seam', seam is not None)
+    if seam:
+        check('lap3 seam is the U1<->Y1 overlap, signed negative',
+              seam['mm'] == -0.133 and {seam['ref_a'], seam['ref_b']}
+              == {'U1', 'Y1'}, str(seam))
+        check('lap3 seam names both sources',
+              {seam['source_a'], seam['source_b']} == {'silk', 'fab'},
+              str(seam))
+
+
+TESTS = [test_acceptance_numbers, test_the_channel_reports_them,
+         test_no_offset_is_applied_to_silk,
+         test_silk_is_refused_where_it_is_not_a_body,
+         test_occupancy_never_shrinks_below_the_pads,
+         test_seam_is_signed_and_named]
+
+
+def main():
+    for t in TESTS:
+        print(f'--- {t.__name__}')
+        t()
+    print(f"\n{'FAIL' if FAILURES else 'PASS'}: #896 body model, "
+          f"{len(FAILURES)} failure(s)")
+    for f in FAILURES:
+        print(f'  - {f}')
+    return 1 if FAILURES else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_896_body_model.py
+++ b/tests/test_896_body_model.py
@@ -83,7 +83,19 @@ def test_acceptance_numbers():
         path = fixture(lap)
         pcb = _pcb(path)
         bodies = _bodies(path)
-        ga, gb = bodies[ra], bodies[rb]
+        ga, gb = bodies.get(ra), bodies.get(rb)
+        # Named refusals rather than a KeyError/TypeError. A mutation battery
+        # over this module killed three rows by TRACEBACK, and a traceback is
+        # the same non-zero exit a satisfied assertion gives -- it says the
+        # gate reacted, not that it saw the thing it names.
+        if ga is None or gb is None:
+            check(f'{lap} {ra}<->{rb}: both parts are in the body model',
+                  False, f'{ra}={ga is not None} {rb}={gb is not None}')
+            continue
+        if ga.drawn_local is None or gb.drawn_local is None:
+            check(f'{lap} {ra}<->{rb}: both parts have a DRAWN body', False,
+                  f'{ra} drawn={ga.drawn_source} {rb} drawn={gb.drawn_source}')
+            continue
         rect_a = _board_rect(pcb.footprints[ra], ga.drawn_local)
         rect_b = _board_rect(pcb.footprints[rb], gb.drawn_local)
         got = round(rect_gap(rect_a, rect_b), 4)
@@ -136,10 +148,17 @@ def test_no_offset_is_applied_to_silk():
 
     def grown(ref, by):
         g = bodies[ref]
+        if g.drawn_local is None:
+            return None
         x0, y0, x1, y1 = g.drawn_local
         return _board_rect(pcb.footprints[ref],
                            (x0 - by, y0 - by, x1 + by, y1 + by))
-    got = round(rect_gap(grown(ra, 0.2), grown(rb, 0.2)), 4)
+    _a, _b = grown(ra, 0.2), grown(rb, 0.2)
+    if _a is None or _b is None:
+        check('both parts have a drawn body to expand', False,
+              f'{ra}/{rb} drawn bodies missing')
+        return
+    got = round(rect_gap(_a, _b), 4)
     check('a 0.2mm silk expansion would break the issue\'s own numbers',
           abs(got - (want - 0.4)) < 1e-6,
           f'expanded gap {got:+.4f}, unexpanded {want:+.4f}')
@@ -157,7 +176,10 @@ def test_silk_is_refused_where_it_is_not_a_body():
     bodies = _bodies(path)
     pcb = _pcb(path)
     for ref in ('Q1', 'Q2'):
-        g = bodies[ref]
+        g = bodies.get(ref)
+        if g is None:
+            check(f'{ref} is in the body model', False, 'absent')
+            continue
         check(f'{ref} silk refused as a tick mark',
               g.silk_rejected and g.drawn_source == 'none'
               and g.source == 'pad_bbox',
@@ -167,7 +189,10 @@ def test_silk_is_refused_where_it_is_not_a_body():
     check('the board carries pad-less blocks to refuse', len(padless) >= 3,
           f'{len(padless)} found')
     for ref in padless:
-        g = bodies[ref]
+        g = bodies.get(ref)
+        if g is None:
+            check(f'{ref} is in the body model', False, 'absent')
+            continue
         check(f'{ref} (pad-less) claims no silk body',
               g.drawn_source != 'silk', f'drawn={g.drawn_source}')
 
@@ -206,6 +231,119 @@ def test_occupancy_never_shrinks_below_the_pads():
           shrunk == [], f'{len(shrunk)}: {shrunk[:5]}')
 
 
+def test_a_silk_body_is_never_smaller_than_its_pads():
+    """Rule 1, asserted where it can FAIL.
+
+    Added because a mutation battery removed the union from the silk rung and
+    every other arm here still passed: the acceptance numbers cannot see it
+    (CON1/CON2/U2's silk already contains their pad field, so the union is a
+    no-op there) and the occupancy arm cannot see it either (occupancy unions
+    with the pads again at the end regardless). The union's whole job is to
+    stop `drawn_local` -- the rect the BODY channel grades -- from being
+    narrower than the copper it sits on, and only this arm watches that.
+    """
+    from placement.utility import compute_footprint_bbox_local
+    import run_utils
+    boards = run_utils.corpus_boards()
+    checked, shrunk = 0, []
+    for b in boards:
+        pcb = _pcb(b)
+        for ref, g in _bodies(b).items():
+            if g.drawn_source != 'silk' or g.drawn_local is None:
+                continue
+            fp = pcb.footprints.get(ref)
+            if fp is None or not (fp.pads or ()):
+                continue
+            pads = compute_footprint_bbox_local(fp)
+            checked += 1
+            d = g.drawn_local
+            if (d[0] > pads[0] + 1e-9 or d[1] > pads[1] + 1e-9
+                    or d[2] < pads[2] - 1e-9 or d[3] < pads[3] - 1e-9):
+                shrunk.append((os.path.basename(b), ref))
+    # Non-vacuity: this arm is worthless if no part on the corpus takes the
+    # silk rung at all, which is exactly what a future ladder change could
+    # cause without anyone noticing.
+    check('some corpus part takes the silk rung', checked > 0,
+          f'{checked} silk-sourced parts')
+    check('no silk body is narrower than its own pads', shrunk == [],
+          f'{len(shrunk)}: {shrunk[:5]}')
+
+
+def test_the_courtyard_is_not_on_the_drawn_ladder():
+    """A courtyard is a body PLUS an assembly margin plus any shell overhang.
+
+    Run-6 calibrated the courtyard channel and the fab channel apart for that
+    reason -- the courtyard ships frac-1.0 containment on four healthy boards
+    -- so putting the courtyard on the drawn ladder would quietly re-merge
+    them. esp_prog cannot see this (no part on it draws a courtyard at all),
+    which is why the arm sweeps the corpus for parts that draw BOTH.
+    """
+    from placement.parser import extract_courtyard_sides, extract_fab_sides
+    import run_utils
+    both, wrong = 0, []
+    for b in run_utils.corpus_boards():
+        crt, fab = extract_courtyard_sides(b), extract_fab_sides(b)
+        bodies = _bodies(b)
+        for ref in set(crt) & set(fab):
+            g = bodies.get(ref)
+            if g is None:
+                continue
+            both += 1
+            if g.drawn_source != 'fab':
+                wrong.append((os.path.basename(b), ref, g.drawn_source))
+            if g.source != 'courtyard':
+                wrong.append((os.path.basename(b), ref,
+                              f'occupancy={g.source}'))
+    check('the corpus has parts drawing both a courtyard and a fab body',
+          both > 100, f'{both} parts')
+    check('such a part reads fab as its DRAWN body and courtyard as its '
+          'occupancy', wrong == [], f'{len(wrong)}: {wrong[:5]}')
+
+
+def test_a_silk_body_never_gates():
+    """The rule with the most consequences in #896, asserted both ways.
+
+    Added because a mutation row that DELETED the exclusion survived every
+    other arm here: the model was right, the disclosure was right, and nothing
+    watched the one decision that can turn a board NOT BUILDABLE.
+
+    Both directions matter, and the positive control is the half that is easy
+    to leave out. esp_prog's R1 clears U2's real body by 2.1mm and reads 89%
+    CONTAINED inside U2's silk square -- four corner brackets 5.2mm apart
+    around a 4.5mm part -- so the pair MUST be in the disclosed census and
+    MUST NOT be in the gating one. An arm checking only the gating side would
+    pass just as well on a build that had stopped producing the pair at all.
+    """
+    from placement.legality import grade_body_overlap
+    import run_utils
+
+    path = os.path.join(ROOT, 'kicad_files', 'esp_prog.kicad_pcb')
+    g = grade_body_overlap(_pcb(path), 0.15, pcb_file=path)
+    disclosed = {(q.a, q.b) for q in g['pairs'] if q.contained}
+    check('esp_prog DISCLOSES R1<->U2 as contained (the positive control -- '
+          'without it the arm below passes vacuously)',
+          ('R1', 'U2') in disclosed, f'contained pairs: {sorted(disclosed)}')
+    gating = {(q.a, q.b) for q in g['containment_blocking_pairs']}
+    check('esp_prog does not GATE on R1<->U2', ('R1', 'U2') not in gating,
+          f'gating pairs: {sorted(gating)}')
+
+    offenders = []
+    for b in run_utils.corpus_boards():
+        gg = grade_body_overlap(_pcb(b), 0.15, pcb_file=b)
+        silk_drawn = {r for r, s in (gg.get('body_sources') or {}).items()
+                      if s == 'silk'}
+        silk_occ = {r for r, x in _bodies(b).items() if x.source == 'silk'}
+        for q in gg['containment_blocking_pairs']:
+            if q.a in silk_drawn or q.b in silk_drawn:
+                offenders.append((os.path.basename(b), 'containment',
+                                  q.a, q.b))
+        for q in gg['courtyard_blocking_pairs']:
+            if q.a in silk_occ or q.b in silk_occ:
+                offenders.append((os.path.basename(b), 'courtyard', q.a, q.b))
+    check('no corpus board gates on a silk-sourced body', offenders == [],
+          f'{len(offenders)}: {offenders[:5]}')
+
+
 def test_seam_is_signed_and_named():
     """A seam and a collision are ONE number, and it says what it rests on."""
     from placement.legality import grade_body_overlap
@@ -226,6 +364,9 @@ TESTS = [test_acceptance_numbers, test_the_channel_reports_them,
          test_no_offset_is_applied_to_silk,
          test_silk_is_refused_where_it_is_not_a_body,
          test_occupancy_never_shrinks_below_the_pads,
+         test_a_silk_body_is_never_smaller_than_its_pads,
+         test_the_courtyard_is_not_on_the_drawn_ladder,
+         test_a_silk_body_never_gates,
          test_seam_is_signed_and_named]
 
 

--- a/tests/test_896_one_body_implementation.py
+++ b/tests/test_896_one_body_implementation.py
@@ -97,7 +97,8 @@ _DECLARED = {
     #    here, and the one a follow-up issue owns.
     (os.path.join('py_placer', 'placement', 'quench.py'),
      '_Part.__init__'): (
-        2, 'the SEARCH ladder. Adopting the model here changes which poses '
+        2, 'the SEARCH ladder -- #916 owns it. Adopting the model here '
+        'changes which poses '
         '`seeder.pose_ok` admits -- it reads these baked bounds -- and so the '
         'basin the anneal lands in: a placement-engine change needing its own '
         'A/B, not a ride-along on a reporting one. Measured, it would grow 23 '

--- a/tests/test_896_one_body_implementation.py
+++ b/tests/test_896_one_body_implementation.py
@@ -1,0 +1,302 @@
+"""#896 acceptance 3: no consumer computes a body on its own.
+
+`placement.body` answers "what is this part's body, and where did it come
+from". Before it, that question was answered in five places with three
+different ladders, and the one most consumers used skipped `.Fab` entirely --
+which is the whole defect.
+
+WHAT THIS GATE CAN AND CANNOT SEE
+---------------------------------
+A body ladder has no single spelling, so this does not grep for one. It greps
+for the two functions a ladder is BUILT from -- `compute_footprint_bbox_local`
+and the `placement.parser.extract_*` readers -- exactly as
+`tests/test_878_side_rule_sites.py` anchors on `side_of_layer`. Every call site
+outside the model and its parser must be DECLARED here with a reason, and the
+declaration is COUNTED, so deleting one of two calls inside a function is a
+finding rather than a silent pass.
+
+It cannot see a ladder written from raw regexes, and it says so
+(`_UNMATCHABLE`) rather than leaving a reader to assume coverage it does not
+have.
+
+WHY SO MANY SITES ARE DECLARED RATHER THAN CONVERTED
+----------------------------------------------------
+Some of them are not asking the body question at all, and converting them
+would be a behaviour change wearing a cleanup's clothes. Each declaration
+below carries the reason and, where one exists, the issue that owns it. A
+declaration is a decision on the record, not an exemption: the point is that a
+NEW site cannot appear without someone writing down which of these it is.
+"""
+import ast
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path[:0] = [os.path.join(ROOT, 'py_router'),
+                os.path.join(ROOT, 'py_placer')]
+
+RUN_ALL_TIMEOUT = 300
+RUN_ALL_FAST_OK = True
+
+FAILURES = []
+
+#: Production trees only. `tests/` is excluded deliberately: a test may spell a
+#: ladder in order to check one, and `test_896_body_model.py` does.
+_TREES = ('py_placer', 'py_router', 'py_tools', 'kicad_routing_plugin')
+
+#: THE model and its reader. Everything else is a consumer.
+_HOME = (os.path.join('py_placer', 'placement', 'body.py'),
+         os.path.join('py_placer', 'placement', 'parser.py'),
+         os.path.join('py_placer', 'placement', 'utility.py'))
+
+#: What a body ladder is built from. Not the ladder itself -- see the module
+#: docstring for why this is the anchor.
+_CALLS = re.compile(
+    r'\b(compute_footprint_bbox_local|extract_courtyard_sides'
+    r'|extract_courtyard_bboxes|extract_fab_sides|extract_silk_sides'
+    r'|courtyard_for_side)\b')
+
+#: Spellings this scanner CANNOT see, named in source rather than left to be
+#: discovered. A ladder built from `re.finditer` over the board text, or from
+#: `pcbnew`'s `GetCourtyard()`, would not match `_CALLS`.
+_UNMATCHABLE = (
+    'a hand-rolled regex over the board text (what wk/run25/probe_housings.py '
+    'was, and what #896 exists to make unnecessary)',
+    "pcbnew's GetCourtyard()/GetPolyCourtyard(), which nothing in the tree "
+    'calls today',
+    'a ladder reached through a variable holding one of these functions',
+)
+
+#: Conversely, what the scanner deliberately does NOT count, because counting
+#: it would make the gate satisfiable by prose: a mention inside a comment or a
+#: string. `routability.LaneContext.graded` names `extract_courtyard_sides` in
+#: its docstring and calls it nowhere; `board_brief.SOURCES_NOTE` names two of
+#: these functions in a string. Both were false positives of a line-matching
+#: first draft, and this repo has already been bitten by the inverse -- a
+#: comment quoting code that satisfied a source-grep test while the code was
+#: gone.
+
+#: {(relpath, enclosing qualname): (count, why it is not converted)}
+#:
+#: MEASURED, not remembered. The first draft of this table was written from
+#: memory and the gate rejected 7 of its 15 rows as invented qualnames and 2
+#: more as wrong counts, which is the table doing its job on its own author.
+_DECLARED = {
+    # -- goes through the model; the call here is not a ladder.
+    (os.path.join('py_placer', 'placement', 'legality.py'),
+     'part_local_bounds'): (1, 'the +/-0.5mm fiction for a part the model '
+                            'reports as SOURCE_NONE; the ladder itself is '
+                            'body.board_bodies'),
+    (os.path.join('py_tools', 'board_brief.py'),
+     'parts_section'): (1, 'fallback only, when the model returns no box; '
+                        'the extent itself is body.occupancy_local'),
+
+    # -- the SEARCH ladder, deferred deliberately. The biggest declaration
+    #    here, and the one a follow-up issue owns.
+    (os.path.join('py_placer', 'placement', 'quench.py'),
+     '_Part.__init__'): (
+        2, 'the SEARCH ladder. Adopting the model here changes which poses '
+        '`seeder.pose_ok` admits -- it reads these baked bounds -- and so the '
+        'basin the anneal lands in: a placement-engine change needing its own '
+        'A/B, not a ride-along on a reporting one. Measured, it would grow 23 '
+        'of 1349 corpus parts and shrink none, on 4 of 22 boards.'),
+    (os.path.join('py_placer', 'placement', 'quench.py'),
+     'QuenchState.__init__'): (1, 'builds the courtyard map _Part consumes; '
+                               'same deferral'),
+    (os.path.join('py_placer', 'placement', 'quench.py'),
+     'QuenchState.fab_rect'): (1, 'the fab body for the quench containment '
+                               'test, on the same deferred ladder'),
+
+    # -- a DIFFERENT question, where converting would change a measured
+    #    currency or reason in a circle.
+    (os.path.join('py_placer', 'placement', 'options.py'),
+     'grow_board'): (2, '#878 far-face AREA currency, which reads the '
+                     'side-BLIND extract_courtyard_bboxes on purpose: a '
+                     "through-hole part's leads block the far face too. "
+                     'Converting it changes the currency and forces a #878 '
+                     're-record.'),
+    (os.path.join('py_placer', 'placement', 'labels.py'),
+     '_world_courtyard'): (1, 'silkscreen LABEL placement. A silk-derived '
+                           'body feeding a silk-placement algorithm is '
+                           'circular, and its fallback is a 1mm box rather '
+                           "than the model's fiction."),
+    (os.path.join('py_placer', 'placement', 'labels.py'),
+     'beautify_labels'): (1, 'reads the courtyard map _world_courtyard '
+                          'consumes; same argument'),
+    (os.path.join('py_placer', 'placement', 'fanout_clearance.py'),
+     '_Repair.__init__'): (3, 'the #313 via-nudge cap model, which prices its '
+                           'own clearance ceiling (#768/#769) and is the one '
+                           'PLACEMENT step that lays copper; a separate '
+                           'question from what a part body is'),
+
+    # -- convertible, and simply not in this PR. Each is a candidate for the
+    #    follow-up, and saying so is the point: a reader can tell a decision
+    #    from a leftover.
+    (os.path.join('py_placer', 'placement', 'placement_state.py'),
+     '_global_rect'): (2, 'a third copy of courtyard-or-pad-bbox; '
+                       'behaviour-preserving to convert, not in this PR'),
+    (os.path.join('py_placer', 'placement', 'placement_state.py'),
+     '_outside_fraction'): (1, 'builds the courtyard map _global_rect '
+                            'consumes'),
+    (os.path.join('py_placer', 'placement', 'lock_advisor.py'),
+     'advise_locks'): (1, 'pose-plausibility geometry; convertible, not in '
+                       "this PR's scope"),
+    (os.path.join('py_tools', 'check_pockets.py'),
+     'pocket_census'): (3, 'the pocket census; convertible, not in this PR'),
+}
+
+
+def check(name, cond, detail=''):
+    if cond:
+        print(f'  PASS: {name}')
+    else:
+        FAILURES.append(f'{name}{(" -- " + detail) if detail else ""}')
+        print(f'  FAIL: {name} -- {detail}')
+
+
+def _code_names(src):
+    """[(lineno, NAME token)] with comments, strings and imports removed.
+
+    Returns None when the file cannot be tokenized, which is reported rather
+    than skipped: a file the scanner could not read is not a file it checked.
+    """
+    import io as _io
+    import tokenize
+    out = []
+    try:
+        toks = list(tokenize.generate_tokens(
+            _io.StringIO(src).readline))
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        return None
+    logical = []
+    line_start = True
+    skip_line = None
+    for tok in toks:
+        if tok.type in (tokenize.NEWLINE, tokenize.NL):
+            line_start = True
+            skip_line = None
+            continue
+        if tok.type in (tokenize.COMMENT, tokenize.STRING,
+                        tokenize.INDENT, tokenize.DEDENT):
+            continue
+        if line_start and tok.type == tokenize.NAME and                 tok.string in ('import', 'from'):
+            # An import names the function without calling it.
+            skip_line = tok.start[0]
+        line_start = False
+        if skip_line is not None:
+            continue
+        if tok.type == tokenize.NAME:
+            out.append((tok.start[0], tok.string))
+    del logical
+    return out
+
+
+def _qualnames(src):
+    """line number -> enclosing def/class qualname."""
+    out = {}
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return None
+
+    def walk(node, prefix):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef,
+                                  ast.ClassDef)):
+                name = f'{prefix}.{child.name}' if prefix else child.name
+                lo = child.lineno
+                hi = getattr(child, 'end_lineno', lo)
+                for ln in range(lo, hi + 1):
+                    out[ln] = name
+                walk(child, name)
+    walk(tree, '')
+    return out
+
+
+def scan():
+    """[(relpath, qualname, count)] over the production trees."""
+    found = {}
+    files = 0
+    broken = []
+    for tree in _TREES:
+        base = os.path.join(ROOT, tree)
+        for root, _dirs, names in os.walk(base):
+            if '__pycache__' in root:
+                continue
+            for fn in names:
+                if not fn.endswith('.py'):
+                    continue
+                path = os.path.join(root, fn)
+                rel = os.path.relpath(path, ROOT)
+                files += 1
+                if rel in _HOME:
+                    continue
+                with open(path, encoding='utf-8', errors='replace') as fh:
+                    src = fh.read()
+                if not _CALLS.search(src):
+                    continue
+                qn = _qualnames(src)
+                if qn is None:
+                    broken.append(f'UNPARSEABLE: {rel}')
+                    continue
+                # TOKENIZED, not line-matched. A comment or a docstring
+                # that NAMES one of these functions is not a call, and a
+                # grep that counts it is satisfiable by prose -- this repo
+                # has been bitten by exactly that (a comment quoting code
+                # made a source-grep test pass while the code was gone).
+                # `board_brief.SOURCES_NOTE` names two of them in a string.
+                names = _code_names(src)
+                if names is None:
+                    broken.append(f'UNTOKENIZABLE: {rel}')
+                    continue
+                for i, name in names:
+                    if not _CALLS.fullmatch(name):
+                        continue
+                    key = (rel, qn.get(i, '<module>'))
+                    found[key] = found.get(key, 0) + 1
+    return found, files, broken
+
+
+def main():
+    found, files, broken = scan()
+    print(f'--- scanned {files} production file(s), '
+          f'{len(found)} declared site(s) expected')
+    for b in broken:
+        check(b, False, 'a file the scanner could not parse is not a file it '
+                        'checked')
+
+    # Not vacuous. A scanner that finds nothing passes every assertion below
+    # it, and the two ways that happens -- a broken regex and a wrong tree
+    # list -- both look exactly like success.
+    check('the scan is not vacuous', files >= 100 and len(found) >= 10,
+          f'{files} files, {len(found)} sites')
+
+    undeclared = sorted(k for k in found if k not in _DECLARED)
+    check('no UNDECLARED body-ladder site', undeclared == [],
+          'a new site must be converted to placement.body or declared here '
+          f'with its reason: {undeclared}')
+
+    stale = sorted(k for k in _DECLARED if k not in found)
+    check('no STALE declaration', stale == [],
+          f'declared but not found -- renamed or removed: {stale}')
+
+    miscount = sorted((k, found[k], _DECLARED[k][0])
+                      for k in found if k in _DECLARED
+                      and found[k] != _DECLARED[k][0])
+    check('every declaration matches its COUNT', miscount == [],
+          f'(site, found, declared): {miscount}')
+
+    check('the unmatchable spellings are named in source',
+          len(_UNMATCHABLE) >= 3)
+
+    print(f"\n{'FAIL' if FAILURES else 'PASS'}: #896 one body "
+          f"implementation, {len(FAILURES)} failure(s)")
+    for f in FAILURES:
+        print(f'  - {f}')
+    return 1 if FAILURES else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_board_brief.py
+++ b/tests/test_board_brief.py
@@ -228,22 +228,32 @@ with tempfile.TemporaryDirectory() as wd:
 # fed to --fit WxH for half a board -- and the understated area fed
 # grow_board's utilisation.
 # --------------------------------------------------------------------------
+# #896: the canonical box is `placement.body`'s OCCUPANCY rect, and this arm
+# CALLS it rather than re-deriving the ladder. It used to spell out
+# courtyard-or-pad-bbox here, which was a mirror of the implementation -- so
+# when the ladder gained the .Fab and silk rungs the arm reported five
+# esp_prog "mismatches" that were the fix working (CON1 [1.5, 7.25] -> [3.2,
+# 9.7], CON2 [17.018, 1.778] -> [17.78, 2.54]). A test that re-implements what
+# it grades can only ever detect that the two copies drifted.
+from placement.body import board_bodies
 from placement.legality import rotate_local_bounds
-from placement.parser import extract_courtyard_bboxes
-from placement.utility import compute_footprint_bbox_local
+from placement.utility import compute_footprint_bbox_local  # noqa: F401
 
 for _bd in (BOARD, os.path.join(REPO, 'kicad_files', 'esp_prog.kicad_pcb')):
     if not os.path.isfile(_bd):
         continue
     _pcb = parse_kicad_pcb(_bd)
     _brief = build_brief(_pcb, _bd)
-    _cy = extract_courtyard_bboxes(_bd) or {}
+    _bodies = board_bodies(_pcb, _bd)
     bad, rotated, twopad = [], 0, 0
     for _ref, _row in _brief['parts'].items():
         _fp = _pcb.footprints.get(_ref)
         if _fp is None or _row['extent_source'] == 'none':
             continue
-        _box = _cy.get(_ref) or compute_footprint_bbox_local(_fp)
+        _geom = _bodies.get(_ref)
+        _box = (_geom.occupancy_local if _geom is not None
+                and _geom.occupancy_local is not None
+                else compute_footprint_bbox_local(_fp))
         _g = rotate_local_bounds(*_box, _fp.rotation or 0.0)
         want = [round(_g[2] - _g[0], 3), round(_g[3] - _g[1], 3)]
         if want != _row['extent_mm']:

--- a/tests/test_pair_order.py
+++ b/tests/test_pair_order.py
@@ -70,14 +70,21 @@ def _facing_pair(order_b):
 def test_identity_is_planar():
     st = _facing_pair([1, 2, 3, 4, 5])
     m = pair_metrics(st, 'A', 'B')
-    assert m == {'inversions': 0, 'lis': 5, 'nets': 5}, m
-    print("  PASS: matched order -> 0 inversions, all 5 nets planar")
+    # #896/#891: `ties` is an additive key -- how many pads project to the
+    # same point on the channel axis, where the sort falls back to the net
+    # id and INVENTS an order. Asserted here rather than filtered out,
+    # because a synthetic fixture with 0 ties is what makes the inversion
+    # count above mean anything at all.
+    assert m == {'inversions': 0, 'lis': 5, 'nets': 5, 'ties': 0}, m
+    print("  PASS: matched order -> 0 inversions, all 5 nets planar, "
+          "no ties")
 
 
 def test_full_reversal_is_maximal():
     st = _facing_pair([5, 4, 3, 2, 1])
     m = pair_metrics(st, 'A', 'B')
-    assert m == {'inversions': 10, 'lis': 1, 'nets': 5}, m  # n(n-1)/2, LIS 1
+    assert m == {'inversions': 10, 'lis': 1, 'nets': 5,
+                 'ties': 0}, m               # n(n-1)/2, LIS 1, no ties
     print("  PASS: reversed order -> n(n-1)/2 inversions, LIS 1")
 
 

--- a/tests/test_run6_body_overlap.py
+++ b/tests/test_run6_body_overlap.py
@@ -29,11 +29,14 @@ FINAL5 = os.path.join(ROOT, 'wk', 'run5', 'final5.kicad_pcb')
 HUMAN = os.path.join(ROOT, 'wk', 'run2', 'original', 'tigard_v10.kicad_pcb')
 
 
-def _grade(board, **kw):
+def _pcb(board):
     from kicad_parser import parse_kicad_pcb
+    return parse_kicad_pcb(board)
+
+
+def _grade(board, **kw):
     from placement.legality import grade_body_overlap
-    return grade_body_overlap(parse_kicad_pcb(board), 0.09,
-                              pcb_file=board, **kw)
+    return grade_body_overlap(_pcb(board), 0.09, pcb_file=board, **kw)
 
 
 
@@ -325,8 +328,8 @@ class TestContainment(unittest.TestCase):
         self.assertEqual(len(g['fab_unjudged_refs']), g['fab_unjudged'])
 
     def test_the_bodyless_hole_is_exactly_what_was_measured(self):
-        """140 footprints draw no .Fab body, and that is the FINAL answer,
-        not a TODO.
+        """77 footprints have no drawn body at all -- re-recorded at #896,
+        from 140, and no longer "the FINAL answer".
 
         It was 144 over 33 boards. The count is a census of whatever
         `kicad_files/` holds, and as the next test says, the generated
@@ -344,9 +347,22 @@ class TestContainment(unittest.TestCase):
         min/max over points).
 
         This test exists so a future "helpful" parser change that alters the
-        count has to come and argue with the number. The dangerous direction
-        is a FALLBACK body for bodyless parts: measured, that adds 77 fab
-        pairs, 65 above the threshold, and breaks the calibration gate below.
+        count has to come and argue with the number. #896 came and argued.
+
+        The dangerous direction named here -- a FALLBACK body for bodyless
+        parts, measured at +77 fab pairs, 65 above the threshold -- was a
+        COURTYARD-or-pad-bbox fallback, and it is still dangerous. The SILK
+        rung is different geometry and was measured separately over the same
+        corpus: 140 unjudged -> 77, +6 advisory pairs, +2 disclosed
+        containments, and ZERO new pairs able to gate, because a silk-sourced
+        body is excluded from `containment_blocking` and `courtyard_blocking`
+        structurally (see the next test down and legality's `_silk_*_pair`).
+
+        The 63 parts that gained a body are the ones #896 is about: on
+        esp_prog every one of the 21 footprints draws silk and none draws a
+        courtyard, so CON1, CON2, U1 and U2 -- the connector housings, the
+        SSOP and the SOT89 whose collisions cost run 25 two laps -- were
+        unjudged by this channel and are now judged.
         """
         boards = _corpus()
         # 22, not 30. The floor is an anti-vacuity guard -- a sweep
@@ -356,26 +372,31 @@ class TestContainment(unittest.TestCase):
         # file's own runner (#876) so nothing ever reported the drift.
         self.assertGreaterEqual(len(boards), 22)
         total_unjudged = sum(_grade(b)['fab_unjudged'] for b in boards)
-        self.assertEqual(total_unjudged, 140,
+        self.assertEqual(total_unjudged, 77,
                          f'corpus fab_unjudged moved to {total_unjudged}; if '
-                         f'that was deliberate, re-measure the 4-pair census '
+                         f'that was deliberate, re-measure the 6-pair census '
                          f'below and this number together')
 
-    def test_no_unjudged_part_has_fab_geometry_to_read(self):
+    def test_no_unjudged_part_has_body_geometry_to_read(self):
         """The INVARIANT behind the count above, and the stronger claim.
 
-        `fab_unjudged == 144` is a census of THIS corpus, and 11 of the 33
-        boards it sweeps are untracked generated fixtures, so the number moves
-        when someone regenerates one. This assertion does not depend on corpus
-        membership: whatever the set is, every unjudged part must draw NO .Fab
-        geometry at all.
+        The count is a census of THIS corpus, so it moves when someone adds or
+        regenerates a board. This assertion does not depend on corpus
+        membership: whatever the set is, every unjudged part must draw NO body
+        geometry the model could have read -- since #896 that means no .Fab
+        AND no silk the drawn-body ladder would accept, not just no .Fab.
 
         That is what licenses "a parser tolerance or polygon-closure fix moves
-        zero footprints" -- not the 144. If this ever fails, the parser really
-        is failing to read a body it was handed, and the disclosure-not-a-fix
-        conclusion has to be revisited.
+        zero footprints" -- not the count. If this ever fails, the parser
+        really is failing to read a body it was handed, and the
+        disclosure-not-a-fix conclusion has to be revisited.
+
+        Checked by calling `placement.body` rather than re-deriving the
+        ladder: a second implementation of the rung order is exactly what
+        #896 exists to remove, and a test carrying one would grade its own
+        copy.
         """
-        from placement.parser import extract_fab_sides
+        from placement.body import board_bodies
         boards = _corpus()
         # 22, not 30. The floor is an anti-vacuity guard -- a sweep
         # over an empty glob passes every assertion below it -- and it
@@ -385,33 +406,52 @@ class TestContainment(unittest.TestCase):
         self.assertGreaterEqual(len(boards), 22)
         readable, checked = [], 0
         for b in boards:
-            sides = extract_fab_sides(b)
+            bodies = board_bodies(_pcb(b), b)
             for ref in _grade(b)['fab_unjudged_refs']:
                 checked += 1
-                if sides.get(ref):
-                    readable.append((os.path.basename(b), ref))
+                geom = bodies.get(ref)
+                if geom is not None and geom.drawn_local is not None:
+                    readable.append((os.path.basename(b), ref,
+                                     geom.drawn_source))
         self.assertGreater(checked, 0, 'nothing was checked')
         self.assertEqual(readable, [], f'{len(readable)} part(s) are reported '
-                                       f'unjudged while their .Fab geometry '
+                                       f'unjudged while their body geometry '
                                        f'parses fine: {readable[:5]}')
 
     def test_corpus_carries_no_nonexempt_body_containment(self):
         """THE calibration gate for the threshold, sibling of
         test_all_healthy_boards_grade_zero_blocking.
 
-        Measured over all 33 boards: the fab census is exactly 4 pairs, and
-        every non-exempt one is a shell KISS three orders of magnitude below
-        the threshold (GPDI1/J5 at 0.011, GPDI1/SW1 at 0.001) against a
-        measured defect of 1.000. That ~90x separation is what licenses
-        CONTAINMENT_FRAC.
+        Measured over all 33 boards, BEFORE #896: the fab census was exactly 4
+        pairs, and every non-exempt one was a shell KISS three orders of
+        magnitude below the threshold (GPDI1/J5 at 0.011, GPDI1/SW1 at 0.001)
+        against a measured defect of 1.000. That ~90x separation is what
+        licenses CONTAINMENT_FRAC, and it is unchanged.
 
         It is also why the ENGINE predicate may use the fab currency and never
         the courtyard: the courtyard ships frac-1.0 containment on four healthy
         boards (esp_prog, orangecrab_ext_pll, rp2350_fpga_eensy_prePlane,
         ulx3s), so a courtyard-based predicate would false-veto legitimate
         poses on 12% of the corpus -- the run-4 lesson in a new costume.
+
+        RE-RECORDED at #896, from 4 to 6. The channel now reads the drawn-body
+        ladder (fab, else silk united with the pad bbox), so parts whose
+        library draws no .Fab are judged instead of being counted unjudged.
+        The two new pairs are both on esp_prog and both come from SILK:
+
+            CON2 <-> U2  frac 0.0538   (the -0.090mm seam of issue #896)
+            R1   <-> U2  frac 0.8917
+
+        R1 <-> U2 is why silk never gates. U2's OLIMEX SOT89 draws four corner
+        brackets at +/-2.5mm plus a pin-1 dot -- a 5.2 x 5.2mm assembly square
+        centred on an origin its pads are not centred on -- so R1, which clears
+        U2's real body by 2.1mm, reads as 89% contained. The pair is DISCLOSED
+        here, and the engine excludes silk-sourced pairs from
+        `containment_blocking` structurally, which the last assertion below
+        checks by calling the engine rather than re-deriving it.
         """
         from placement.legality import CONTAINMENT_FRAC
+        from placement.body import SOURCE_SILK
         boards = _corpus()
         # 22, not 30. The floor is an anti-vacuity guard -- a sweep
         # over an empty glob passes every assertion below it -- and it
@@ -420,15 +460,30 @@ class TestContainment(unittest.TestCase):
         # file's own runner (#876) so nothing ever reported the drift.
         self.assertGreaterEqual(len(boards), 22)
         census = []
+        gated = []
         for b in boards:
-            for p in _grade(b)['pairs']:
+            g = _grade(b)
+            srcs = g.get('body_sources') or {}
+            for p in g['pairs']:
                 if p.kind == 'fab':
                     census.append((os.path.basename(b), p.a, p.b,
-                                   p.contained_frac, bool(p.waiver)))
-        self.assertEqual(len(census), 4, census)
+                                   p.contained_frac, bool(p.waiver),
+                                   srcs.get(p.a, ''), srcs.get(p.b, '')))
+            gated += [(os.path.basename(b), q.a, q.b)
+                      for q in g['containment_blocking_pairs']]
+        self.assertEqual(len(census), 6, census)
+        # The threshold calibration, on the pairs that can reach a verdict:
+        # a silk body is an assembly marking as often as an outline, so it is
+        # disclosed above and excluded here -- the same rule the engine
+        # applies, stated once in each place because this arm deliberately
+        # re-derives the predicate the engine's `containment_blocking` uses.
         offenders = [c for c in census
-                     if c[3] >= CONTAINMENT_FRAC and not c[4]]
+                     if c[3] >= CONTAINMENT_FRAC and not c[4]
+                     and SOURCE_SILK not in (c[5], c[6])]
         self.assertEqual(offenders, [], offenders)
+        # And the engine's own answer, not a mirror of it: no corpus board
+        # gates on body containment.
+        self.assertEqual(gated, [], gated)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Two run-25 findings on `esp_prog`, whose OLIMEX library draws **no courtyards**.

`legality.part_local_bounds` is the ladder every placement instrument reaches
through, and it went **courtyard → pad bounding box** — it never looked at
`.Fab`. A second fab implementation lived inline inside `grade_body_overlap`, a
third in `quench.fab_rect`. On esp_prog **0 of 21** footprints draw a courtyard,
and the six parts the issue names — CON1, CON2, U1, U2, Q1, Q2 — draw no `.Fab`
either. Silk is their only body, and nothing in `py_placer/` read silk. Both
placement-verifier FAILs that run were body collisions no instrument could see;
each was found only by an adversarial reviewer writing ~950 lines of its own
geometry, and each cost a lap past the P4 cap.

## The three acceptance numbers, reproduced exactly

Ladder: **courtyard → fab → silk ∪ pads → pad bbox**, silk at stroke centreline
with no expansion. Measured on the run-25 laps, now committed as fixtures:

| pair | sources | measured | issue |
|---|---|---|---|
| lap3 CON1↔CON2 | silk / silk | **−0.1200** | −0.12 |
| lap3 CON2↔U2 | silk / silk | **−0.0900** | −0.09 |
| lap3+5 U1↔Y1 | silk / **fab** | **−0.1330** | −0.133 |

The mixed source on the third row is the ladder doing its job: U1 draws no fab,
Y1 does. `check_assembly` prints all three, attributed:

```
U1   <-> Y1    body(silk/fab)   0.4256mm2 side F  advisory
CON1 <-> CON2  body(silk/silk)  0.1248mm2 side F  advisory
CON2 <-> U2    body(silk/silk)  0.0918mm2 side F  advisory
```

**This refutes the issue's own proposal** of expanding silk by "~0.2 mm on
OLIMEX": that turns −0.12 / −0.09 / −0.133 into −0.52 / −0.49 / −0.53. There is
no offset constant, and a test states the magnitude so a future one has to argue
with a figure.

## Corpus effect: 22 tracked boards, symmetric diff, nothing lost

| | before | after |
|---|---|---|
| `fab_unjudged` | 140 | **77** |
| `blocking` | 0 | 0 |
| `containment_blocking` | 0 | 0 |
| `courtyard_blocking` | 118 | 119 |
| `advisory` | 177 | 183 |
| `waived` | 123 | 134 |

63 parts gained a body. The symmetric diff earned its keep twice: an earlier
arm of this work *removed* three real ulx3s findings and two esp_prog ones, and
a one-sided "new pairs" count would not have seen it.

The one new gating pair is orangecrab's **J3 (micro-USB) ↔ J4 (micro-SD)**: J4's
`.Fab` outline is a 12 × 4 mm strip drawn 4 mm clear of its own 12.15 mm pad
field, so the union of the two is 3.8 mm taller than either. Real geometry,
newly visible; it carries an `edge_class` waiver that run-23's interior-overlap
rule un-waives. Worth a look — I have not moved anything on that board.

Source mix over 1349 corpus parts: 1267 courtyard, 27 fab, **6 silk**, 49 pad
bbox, 0 with no geometry at all; 2 silk boxes refused as tick marks.

## Four decisions that are measurements, not preferences

**Only the silk rung unions with the pads.** Silk is not an outline — on a stock
KiCad footprint it is a pair of clipped side ticks. Over the **10 esp_prog
footprints that draw both**, the silk bbox is narrower than the `.Fab` body in
W on **10 of 10** and wider in H on **10 of 10** (Y1: 0.508 x 2.540 against a
3.200 x 2.500 body; C1: 1.016 x 1.524 against 1.524 x 0.762), so no offset
reconciles them — the sign of the error differs per axis. Silk area is smaller
than fab area on 7 of those 10. Taken bare it would shrink Q1/Q2 from a
3.610 × 2.902 pad box to 0.838 × 2.845. Unioning the courtyard and fab rungs too
is a *different* measurement: it moves U1↔Y1 to −0.2830, because Y1's pads
overhang its fab body.

**Two ladders, not one value with a flag.** `occupancy_local` (courtyard → fab →
silk ∪ pads → pads) is what every consumer deciding whether something may be
seated somewhere reads, and it never shrinks. `drawn_local` (fab → silk ∪ pads)
is what the library drew, and the courtyard is deliberately not on it: a
courtyard is a body plus an assembly margin plus any shell overhang, which is
why run 6 calibrated those two channels apart.

**A pad-less footprint gets no silk body.** Allowing it put 5 corpus pairs above
the run-23 blocking floors and all five were logos.

**A silk-sourced body never gates — structurally, not because a census came out
clean.** On the shipped esp_prog, U2's OLIMEX SOT89 draws four corner brackets
at ±2.5 mm plus a pin-1 dot — a 5.2 × 5.2 mm assembly square centred on an
origin its pads are not centred on — and R1, which clears U2's real body by
2.1 mm, reads as 89 % *contained* and gated the board NOT BUILDABLE. The pair is
reported with its source; it does not decide. The exclusion is scoped per
channel, because scoping it to one set threw away four pre-existing findings
silk had nothing to do with.

## The tightest body seam

`body_overlap_pairs` reports a depth only for pairs that already overlap, so a
board a hair from a collision reported nothing at all. `tightest_body_seam` is
signed (negative is an overlap) and names the source each side rests on. On run
25's final board:

```
tightest body seam: +0.019mm  C3<->U2 (fab/silk)  |  bodies from 10 fab, 4 silk
```

and the issue's own 0.183 mm figure is the next-but-two pair, `CON2↔R3`
(silk/fab) — reproduced, with two tighter ones found. That the headline depends
on the source is exactly why the seam names its sources.

A silk-sourced outline is drawn **dashed** on every panel, with a legend row
that appears only when the board has one.

## #891: the component-context sheet

`py_tools/board_context.py BOARD [--md | --json] [--panels DIR] [--brief F]` —
an assembler, not a new engine. Body and its rung from `placement.body`; pads by
board face from `escape.assign_faces`; pin order from `pair_order`; class from
`part_class`; decap partner from `groups`; pairs from the resonator-safe
`list_nets` wrapper; panels from `render_placement`'s own `PanelSpec`. The
sheet's SOURCES section says which column came from where, and `unknown` is a
value it actually produces.

Two additive changes in `pair_order`:

* **`pair_metrics(only_nets=…)`** narrows the question to a declared pair. What
  it buys is *attribution*: on lap 5 the U1↔USB1 interface blends 3 inversions
  across 3 nets, and the pair scope says exactly 1 of them belongs to
  `/D_P`,`/D_N` — the part a mirror or a via hop fixes and rotation does not.
* **`ties`** counts pads that project to the same point on the channel axis,
  where the sort falls back to the net id and *invents* an order. On the tracked
  esp_prog, U1's `/D_P` and `/D_N` sit at the same y while the channel runs
  along x, so the pair reported "AGREES" for a question with no answer at that
  pose. The sheet says `UNDETERMINED`; lap 5, where U1 sits at 270°, says
  `CROSSED`.

The sheet also carries the **mating face** column #891 names -- which edge a
connector mates through, its distance, whether it is INTERIOR, and its
overhang -- measured from the body model rather than from
`connector_edge_facts`' own number, which reads the quench's pad-box ladder
(USB1's pad box sits 0.49 mm inside the west edge while its drawn body reaches
it). One correction to the issue while I was there: it asks for "USB1's mating
face reads W with overhang > 0". The face **is** W; the overhang is **zero** on
both esp_prog boards, because USB1's body starts at x 114.000 and the outline's
west edge is 114.000 — flush, not overhanging. The test asserts flush.

## What is deliberately NOT in this PR

**The search does not adopt the model.** `quench._Part.__init__` inlines its own
courtyard-or-pad-bbox ladder and `seeder.pose_ok` reads those baked bounds, so
changing `part_local_bounds` does not touch the search at all — reporting-only
is a no-op boundary here, not a special case. Adopting it would change which
poses `pose_ok` admits and therefore the basin the anneal lands in; measured, 23
of 1349 corpus parts would grow and none shrink, on 4 of 22 boards. That needs
`tests/test_placement_ab.py` as a gate rather than a tripwire, and a pair census
on finished boards says nothing about it. The site is **declared with that
reason** in the one-implementation gate, and I will file the follow-up.

`options.grow_board` (#878's side-blind far-face area currency), the two
silkscreen-label sites (a silk-derived body feeding a silk-placement algorithm
reasons in a circle) and `fanout_clearance`'s cap model are declared for their
own reasons rather than converted. `placement_state._global_rect`,
`lock_advisor` and `check_pockets` are convertible and simply not in this PR —
and the gate says so, so a reader can tell a decision from a leftover.

## Suite

571 passed. Four failures, each accounted for rather than averaged away:
`test_run15_handback_contract` fails identically on a baseline worktree at the
same base commit (pre-existing); `test_interf_u` timed out under parallel load
and passes alone; and three are mine, all from esp_prog's parts now carrying
real bodies — `test_pair_order` (the additive `ties` key broke an exact-dict
compare), `test_709_cold_windows` and `test_709_arrangement_census`. The last
two are re-recorded **with the measurement and the argument**, not quietly:

* the cold "empty band south of CON2's eastern half" is 0.88 mm of real board,
  not the 2.49 mm the pad boxes implied — the rest is connector plastic, and
  offering a router a lane through it is exactly the claim #709 exists to make
  trustworthy. The band is gone, correctly; the structural claim it was written
  for is what the arm now asserts. The companion "beside U2" region gets a
  caveat rather than a clean conscience, because U2's silk square overstates
  that part.
* the arrangement census's AREA-weighted centroid moved 0.0107 → 0.0205 while
  the COUNT form barely moved (0.1494 → 0.1515). The issue's finding survives,
  and the number is stated: the separation is now **7.4×, not 14×**, and it
  narrowed because the area form grew, not because the count form shrank.

## Gates

* `tests/test_896_body_model.py` — the three acceptance rows with their source
  pair, both silk refusals, two corpus-wide monotonicity claims, and a change
  detector for the 0.2 mm expansion.
* `tests/test_896_one_body_implementation.py` — the no-second-implementation
  audit: tokenized (so a comment or docstring cannot satisfy it), counted, keyed
  by enclosing qualname, with the unmatchable spellings named in source.
* `tests/test_891_board_context.py` — both boards, `--json` parseable from char
  0, sources present, `unknown` reachable, panels written and referenced.
* Seven rows in `tests/mutate_837.py` (new `bo` target), all KILLED.
* Two corpus censuses in `tests/test_run6_body_overlap.py` re-recorded **with**
  the measurement and the argument: `fab_unjudged` 140 → 77 and the fab
  containment census 4 → 6 pairs.

### Three things the gates found in my own work

* A mutation row deleting the silk∪pads union **survived** every arm — the
  acceptance numbers cannot see it and neither can the occupancy arm.
* A mutation row deleting the silk gating exclusion **survived** too: nothing
  watched the one decision that can turn a board NOT BUILDABLE.
* The one-implementation registry, written from memory, had 7 invented qualnames
  and 2 wrong counts; and its first draft counted two mentions inside string
  literals.

Each is now an arm, and the docstrings record why.

Closes #896
Closes #891
