### PR TITLE
#902 + #895: a proximity clause the toolchain can grade, and a boundary review that measures

### DIFF
--- a/.claude/skills/plan-pcb-placement-and-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-placement-and-routing/SKILL.md
@@ -236,8 +236,8 @@ reviewer has to decide -- and an unanswered criterion blocks the close.
 1. **Pair and bus length.** For every diff pair and every bus of two parts,
    `span_mm` from `board_context.py --json` (`pin_order.rows[].span_mm`) is the
    straight-line pad distance the connection is forced to run. Compare it with
-   the shortest the two bodies allow side by side -- their `body_mm` are on the
-   same sheet. A ratio much above 1.5 is a finding you must explain or move.
+   the shortest the two bodies allow side by side -- `parts[].body_mm` is on
+   the same sheet. A ratio much above 1.5 is a finding you must explain or move.
 2. **Pin-order agreement.** `pin_order.rows[].verdict`. A `CROSSED` pair costs
    back-side copper or a via per net on two layers, and rotation cannot fix it:
    parity flips only under a mirror. Say WHICH nets.
@@ -257,8 +257,9 @@ reviewer has to decide -- and an unanswered criterion blocks the close.
    sheet also names which rung each body came from, and a seam measured between
    two silk markings is a much weaker claim than one between two drawn outlines.
 6. **Density and balance.** `check_pockets.py --bin 5 --json <PATH>`: the
-   emptiest region (`cold_regions[0].area_mm2`) against the densest
-   (`hot[].ratio`), and the centroid offset (`arrangement.sides[*].offset_mm`).
+   emptiest region (`cold_regions[0].area_mm2`) against the densest window
+   (`windows[0].ratio` -- `windows` is already sorted by descending ratio),
+   and the centroid offset (`arrangement.sides[<layer>].offset_mm`).
    That centroid is weighted by COURTYARD AREA, not pad area, and the tool says
    so -- quote it as what it is.
 7. **The human question, written out.** "Would a competent engineer accept this

--- a/.claude/skills/plan-pcb-placement-and-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-placement-and-routing/SKILL.md
@@ -216,6 +216,66 @@ first and the raw logs only when a section names one. `tests/stress/RUNBOOK.md`
 has the mechanics; `tests/stress/run_watch.py` is the part that costs nothing to
 leave running and should be started at the beginning.
 
+### The seven criteria, MEASURED and written down
+
+Looking is not enough on its own, and that is measured too: run 25's boundary
+review followed the mandate above to the letter -- sheet built with stdout
+suppressed, viewed, observations written first, then reconciled -- and passed a
+layout a human rejects at a glance. A bridge IC 9mm from its USB socket with the
+pair needing a hop, a header squeezing two resistors into a 0.18mm seam, three
+nets forced onto the back. Both reviewers looked for what the list above names,
+because that is what the text told them to look for. The run-23 lesson repeated
+one level up: numbers gate legality, nothing gates LOOKING, and now the LOOK has
+a list and nothing gates JUDGING.
+
+So the observations are not free-form. Answer all seven, in writing, each with
+its number and the instrument that produced it. A threshold here is a JUDGEMENT
+and not a tool's verdict -- the tools report measurements precisely so the
+reviewer has to decide -- and an unanswered criterion blocks the close.
+
+1. **Pair and bus length.** For every diff pair and every bus of two parts,
+   `span_mm` from `board_context.py --json` (`pin_order.rows[].span_mm`) is the
+   straight-line pad distance the connection is forced to run. Compare it with
+   the shortest the two bodies allow side by side -- their `body_mm` are on the
+   same sheet. A ratio much above 1.5 is a finding you must explain or move.
+2. **Pin-order agreement.** `pin_order.rows[].verdict`. A `CROSSED` pair costs
+   back-side copper or a via per net on two layers, and rotation cannot fix it:
+   parity flips only under a mirror. Say WHICH nets.
+3. **Cluster distance.** Every decap and series part within N mm of the pin it
+   serves -- `check_floorplan`'s `decap_pin_distance` where the intent declares
+   a limit. For the parts its tether election cannot reach (a regulator with
+   fewer than four pads is never a tether target), declare `proximity` clauses
+   and read the `proximity` findings. The regulator's input cap belongs on its
+   input side and its output cap on its output side; nothing measures that, so
+   say it in words.
+4. **Facing.** Each IC's pad row that carries a connector's nets should face
+   that connector, and a crystal's pads should face the pins they load. Read
+   `parts[].pads_by_face` and `parts[].partners` from the same sheet.
+5. **Seams.** The tightest body-to-body seam on the board, in mm:
+   `checklist.b_body_seam` from `render_placement --review-sheet ... --json-out`.
+   Below 0.3mm is a finding -- ask whether a hand could place or rework it. The
+   sheet also names which rung each body came from, and a seam measured between
+   two silk markings is a much weaker claim than one between two drawn outlines.
+6. **Density and balance.** `check_pockets.py --bin 5 --json <PATH>`: the
+   emptiest region (`cold_regions[0].area_mm2`) against the densest
+   (`hot[].ratio`), and the centroid offset (`arrangement.sides[*].offset_mm`).
+   That centroid is weighted by COURTYARD AREA, not pad area, and the tool says
+   so -- quote it as what it is.
+7. **The human question, written out.** "Would a competent engineer accept this
+   layout without changes? If not, the first thing they would move is ___."
+
+A worked example, with the numbers a real board produced, is in
+[references/boundary-criteria.md](references/boundary-criteria.md).
+
+### The sheet comes before any VERDICT, not merely before any key
+
+The mandate above says "before reading any checklist key". Its intent is
+stronger: before any verdict at all. At one close-out the three checker
+verdicts -- assembly, connectivity, DRC -- were read 16 seconds before the
+review sheet existed, which satisfies the letter and defeats the purpose. Build
+the sheet and answer the seven criteria FIRST, then run the checkers, then
+reconcile. Anything else is a reviewer with a closed question.
+
 ## What a run DELIVERS
 
 Seven artifacts, every time, in the work dir, **AND IN THIS ORDER**. A run that

--- a/.claude/skills/plan-pcb-placement-and-routing/references/boundary-criteria.md
+++ b/.claude/skills/plan-pcb-placement-and-routing/references/boundary-criteria.md
@@ -27,10 +27,15 @@ board_context.py <board> --json   ->   pin_order.rows[].span_mm
 | header ↔ regulator | interface (3 nets) | 13.77 mm |
 | bulk cap ↔ regulator | interface (2 nets) | 2.56 mm |
 
-The two parts are 7.2 × 5.3 mm and 9 × 7 mm. Placed edge to edge their pads
-could face each other across roughly 2–3 mm, so the pair is running about **3×
-the shortest length these bodies allow** — well past the ratio worth explaining.
-On a 2-layer board that length is also where the return path has to come from.
+Read the denominator off the same document: `parts[].body_mm` gives the
+receptacle **7.12 × 7.40 mm** (`fab`) and the bridge **8.51 × 7.62 mm** (`silk`).
+Two bodies of that size sitting against each other put their facing pad rows a
+few millimetres apart, so a 12.70 mm interface span means there is roughly a
+part's width of board between them — which is what the numbers say plainly: the
+two are not adjacent. **The denominator stays the reviewer's judgement**; the
+criterion asks you to state it beside the span, not to read a verdict off a
+tool. On a 2-layer board that length is also where the return path has to come
+from.
 
 **Verdict: explain or move.** The two parts are on opposite sides of the board
 with a header between them.
@@ -62,9 +67,10 @@ wrong partners. Nothing in the toolchain measured the thing the spec actually
 said.
 
 That is what `proximity` clauses are for. Declared, the same board reports the
-crystal's far leg at **3.14 mm** from the pin it loads against a 2.00 mm limit,
-and the bulk caps at 1.12 mm and 0.29 mm from the regulator — measured pad edge
-to pad edge, against the parts the spec names.
+crystal's far leg at **2.69 mm** from the pin it loads against a 2.00 mm limit
+— its near leg is 1.62 mm and passes — and the bulk caps at 1.12 mm and 0.29 mm
+from the regulator, measured pad edge to pad edge against the parts the spec
+names.
 
 The input-cap-on-the-input-side half is **not measured by anything**. Say it in
 words or it is not said.

--- a/.claude/skills/plan-pcb-placement-and-routing/references/boundary-criteria.md
+++ b/.claude/skills/plan-pcb-placement-and-routing/references/boundary-criteria.md
@@ -67,10 +67,17 @@ wrong partners. Nothing in the toolchain measured the thing the spec actually
 said.
 
 That is what `proximity` clauses are for. Declared, the same board reports the
-crystal's far leg at **2.69 mm** from the pin it loads against a 2.00 mm limit
-— its near leg is 1.62 mm and passes — and the bulk caps at 1.12 mm and 0.29 mm
-from the regulator, measured pad edge to pad edge against the parts the spec
-names.
+crystal's far leg at **2.69 mm** from the pin it loads, past its 2.00 mm limit —
+measured pad edge to pad edge, against the part the spec names.
+
+**A passing clause is silent, and that is a limit of the criterion.** The rule
+yields nothing when a gap is inside its limit, so the crystal's near leg
+(1.62 mm) and the two bulk caps (1.12 mm and 0.29 mm) produce no output at this
+board's declared limits. They are real measurements — the gate that pins this
+page re-derives each one by tightening the declared `max_mm`, which is how they
+are quoted here — but a reviewer who only reads the findings sees the one
+failure and no evidence that the other three were measured at all. Answer the
+criterion from the clause list, not from the finding list.
 
 The input-cap-on-the-input-side half is **not measured by anything**. Say it in
 words or it is not said.

--- a/.claude/skills/plan-pcb-placement-and-routing/references/boundary-criteria.md
+++ b/.claude/skills/plan-pcb-placement-and-routing/references/boundary-criteria.md
@@ -1,0 +1,138 @@
+# The seven boundary criteria, worked on a real board
+
+The subject is a **2-layer, 21-part USB debug adapter**: a micro-USB receptacle,
+a USB-to-UART bridge in an SSOP-20, a 3-pad SOT-89 regulator, a crystal with two
+load caps, an auto-reset transistor pair, two headers and a handful of 0402s.
+It is a tracked fixture in this repository, and the numbers below come from the
+instruments named beside them — every one is re-derived by a test, so a figure
+that stops being true fails the suite rather than ageing quietly in prose.
+
+The board it is taken from PASSED every gate the toolchain had. That is the
+point of the example: the criteria exist because a review can follow the
+blind-first mandate exactly and still hand on a layout a competent engineer
+would send back.
+
+---
+
+## 1. Pair and bus length — **A FINDING**
+
+```
+board_context.py <board> --json   ->   pin_order.rows[].span_mm
+```
+
+| pair | scope | span |
+|---|---|---|
+| bridge ↔ receptacle | the differential pair alone | **8.10 mm** |
+| bridge ↔ receptacle | the whole interface (3 nets) | **12.70 mm** |
+| header ↔ regulator | interface (3 nets) | 13.77 mm |
+| bulk cap ↔ regulator | interface (2 nets) | 2.56 mm |
+
+The two parts are 7.2 × 5.3 mm and 9 × 7 mm. Placed edge to edge their pads
+could face each other across roughly 2–3 mm, so the pair is running about **3×
+the shortest length these bodies allow** — well past the ratio worth explaining.
+On a 2-layer board that length is also where the return path has to come from.
+
+**Verdict: explain or move.** The two parts are on opposite sides of the board
+with a header between them.
+
+## 2. Pin-order agreement — **A FINDING**
+
+```
+board_context.py <board> --json   ->   pin_order.rows[].verdict
+```
+
+The differential pair reads **CROSSED**, one inversion: the receptacle's D- pad
+is north of its D+, and the bridge's D+ is north of its D-. Parity is invariant
+under rotation — only a mirror or a hop flips it — so **no pose of either part
+fixes this**. It costs a via per net or back-side copper.
+
+The whole interface reads CROSSED with three inversions, and that is why the
+pair-scoped row exists: asked as one question, the interface answer would have
+blended the pair's parity into a bus statistic and hidden the fact that decided
+this board's only open clause. It was found after routing.
+
+**Say which nets.** Here: the two pair nets, and nothing else.
+
+## 3. Cluster distance — **A FINDING, and the one no rule could reach**
+
+The regulator has **three pads**. The decap tether election requires four, so it
+can never be a tether target at any radius, and its own bulk caps were graded
+against a USB socket and the bridge IC instead — 2.03 mm and 1.83 mm to the
+wrong partners. Nothing in the toolchain measured the thing the spec actually
+said.
+
+That is what `proximity` clauses are for. Declared, the same board reports the
+crystal's far leg at **3.14 mm** from the pin it loads against a 2.00 mm limit,
+and the bulk caps at 1.12 mm and 0.29 mm from the regulator — measured pad edge
+to pad edge, against the parts the spec names.
+
+The input-cap-on-the-input-side half is **not measured by anything**. Say it in
+words or it is not said.
+
+## 4. Facing — reads clean
+
+```
+board_context.py <board> --json   ->   parts[].pads_by_face, parts[].partners
+```
+
+The bridge's west row carries the receptacle's nets and faces it; the crystal's
+pads face the pins they load. Nothing to report — which is what a criterion that
+passes looks like, and it still gets written down.
+
+## 5. Seams — **A FINDING**
+
+```
+render_placement.py <board> --review-sheet <PATH> --json-out <PATH>.json --quiet
+                                  ->   checklist.b_body_seam
+```
+
+**-0.133 mm, bridge ↔ crystal**, sourced `silk` / `fab`. Negative is an overlap:
+the SSOP body end intrudes into the crystal can. It is below any hand-assembly
+threshold because it is not a gap at all.
+
+Two things this number teaches. It was found on this board only by an
+adversarial reviewer who wrote their own geometry — no instrument in the chain
+produced a seam until one was built, because the overlap report gave a depth
+only for pairs that ALREADY overlap, so a board one micron from collision
+reported nothing. And the sources matter: a seam between two silk markings is a
+much weaker claim than one between two drawn outlines. Quote the rung.
+
+## 6. Density and balance — reads clean, with a caveat
+
+```
+check_pockets.py <board> --bin 5 --json <PATH>
+```
+
+- emptiest contiguous region **24.0 mm²**, 8.7 % of the board in cold windows
+- centroid offset **3.0 %** of span (the part-count control reads 6.9 %)
+
+A 3 % centroid offset on a board this size is not a finding. **The weight is
+COURTYARD AREA, not pad area** — the tool says so in its own output, and on one
+tracked board the two readings differ by 5× — so quote it as the courtyard-area
+centroid, not as "the centroid".
+
+## 7. The human question
+
+> Would a competent engineer accept this layout without changes? If not, the
+> first thing they would move is ___.
+
+For this board: **no**. The first thing to move is the bridge IC, to put its
+pair pads facing the receptacle — which addresses criteria 1 and 2 together and
+is the only change that can fix the crossing without a via.
+
+---
+
+## What the example is for
+
+Three of the seven fire on a board that passed every automated gate, and the
+three that fire are the three a human notices in the first five seconds. That
+gap is the reason the criteria are written down rather than left to judgement:
+the judgement was there, and it had nothing to measure.
+
+Two of the numbers here are also a warning about prose. The seam was recorded
+in a run journal as 0.183 mm and the pair as 9.3 mm; re-measured with the
+shipped instruments they are -0.133 mm and 8.10 mm. Neither journal figure was
+wrong when it was written — they were measured differently, by hand, on a
+different lap — but neither could be reproduced from what was written down.
+Every number above names the instrument and is pinned by a test for exactly
+that reason.

--- a/.claude/skills/plan-pcb-placement-and-routing/references/boundary-criteria.md
+++ b/.claude/skills/plan-pcb-placement-and-routing/references/boundary-criteria.md
@@ -124,10 +124,11 @@ is the only change that can fix the crossing without a via.
 
 ## What the example is for
 
-Three of the seven fire on a board that passed every automated gate, and the
-three that fire are the three a human notices in the first five seconds. That
-gap is the reason the criteria are written down rather than left to judgement:
-the judgement was there, and it had nothing to measure.
+FOUR of the seven fire on a board that passed every automated gate -- pair
+length, pin order, cluster distance and the seam -- and they are the ones a
+human notices in the first five seconds. That gap is the reason the criteria
+are written down rather than left to judgement: the judgement was there, and it
+had nothing to measure.
 
 Two of the numbers here are also a warning about prose. The seam was recorded
 in a run journal as 0.183 mm and the pair as 9.3 mm; re-measured with the

--- a/.claude/skills/plan-pcb-placement-and-routing/references/verifier-prompts.md
+++ b/.claude/skills/plan-pcb-placement-and-routing/references/verifier-prompts.md
@@ -69,9 +69,15 @@ a clean-looking report.
 
 **1. `intent`** — given `intent.json`, `intent_result.json`, the front panel.
 > Does this board honour the declared floorplan? Report every `violations[]`
-> entry with its `measured` vs `expected`. Check `rules_run` and
-> `rules_skipped`: if `rules_run` is 0 this is a vacuous pass and you must FAIL
-> it. You may not conclude anything about DRC or connectivity.
+> entry with its `measured` vs `expected`. Then check CLAUSE COVERAGE, which
+> is a different question from the rule count: read `brief_coverage` and FAIL
+> if any clause the design brief declared is `uncovered` or `abstained`, or if
+> one is `drifted` -- graded, but not against what the brief says. `rules_run`
+> counts RULES: one run graded six of them, passed, and measured not one
+> clause its brief declared. `rules_run: 0` is still a vacuous pass and still a
+> FAIL, as the floor beneath that. A clause the author wrote `"unknown"`, and
+> one this toolchain carries by design, are NOT findings. You may not conclude
+> anything about DRC or connectivity.
 
 **2. `legality`** — given `view.log`'s JSON, both side panels.
 > Did legality regress? Compare `overlap_area` and `oob_count`/`oob_amount`
@@ -198,8 +204,9 @@ Two failure modes to refuse by name:
   warnings" describes a board that did not pass. Either fix it, or report it as
   not done.
 - **Do not accept a lens that passed vacuously.** A lens whose inputs were empty
-  has not verified anything; that is why lens 1 must FAIL on `rules_run == 0` and
-  lens 9 must report `ungraded` as a finding.
+  has not verified anything; that is why lens 1 must FAIL on any declared brief
+  clause reported `uncovered` or `abstained` (and on `rules_run == 0` beneath
+  that), and lens 9 must report `ungraded` as a finding.
 
 **Stop condition 4 is the exception, and it is the only one.** A requirement that
 is geometrically unsatisfiable does not get more iterations — it gets a

--- a/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
+++ b/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
@@ -2162,7 +2162,18 @@ tell a finished run from a stalled one.
 
 {why}
 
-Confirm with the instruments, and put the numbers in the report beside the
+FIRST, LOOK -- before any verdict, not merely before any checklist key. Build
+the review sheet and answer the seven boundary criteria (the combined SKILL's
+"Eyes at the boundaries"), then run the checkers below, then reconcile. This
+order is the whole mechanism: a reviewer who has already read three checker
+verdicts has a closed question, and at one close-out those three were read 16
+seconds before the sheet existed -- satisfying the letter of the old rule and
+defeating its purpose. That is why this block comes first in this text.
+
+  python3 -X utf8 py_tools/render_placement.py {a.board} \
+      --review-sheet wk/close_sheet.png --json-out wk/close_sheet.json --quiet
+
+THEN confirm with the instruments, and put the numbers in the report beside the
 names of the instruments that produced them:
 
   python3 -X utf8 check_complete.py {a.board} --clearance <floor> \\

--- a/.claude/skills/plan-pcb-placement/SKILL.md
+++ b/.claude/skills/plan-pcb-placement/SKILL.md
@@ -1287,11 +1287,24 @@ you mean to grade at a different floor than the board's own.
 Worth declaring, in rough order of value: `must_lock` for the parts the lock
 advisor flagged; `edge_connectors` for anything that is *meant* to overhang
 (this is what stops `oob_count` reporting a card edge as a defect forever);
-`keepouts` for mounting holes and antenna clearances; `decaps.max_distance_mm`;
+`keepouts` for mounting holes and antenna clearances; **`proximity` for the
+pairs whose separation is a requirement rather than an outcome -- a crystal to
+its load pins, bulk caps to the regulator they feed -- because that is the one
+constraint the netlist implies and nothing here measures until it is declared
+(a 3mm crystal loop and a 30mm one have identical connectivity, and the decap
+rules cannot stand in: they elect their own partner and need four copper pads,
+so a 3-pad regulator is never one);** `decaps.max_distance_mm`;
 and `blocks` with a `zone` **only where the parts really are one contiguous
 area**. Schematic sheets usually are not: on one 4-layer corpus board all ten sheet
 bounding boxes overlap each other, so `--emit-intent` claims a zone for only 4 of 10 and
 says why for the rest.
+
+Declaring is half of it. A clause reaches a rule only if the **graded**
+document carries it, so after editing the brief, re-emit and read
+`brief_coverage` in the `--json` result: `rules_run` counts *rules*, not
+*clauses*, and one run closed clean with six rules run and every declared
+clause ungraded. `--require-brief-coverage` turns that into a non-zero exit
+instead of a paragraph nobody reads.
 
 A misspelled key is **refused**, at every level of the file and including
 `severity` keys — you will be told the key that was wrong and the ones that

--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -956,6 +956,27 @@ def _guard_render(a):
             f'--expect-moved {d.get("expected")}.\n\nOne of the two is wrong, '
             f'and "more parts moved than the step claimed" is exactly what '
             f'mandate 8(d) exists to catch. Resolve it before continuing.')
+    # #895's fifth check. `render_placement` records the sheet it composed in
+    # `review_sheet`, so "was a review sheet built at all" becomes a gate
+    # rather than a paragraph -- and the seven boundary criteria are answered
+    # FROM that sheet. It still cannot check that anybody LOOKED; what it can
+    # check is that the thing to look at exists, which is where the previous
+    # mandate stopped. A `None` means the run asked for a sheet and the tool
+    # could not write one; an absent key means it was never asked for.
+    _sheet = doc.get('review_sheet') if 'review_sheet' in doc else ''
+    if _sheet is None or (_sheet == '' and 'review_sheet' in doc):
+        return False, (
+            'That render was asked for a review sheet and none was written, '
+            'so there is nothing to answer the seven boundary criteria from.'
+            '\n\nRe-render with --review-sheet <PATH> --json-out <PATH>.json '
+            '--quiet -- the last two flags are what keep the read BLIND, and '
+            'the sheet is what the criteria are measured off.')
+    if _sheet and not os.path.isfile(_sheet):
+        return False, (
+            f'That render names a review sheet that is not there:\n'
+            f'      {_sheet}\n\n'
+            f'A document that names a sheet nobody can open is the same '
+            f'evidence as no sheet at all.')
     return True, ''
 
 
@@ -1892,6 +1913,35 @@ def _self_test():
             want(out.startswith('<error>') and 'UNRECOGNISED' in out,
                  f'an unrecognised clause state ({_st!r}) refuses and is '
                  f'named, rather than passing as if it were graded')
+
+        # #895's fifth render check. It is BACKWARD-COMPATIBLE by design -- a
+        # document with no `review_sheet` key was produced by a run that never
+        # asked for one -- so it can only be seen by feeding the two shapes
+        # that mean something, or it is an arm nothing exercises.
+        _sheet_file = _wr('sheet_exists.json', {'x': 1})
+        for _val, _want in ((None, 'none was written'),
+                            (os.path.join(tmp3, 'no_such_sheet.png'),
+                             'not there')):
+            _rj = dict(_r15)
+            _rj['review_sheet'] = _val
+            out = STAGES['P-close'](_args(
+                ['--board', _pb, '--before', _pa,
+                 '--render-json', _wr('rs1.json', _rj),
+                 '--intent-json', _wr('is1.json', _covered([])),
+                 '--congestion-before', _wr('rs2.json', _dmg),
+                 '--waive', 'congestion:spent']))
+            want(out.startswith('<error>') and _want in out,
+                 f'a render whose review sheet is {_val!r} is refused')
+        _rj = dict(_r15)
+        _rj['review_sheet'] = _sheet_file
+        out = STAGES['P-close'](_args(
+            ['--board', _pb, '--before', _pa,
+             '--render-json', _wr('rs3.json', _rj),
+             '--intent-json', _wr('is3.json', _covered([], brief=None)),
+             '--congestion-before', _wr('rs4.json', _dmg),
+             '--waive', 'congestion:spent']))
+        want(not out.startswith('<error>'),
+             'a render naming a sheet that EXISTS passes the fifth check')
 
         # A malformed block REFUSES; it does not traceback. "Refused, never
         # assumed" is arm 2's contract, and a crash is neither.

--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -615,6 +615,27 @@ def p_close(a):
         # ARM 2 -- NO COVERAGE BLOCK. Refused rather than assumed: "assume
         # covered" is the inert gate again, one key over.
         _cov = _idoc.get('brief_coverage')
+        if _cov is not None and not isinstance(_cov, dict):
+            return err(
+                f'That document\'s `brief_coverage` is '
+                f'{type(_cov).__name__}, not an object, so this gate cannot '
+                f'read it. A malformed block must REFUSE and not crash: a '
+                f'traceback is neither the pass nor the refusal this stage '
+                f'promises, and a non-zero exit is not evidence unless it '
+                f'names its reason.\n' + _regrade)
+        if isinstance(_cov, dict) and _cov.get('schema') not in (None, 1):
+            return err(
+                f'That `brief_coverage` block declares schema '
+                f'{_cov.get("schema")!r} and this gate reads schema 1. A '
+                f'schema this stage has never seen is not something to grade '
+                f'optimistically -- reading a newer block with older rules is '
+                f'the inert gate again, one key over.\n' + _regrade)
+        if isinstance(_cov, dict) and not isinstance(
+                _cov.get('clauses', []), list):
+            return err(
+                f'That `brief_coverage.clauses` is '
+                f'{type(_cov.get("clauses")).__name__}, not a list of '
+                f'clauses.\n' + _regrade)
         if _cov is None:
             return err(
                 f'That intent result carries no `brief_coverage`, so nothing '
@@ -624,8 +645,12 @@ def p_close(a):
                 f'and measured not one clause its brief declared -- the count '
                 f'was satisfied by rules nobody had declared anything for. '
                 f'Re-grade with a build that writes the block:\n' + _regrade
-                + f'\n\nIf this board has no design brief at all, say so on the '
-                  f'record instead: --waive brief:<why nobody can declare one>.')
+                + f'\n\nA board with no design brief at all still closes -- the '
+                  f'block is written EMPTY for it, and this stage prints the '
+                  f'absence. What it cannot do is read a document that '
+                  f'predates the block. If there is no spec to declare at all, '
+                  f'the honest route is the intent waiver: drop --intent-json '
+                  f'and pass --waive intent:<why there is no spec>.')
         # ARM 3 -- CLAUSE COVERAGE. `not_claimed` and `carried` never reach
         # here: an author writing "unknown" is declaring honestly, and
         # punishing that is how a channel teaches people to stop declaring.
@@ -637,6 +662,12 @@ def p_close(a):
         # That is why the block is written even when it is empty: absent and
         # empty would otherwise be the same document.
         _rows = _cov.get('clauses') or []
+        _junk = [r for r in _rows if not isinstance(r, dict)]
+        if _junk:
+            return err(
+                f'A `brief_coverage.clauses` entry is '
+                f'{type(_junk[0]).__name__}, not a clause object.\n'
+                + _regrade)
         _known = {str(r.get('id')) for r in _rows}
         # The id is resolved AGAINST THE DOCUMENT rather than by splitting on
         # colons: a clause id contains them (`proximity[0:Y1~U1].max_mm`) and
@@ -647,10 +678,19 @@ def p_close(a):
             if not _w.startswith('brief-clause:'):
                 continue
             _rest = _w[len('brief-clause:'):]
+            # LONGEST first, and the `+ ':'` matters: without it
+            # `keepouts[batt]xyz:reason` would silently waive `keepouts[batt]`,
+            # and without longest-first a waiver for `interfaces[J1].edge_band`
+            # could resolve to `interfaces[J1].edge` and leave the real clause
+            # open while reporting it waived.
             _hit = next((i for i in sorted(_known, key=len, reverse=True)
                          if _rest == i or _rest.startswith(i + ':')), None)
             if _hit is None:
-                _phantom.append(_rest.split(':', 1)[0])
+                # The WHOLE residue, not `split(':', 1)[0]` -- that is the
+                # very bug this resolution fixed, surviving one line over in
+                # the message: a waiver for `proximity[0:Y1~U2].max_mm` was
+                # reported as naming `proximity[0`.
+                _phantom.append(_rest)
             elif not _rest[len(_hit) + 1:].strip():
                 _noreason.append(_hit)
             else:
@@ -667,10 +707,17 @@ def p_close(a):
                 f'document does not carry. A waiver that matches nothing is a '
                 f'gate that looks satisfied and is not. The clause ids here '
                 f'are:\n' + '\n'.join(f'  {i}' for i in sorted(_known)))
+        # A WHITELIST of the states that may pass, not a blacklist of the two
+        # that may not. The producer's good set is closed and tiny, and a
+        # blacklist fails OPEN on a sixth state: measured, a row spelled
+        # `ungraded` or `UNCOVERED` or carrying no `state` at all sailed
+        # through while the clause was genuinely unmeasured. Note the
+        # asymmetry that made this easy to miss -- the producer raises on a
+        # novel state (`counts[state] += 1`) while the consumer stayed silent.
+        _PASSES = ('graded', 'not_claimed', 'carried')
         _open = [r for r in _rows
                  if str(r.get('id')) not in _waived
-                 and (r.get('state') in ('uncovered', 'abstained')
-                      or r.get('drifted'))]
+                 and (r.get('state') not in _PASSES or r.get('drifted'))]
         if _open:
             def _bucket(name, pred):
                 got = [r for r in _open if pred(r)]
@@ -691,6 +738,15 @@ def p_close(a):
                           'declares',
                           lambda r: (r.get('drifted')
                                      and r.get('state') == 'graded'))
+                # The catch-all, so a row can never land in `_open` and in no
+                # bucket: that produced a refusal with a BLANK list, which is
+                # unactionable and reads like a bug in the gate rather than a
+                # finding about the board.
+                + _bucket('UNRECOGNISED -- this gate does not know this state',
+                          lambda r: (r.get('state') not in
+                                     ('uncovered', 'abstained')
+                                     and not (r.get('drifted')
+                                              and r.get('state') == 'graded')))
                 + f'\n\n`rules_run` counts RULES, not CLAUSES, and a count of '
                   f'six is what let one run close clean with a whole list like '
                   f'this ungraded. Fold the brief into the document that is '
@@ -708,6 +764,16 @@ def p_close(a):
             f"clause(s) graded"
             + (f", {len(_waived)} waived by name" if _waived else '')
             + '.') if _rows else (
+            # Read off `brief`, which `clause_coverage` fills with the brief's
+            # own basename precisely so a consumer can tell these apart.
+            # Inferring absence from an EMPTY CLAUSE LIST made this stage
+            # report "no design brief beside this board" for a board whose
+            # brief was named in the very same block -- it declared only
+            # free-text unknowns, so it compiled to no clause.
+            f"the design brief {_cov.get('brief')} declares no gradable "
+            f"clause -- everything in it is carried, declared unknown, or "
+            f"free text, so there was nothing for a rule to reach."
+            if _cov.get('brief') else
             'no design brief beside this board, so 0 clauses were declared '
             'and none could be graded. Every `edge` in that intent is an '
             'INFERENCE from a part pose, not a declaration.')
@@ -1663,9 +1729,12 @@ def _self_test():
              and 'require-brief-coverage' in out,
              'P-close refuses a graded intent that carries no coverage block')
 
-        def _covered(rows, graded=0):
+        def _covered(rows, graded=0, brief='b.json'):
+            # `brief` is what the block says was FOUND, and it is a separate
+            # fact from whether any clause compiled: a brief declaring only
+            # free-text unknowns names itself here and carries no clause.
             return {'rules_run': _six,
-                    'brief_coverage': {'brief': 'b.json', 'clauses': rows,
+                    'brief_coverage': {'brief': brief, 'clauses': rows,
                                        'graded': graded}}
 
         _open_rows = [
@@ -1677,7 +1746,7 @@ def _self_test():
              'drifted': False, 'why': 'this board has no usable bounds'},
         ]
 
-        def _close_cov(rows, extra=(), graded=0):
+        def _close_cov(rows, extra=(), graded=0, brief='b.json'):
             # The `_r15` / `_dmg` pair is run 15's shape, which this stage
             # REPORTS and refuses until somebody dispositions it -- so every
             # case that expects the stage to PROCEED carries that disposition
@@ -1685,7 +1754,8 @@ def _self_test():
             return STAGES['P-close'](_args(
                 ['--board', _pb, '--before', _pa,
                  '--render-json', _wr('rc.json', _r15),
-                 '--intent-json', _wr('ic.json', _covered(rows, graded)),
+                 '--intent-json', _wr('ic.json',
+                                      _covered(rows, graded, brief)),
                  '--congestion-before', _wr('rd.json', _dmg),
                  '--waive', 'congestion:every lever spent'] + list(extra)))
 
@@ -1730,9 +1800,113 @@ def _self_test():
 
         # A brief-less board closes, and SAYS SO: #711 made declaring nothing
         # cost nothing, and this must not reverse that.
-        out = _close_cov([])
+        out = _close_cov([], brief=None)
         want(not out.startswith('<error>') and 'no design brief' in out,
              'a board with no brief closes with the absence on the record')
+        # ...and a brief that WAS found but declares no gradable clause must
+        # not be reported as absent. Inferring absence from an empty clause
+        # list said "no design brief beside this board" about a board whose
+        # brief was named in the same block.
+        out = _close_cov([], brief='minimal.design-brief.json')
+        want(not out.startswith('<error>')
+             and 'minimal.design-brief.json' in out
+             and 'no design brief beside' not in out,
+             'a brief that declares no gradable clause is named, not called '
+             'absent')
+
+        # The four mutants that SURVIVED the first battery. Each names the
+        # code it pins, because a case whose subject is not obvious is a case
+        # somebody later deletes as redundant.
+
+        # `True` is an `int` in Python, so without the explicit bool check a
+        # `rules_run: true` reads as a count of ONE and passes every arm.
+        for _b in (True, False):
+            out = STAGES['P-close'](_args(
+                ['--board', _pb, '--before', _pa,
+                 '--render-json', _wr('rb1.json', _r15),
+                 '--intent-json', _wr('ib1.json', {'rules_run': _b}),
+                 '--congestion-before', _wr('rb2b.json', _dmg)]))
+            want(out.startswith('<error>') and 'cannot read' in out,
+                 f'P-close refuses rules_run: {_b} -- a bool is an int in '
+                 f'Python and would read as a count')
+
+        # LONGEST-MATCH resolution. The pair has to be COLON-AMBIGUOUS or the
+        # two orders agree: with `keepouts[a]` and `keepouts[a]:b`, a waiver
+        # for the longer one begins with the shorter one PLUS a colon, so
+        # shortest-first waives the WRONG clause and reads `b:...` as the
+        # reason. A first draft used `edge` / `edge_band`, where no colon
+        # separates them, both orders resolved correctly, and the mutation
+        # survived -- a case that cannot tell the two apart is not a case.
+        _pair = [
+            {'id': 'keepouts[a]', 'state': 'uncovered', 'drifted': False,
+             'why': 'the short one'},
+            {'id': 'keepouts[a]:b', 'state': 'uncovered', 'drifted': False,
+             'why': 'the long one'},
+        ]
+        out = _close_cov(_pair, extra=[
+            '--waive', 'brief-clause:keepouts[a]:b:cannot answer'])
+        want(out.startswith('<error>') and 'the short one' in out
+             and 'the long one' not in out,
+             'a waiver resolves to the LONGEST matching id, leaving the '
+             'shorter clause open')
+
+        # A typo'd SUFFIX must not silently waive the real clause: the `+ ':'`
+        # is what stops `keepouts[batt]xyz:reason` matching `keepouts[batt]`.
+        out = _close_cov(
+            [{'id': 'keepouts[batt]', 'state': 'uncovered', 'drifted': False,
+              'why': 'x'}],
+            extra=['--waive', 'brief-clause:keepouts[batt]xyz:typo'])
+        want(out.startswith('<error>') and 'does not carry' in out
+             and 'keepouts[batt]xyz' in out,
+             'an id with a typo\'d suffix does not waive the real clause')
+
+        # ...and the refusal names the WHOLE id the caller typed. This one
+        # CONTAINS a colon, which is what makes it discriminate: the old
+        # `split(':', 1)[0]` reported `proximity[0` and sent a reader looking
+        # for a clause by that name. A phantom id with no colon in it cannot
+        # tell the two spellings apart.
+        out = _close_cov(
+            [{'id': 'keepouts[batt]', 'state': 'uncovered', 'drifted': False,
+              'why': 'x'}],
+            extra=['--waive', 'brief-clause:proximity[0:Y1~U2].max_mm:typo'])
+        want(out.startswith('<error>')
+             and 'proximity[0:Y1~U2].max_mm' in out,
+             'the phantom-id refusal names the whole id, not the fragment '
+             'before its first colon')
+
+        # THE DRIFTED ARM. Every other fixture here carries `drifted: False`,
+        # so deleting the drift test left the self-test green while the
+        # verifier prompt requires it.
+        out = _close_cov([{'id': 'interfaces[USB1].edge', 'state': 'graded',
+                           'drifted': True, 'why': ''}], graded=1)
+        want(out.startswith('<error>') and 'DRIFTED' in out
+             and 'interfaces[USB1].edge' in out,
+             'a GRADED clause that drifted still refuses -- measured, against '
+             'the wrong requirement')
+
+        # A state this gate has never seen must FAIL CLOSED. The producer
+        # raises on a novel state; the consumer used to pass silently.
+        for _st in ('ungraded', 'UNCOVERED', None):
+            out = _close_cov([{'id': 'keepouts[k]', 'state': _st,
+                               'drifted': False, 'why': 'novel'}])
+            want(out.startswith('<error>') and 'UNRECOGNISED' in out,
+                 f'an unrecognised clause state ({_st!r}) refuses and is '
+                 f'named, rather than passing as if it were graded')
+
+        # A malformed block REFUSES; it does not traceback. "Refused, never
+        # assumed" is arm 2's contract, and a crash is neither.
+        for _shape in ([], 'x', 0, {'clauses': 'x'}, {'clauses': ['x']},
+                       {'schema': 2, 'clauses': []}):
+            out = STAGES['P-close'](_args(
+                ['--board', _pb, '--before', _pa,
+                 '--render-json', _wr('rm1.json', _r15),
+                 '--intent-json', _wr('im1.json',
+                                      {'rules_run': _six,
+                                       'brief_coverage': _shape}),
+                 '--congestion-before', _wr('rm2.json', _dmg)]))
+            want(out.startswith('<error>'),
+                 f'a malformed brief_coverage ({_shape!r}) is refused, not a '
+                 f'traceback')
 
     # Banned shapes: hedging, and a subagent prompt the model might obey itself.
     # The evidence must be REAL files: this used to pass bare names ('b', 'a',

--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -102,6 +102,14 @@ is not a bug in the emitter; it is the only thing it can do with no spec.
      c. Are there zones nothing may enter? (`keepouts` -- an enclosure rib, a
         battery, an antenna clearance. These are GRADED and the seat search
         honours them, and nothing but a human can state one.)
+     d. Which parts must sit within N mm of WHICH, and why? (`proximity` --
+        a crystal to its load pins, bulk caps to the regulator they feed, a
+        transistor pair that must stay matched. Name the pair, the limit in
+        mm, and the requirement it came from.) This is the one constraint
+        the NETLIST implies and no instrument here can read: a 3mm crystal
+        loop and a 30mm one have identical connectivity. The decap rules
+        cannot stand in for it -- they elect their own partner and need >= 4
+        copper pads, so a 3-pad regulator can never be one at any radius.
 
    Write the answers to `<board>.design-brief.json`. See docs/design-brief.md;
    the minimum is three fields and one row per connector, and "unknown" is a
@@ -567,23 +575,142 @@ def p_close(a):
     # vacuously -- by a path to nothing. Open it, and require that rules
     # actually ran, which is what the error text above already tells the reader
     # to produce (`--require-rules 1`).
+    _cov_read = ('no floorplan intent on the record -- waived, and the gap is\n   stated rather than hidden.')
     if a.intent_json:
         _idoc, _ierr = _load(a.intent_json, 'The floorplan intent (--intent-json)')
         if _ierr:
             return err(_ierr + '\n\nThis gate opens the file now; it used to '
                                'accept the ARGUMENT and never the document, so '
                                'a path to nothing satisfied it.')
+        _regrade = (f'  python3 -X utf8 py_tools/check_floorplan.py '
+                    f'{a.board} --intent <the intent> --require-rules 1 '
+                    f'--require-brief-coverage --json wk/intent_result.json')
+        # ARM 0 -- THE SHAPE. `check_floorplan --json` writes `rules_run` as a
+        # LIST of rule names; the JSON_SUMMARY line writes it as a COUNT. Both
+        # are accepted. Anything else, ABSENT INCLUDED, is refused -- because
+        # this gate tested `isinstance(int)` against the very document its own
+        # help text names, which writes a list, so IT NEVER FIRED. Six rules
+        # ran, the pass was clean, and every declared clause was ungraded.
         _ran = _idoc.get('rules_run')
-        if isinstance(_ran, int) and _ran <= 0:
+        if isinstance(_ran, bool) or not isinstance(_ran, (int, list, tuple)):
             return err(
-                f'That intent graded {_ran} rules, so it constrained nothing.\n\n'
+                f'That document\'s `rules_run` is {type(_ran).__name__}, which '
+                f'this gate cannot read as "how much was graded".\n\n'
+                f'`check_floorplan --intent I --json PATH` writes it as a LIST '
+                f'of rule names; the JSON_SUMMARY line writes it as a COUNT. '
+                f'Both are accepted here. Anything else -- including ABSENT -- '
+                f'is not a graded intent, and that is not hypothetical: this '
+                f'gate used to test `isinstance(int)` against a document that '
+                f'writes a list, so it never fired once.\n' + _regrade)
+        _n = len(_ran) if isinstance(_ran, (list, tuple)) else _ran
+        # ARM 1 -- NOTHING GRADED. The long-standing refusal, now firing on
+        # `rules_run: []` too, which is the shape production can write.
+        if _n <= 0:
+            return err(
+                f'That intent graded {_n} rules, so it constrained nothing.\n\n'
                 f'One run shipped `rules_run: 0` and a second covered 0 of 266 '
                 f'parts; nothing objected either time, because this gate only '
                 f'checked that a path was PASSED. Edit the intent down to the '
-                f'clauses this board must satisfy, then:\n'
-                f'  python3 -X utf8 py_tools/check_floorplan.py {a.board} '
-                f'--intent {a.intent_json} --require-rules 1 '
-                f'--json wk/intent_result.json')
+                f'clauses this board must satisfy, then:\n' + _regrade)
+        # ARM 2 -- NO COVERAGE BLOCK. Refused rather than assumed: "assume
+        # covered" is the inert gate again, one key over.
+        _cov = _idoc.get('brief_coverage')
+        if _cov is None:
+            return err(
+                f'That intent result carries no `brief_coverage`, so nothing '
+                f'here can say whether the design brief\'s clauses were GRADED '
+                f'or merely present.\n\n'
+                f'`rules_run` counts RULES. One run graded six of them, passed, '
+                f'and measured not one clause its brief declared -- the count '
+                f'was satisfied by rules nobody had declared anything for. '
+                f'Re-grade with a build that writes the block:\n' + _regrade
+                + f'\n\nIf this board has no design brief at all, say so on the '
+                  f'record instead: --waive brief:<why nobody can declare one>.')
+        # ARM 3 -- CLAUSE COVERAGE. `not_claimed` and `carried` never reach
+        # here: an author writing "unknown" is declaring honestly, and
+        # punishing that is how a channel teaches people to stop declaring.
+        #
+        # An EMPTY clause list is a board that declares nothing, and it closes
+        # -- #711 made a brief-less board cost nothing and this must not
+        # reverse that. The absence is printed in the body instead, because a
+        # gate that passes silently is a gate that vanished from the record.
+        # That is why the block is written even when it is empty: absent and
+        # empty would otherwise be the same document.
+        _rows = _cov.get('clauses') or []
+        _known = {str(r.get('id')) for r in _rows}
+        # The id is resolved AGAINST THE DOCUMENT rather than by splitting on
+        # colons: a clause id contains them (`proximity[0:Y1~U1].max_mm`) and
+        # so may a reason, so any positional split cuts one of the two in half.
+        # The document is the authority on what its own ids are.
+        _waived, _phantom, _noreason = set(), [], []
+        for _w in (a.waive or []):
+            if not _w.startswith('brief-clause:'):
+                continue
+            _rest = _w[len('brief-clause:'):]
+            _hit = next((i for i in sorted(_known, key=len, reverse=True)
+                         if _rest == i or _rest.startswith(i + ':')), None)
+            if _hit is None:
+                _phantom.append(_rest.split(':', 1)[0])
+            elif not _rest[len(_hit) + 1:].strip():
+                _noreason.append(_hit)
+            else:
+                _waived.add(_hit)
+        if _noreason:
+            return err(
+                f'--waive brief-clause:{_noreason[0]}: needs a REASON after '
+                f'the colon -- why THIS board cannot answer that clause. The '
+                f'reason IS the finding; without one the waiver records only '
+                f'that somebody wanted the gate to stop.')
+        if _phantom:
+            return err(
+                f'--waive brief-clause names {_phantom[0]!r}, which this '
+                f'document does not carry. A waiver that matches nothing is a '
+                f'gate that looks satisfied and is not. The clause ids here '
+                f'are:\n' + '\n'.join(f'  {i}' for i in sorted(_known)))
+        _open = [r for r in _rows
+                 if str(r.get('id')) not in _waived
+                 and (r.get('state') in ('uncovered', 'abstained')
+                      or r.get('drifted'))]
+        if _open:
+            def _bucket(name, pred):
+                got = [r for r in _open if pred(r)]
+                if not got:
+                    return ''
+                return f'\n  {name}\n' + '\n'.join(
+                    f"    - {r.get('id')}: {r.get('why') or 'no reason given'}"
+                    for r in got)
+            return err(
+                f'That intent graded {_n} rule(s), but {len(_open)} of the '
+                f'design brief\'s {len(_rows)} declared clause(s) reached no '
+                f'verdict:\n'
+                + _bucket('UNCOVERED -- no rule looked at these',
+                          lambda r: r.get('state') == 'uncovered')
+                + _bucket('ABSTAINED -- a rule ran and declined on this clause',
+                          lambda r: r.get('state') == 'abstained')
+                + _bucket('DRIFTED -- graded, but not against what the brief '
+                          'declares',
+                          lambda r: (r.get('drifted')
+                                     and r.get('state') == 'graded'))
+                + f'\n\n`rules_run` counts RULES, not CLAUSES, and a count of '
+                  f'six is what let one run close clean with a whole list like '
+                  f'this ungraded. Fold the brief into the document that is '
+                  f'actually graded, then re-grade:\n'
+                  f'  python3 -X utf8 py_tools/check_floorplan.py {a.board} '
+                  f'--emit-intent wk/intent.json\n'
+                  f'  # edit it down: keep what the SPEC requires, delete what '
+                  f'is merely observed\n' + _regrade
+                + f'\n\nA clause this board genuinely cannot answer is waived '
+                  f'BY NAME, with a reason:\n'
+                  f'  --waive brief-clause:<id>:<why this board cannot answer '
+                  f'it>')
+        _cov_read = (
+            f"{_cov.get('graded', 0)} of {len(_rows)} declared brief "
+            f"clause(s) graded"
+            + (f", {len(_waived)} waived by name" if _waived else '')
+            + '.') if _rows else (
+            'no design brief beside this board, so 0 clauses were declared '
+            'and none could be graded. Every `edge` in that intent is an '
+            'INFERENCE from a part pose, not a declaration.')
     # The routability read. It REFUSES only when the evidence is missing, never
     # on the numbers themselves -- see _guard_congestion and
     # docs/placement-calibration.md for why the threshold that used to live
@@ -593,6 +720,8 @@ def p_close(a):
         return err(_cwhy)
     return f'''<stage_instructions stage="P-close" name="close out" of="7">
 Prove the placement, then hand it on.
+
+  DECLARED SPEC: {_cov_read}
 
 {_cwhy}
 
@@ -609,8 +738,11 @@ lenses to this board. Your inputs are:
     ledger   wk/ledger.jsonl
     intent   {a.intent_json or '(none -- waived on the record; see --waive)'}
 Lens 1 (`intent`) needs that last file and was dispatched without it, so it had
-no inputs and could not fail. It MUST fail on `rules_run == 0`: a grade that ran
-no rules is a vacuous pass, not a clean board.
+no inputs and could not fail. Its test is CLAUSE COVERAGE, not the rule count:
+read `brief_coverage` in that document and FAIL if any declared clause is
+`uncovered` or `abstained`, or if one is `drifted`. `rules_run: 6` with every
+brief clause ungraded is a vacuous pass, and it is the shape that passed here.
+`rules_run == 0` still fails, as the floor beneath that.
 Re-derive every number yourself from the boards; do not trust the report.
 Answer with a line beginning VERDICT= and nothing above it.
 </subagent_prompt>
@@ -1269,7 +1401,9 @@ def _dump_all():
                 before, halo=100.0, crossings=100.0, hpwl=1000.0)),
             '--intent-json', wrote('i.json', {'rules_run': ['envelope'],
                                               'parts_covered': 7,
-                                              'violations': []}),
+                                              'violations': [],
+                                              'brief_coverage': {'brief': None, 'clauses': [], 'graded': 0,
+                   'uncovered': 0, 'abstained': 0, 'complete': True}}),
             '--waive', 'X:checked'])
         refused = []
         for key in sorted(STAGES):
@@ -1365,7 +1499,9 @@ def _self_test():
             json.dump(doc, open(p, 'w', encoding='utf-8'))
             return p
 
-        _int = _wr('i.json', {'rules_run': ['envelope'], 'violations': []})
+        _int = _wr('i.json', {'rules_run': ['envelope'], 'violations': [],
+                              'brief_coverage': {'brief': None, 'clauses': [], 'graded': 0,
+                   'uncovered': 0, 'abstained': 0, 'complete': True}})
 
         def _close(after, before=None, extra=()):
             argv = ['--board', _pb, '--before', _pa,
@@ -1495,6 +1631,109 @@ def _self_test():
         want(out.startswith('<error>') and 'constrained nothing' in out,
              'P-close refuses an intent that graded 0 rules')
 
+        # #902. THE SHAPE PRODUCTION ACTUALLY WRITES. The case above feeds an
+        # INT, which `check_floorplan --json` never produces -- it writes a
+        # LIST -- so the old `isinstance(_ran, int)` gate passed this test and
+        # never fired once in production.
+        out = STAGES['P-close'](_args(
+            ['--board', _pb, '--before', _pa,
+             '--render-json', _wr('ra4.json', _r15),
+             '--intent-json', _wr('i1.json', {'rules_run': []}),
+             '--congestion-before', _wr('rb4.json', _dmg)]))
+        want(out.startswith('<error>') and 'constrained nothing' in out,
+             'P-close refuses rules_run: [] -- the shape the JSON file writes')
+        for _shape in ({'rules_run': 'envelope'}, {}):
+            out = STAGES['P-close'](_args(
+                ['--board', _pb, '--before', _pa,
+                 '--render-json', _wr('ra5.json', _r15),
+                 '--intent-json', _wr('i2.json', _shape),
+                 '--congestion-before', _wr('rb5.json', _dmg)]))
+            want(out.startswith('<error>') and 'cannot read' in out,
+                 f'P-close refuses a rules_run this gate cannot read '
+                 f'({_shape or "absent"})')
+
+        _six = ['envelope', 'zone_containment', 'zone_side', 'assembly_side',
+                'keepout', 'legality']
+        out = STAGES['P-close'](_args(
+            ['--board', _pb, '--before', _pa,
+             '--render-json', _wr('ra6.json', _r15),
+             '--intent-json', _wr('i3.json', {'rules_run': _six}),
+             '--congestion-before', _wr('rb6.json', _dmg)]))
+        want(out.startswith('<error>') and 'brief_coverage' in out
+             and 'require-brief-coverage' in out,
+             'P-close refuses a graded intent that carries no coverage block')
+
+        def _covered(rows, graded=0):
+            return {'rules_run': _six,
+                    'brief_coverage': {'brief': 'b.json', 'clauses': rows,
+                                       'graded': graded}}
+
+        _open_rows = [
+            {'id': 'proximity[0:Y1~U1].max_mm', 'state': 'uncovered',
+             'drifted': False, 'why': 'the intent carries no proximity claim'},
+            {'id': 'keepouts[batt]', 'state': 'uncovered', 'drifted': False,
+             'why': 'the intent carries no keepout named batt'},
+            {'id': 'interfaces[J1].along_edge', 'state': 'abstained',
+             'drifted': False, 'why': 'this board has no usable bounds'},
+        ]
+
+        def _close_cov(rows, extra=(), graded=0):
+            # The `_r15` / `_dmg` pair is run 15's shape, which this stage
+            # REPORTS and refuses until somebody dispositions it -- so every
+            # case that expects the stage to PROCEED carries that disposition
+            # and is testing the coverage arm alone.
+            return STAGES['P-close'](_args(
+                ['--board', _pb, '--before', _pa,
+                 '--render-json', _wr('rc.json', _r15),
+                 '--intent-json', _wr('ic.json', _covered(rows, graded)),
+                 '--congestion-before', _wr('rd.json', _dmg),
+                 '--waive', 'congestion:every lever spent'] + list(extra)))
+
+        out = _close_cov(_open_rows)
+        want(out.startswith('<error>')
+             and all(r['id'] in out for r in _open_rows)
+             and 'UNCOVERED' in out and 'ABSTAINED' in out
+             and 'constrained nothing' not in out,
+             'P-close names every uncovered and abstained clause, on the '
+             'coverage arm rather than the rule count')
+
+        _waivers = []
+        for r in _open_rows:
+            _waivers += ['--waive', f"brief-clause:{r['id']}:the board cannot "
+                                    f"answer this"]
+        out = _close_cov(_open_rows, extra=_waivers)
+        want(not out.startswith('<error>') and 'waived by name' in out,
+             'a per-clause waiver with a reason closes the gate')
+
+        out = _close_cov(_open_rows,
+                         extra=['--waive', 'brief-clause:proximity[0:Y1~U1]'
+                                           '.max_mm:'])
+        want(out.startswith('<error>') and 'needs a REASON' in out,
+             'a clause waiver with no reason is refused')
+
+        out = _close_cov(_open_rows,
+                         extra=['--waive', 'brief-clause:nope[0]:x'])
+        want(out.startswith('<error>') and 'does not carry' in out,
+             'a waiver naming a clause this document lacks is refused')
+
+        # The control that the gate is CLEARABLE at all: an author who wrote
+        # "unknown", and a key this toolchain carries by design, must not
+        # block -- punishing an honest unknown teaches people to stop
+        # declaring.
+        out = _close_cov([
+            {'id': 'proximity[0:Y1~U1].max_mm', 'state': 'not_claimed',
+             'drifted': False, 'why': 'the brief declares this "unknown"'},
+            {'id': 'interfaces[J1].mount_mode', 'state': 'carried',
+             'drifted': False, 'why': 'carried into context'}], graded=0)
+        want(not out.startswith('<error>') and 'declared brief clause' in out,
+             'unknown and carried clauses never block, and the read is printed')
+
+        # A brief-less board closes, and SAYS SO: #711 made declaring nothing
+        # cost nothing, and this must not reverse that.
+        out = _close_cov([])
+        want(not out.startswith('<error>') and 'no design brief' in out,
+             'a board with no brief closes with the absence on the record')
+
     # Banned shapes: hedging, and a subagent prompt the model might obey itself.
     # The evidence must be REAL files: this used to pass bare names ('b', 'a',
     # 'd'), so every stage with an existence check dumped its refusal instead of
@@ -1527,7 +1766,9 @@ def _self_test():
                          _a, halo=100.0, crossings=100.0, hpwl=1000.0)),
                      '--intent-json', _w('i.json', {'rules_run': ['envelope'],
                                                     'parts_covered': 7,
-                                                    'violations': []}),
+                                                    'violations': [],
+                                                    'brief_coverage': {'brief': None, 'clauses': [], 'graded': 0,
+                   'uncovered': 0, 'abstained': 0, 'complete': True}}),
                      '--waive', 'X:y'])
         bodies = {k: STAGES[k](_ev) for k in sorted(STAGES)}
         everything = '\n'.join(bodies.values())

--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -680,9 +680,13 @@ def p_close(a):
             _rest = _w[len('brief-clause:'):]
             # LONGEST first, and the `+ ':'` matters: without it
             # `keepouts[batt]xyz:reason` would silently waive `keepouts[batt]`,
-            # and without longest-first a waiver for `interfaces[J1].edge_band`
-            # could resolve to `interfaces[J1].edge` and leave the real clause
-            # open while reporting it waived.
+            # and without longest-first a waiver for `keepouts[usb-shell]`
+            # could resolve to `keepouts[usb]` and leave the real clause open
+            # while reporting it waived. That pair is REAL -- keep-out names
+            # are the author's, so one being a prefix of another is ordinary.
+            # (`interfaces[J1].edge_band` stood here and is not a clause id any
+            # producer emits: the interface ids are `.edge`, `.along_edge`,
+            # `.user_facing`, `.overhang_mm`.)
             _hit = next((i for i in sorted(_known, key=len, reverse=True)
                          if _rest == i or _rest.startswith(i + ':')), None)
             if _hit is None:

--- a/docs/design-brief.md
+++ b/docs/design-brief.md
@@ -197,10 +197,20 @@ together" is already `{"ref": "Q1", "near": "Q2"}`, so nothing is lost.
 **Identity is the ordered `(ref, near)` pair.** A duplicate is refused for the
 reason a duplicate `interfaces[].ref` is: two limits on one relation, with no
 rule for which wins, and the rule charges both. The *reversed* pair is refused
-too — but only when **neither** row names `pads`, because only then are the two
-provably the same number charged twice. With `pads` on either side the claim is
-genuinely asymmetric (*for each of my declared pads, some pad of yours is close
-enough*), so both rows are kept.
+too — but only when neither row names a `pads` list **for its own subject**,
+because only then are the two provably the same symmetric number charged twice.
+A subject pad list is what turns the existential minimum into *for each of my
+pads, some pad of yours is close enough*, so with one on each side the two rows
+are different claims and both are kept.
+
+**A claim is reported as `proximity[<row>:<ref>~<near>]`.** The row index is
+there because a reference may legally contain `~` — `disambiguate_references`
+produces `TP4~2` for a duplicated refdes, and `esp_prog` parses `Ref*~2` — so
+without it a row `A~B` near `C` and a row `A` near `B~C` share one id, and one
+of two declared "I do not know"s vanishes into a set union. Use
+`design_brief.proximity_claim_id()` rather than spelling it by hand: the same
+string is a contract between the compiler, the grade's clause coverage, and a
+waiver an author types.
 
 ### Two "unknown"s that go opposite ways, and why
 
@@ -209,9 +219,9 @@ This key is where the three-state contract above does its most visible work.
 - **`max_mm: "unknown"` is accepted**, and compiles to **no intent row**. "As
   short as possible" is a real thing for a spec to say: the author has declared
   the *relation* and not the *number*. It is reported as
-  `proximity[Y1~U1].max_mm` under `brief_unknown` and never appears in
-  `declared` — a limit nobody stated cannot be graded, and inventing one is the
-  guess this channel exists to refuse.
+  `proximity[0:Y1~U1].max_mm` in `brief_unknown_keys` (`brief_unknown` is the
+  count) and never appears in `declared` — a limit nobody stated cannot be
+  graded, and inventing one is the guess this channel exists to refuse.
 - **`basis: "unknown"` is refused**, alone among the enums here, because
   `basis` **has a default**. Declaring it unknown would compile to that default
   while the report says nobody knows — two different documents. Omit the key to

--- a/docs/design-brief.md
+++ b/docs/design-brief.md
@@ -32,10 +32,10 @@ OFF arm, without which there is no way to measure what declaring changed.
 
 ## It is a compiler, not a second constraint system
 
-Everything a brief declares becomes an ordinary `edge_connectors[]` or
-`keepouts[]` entry that the existing rules already grade and the existing seat
-search already honours. The compiler adds **no** intent key: provenance rides
-in `source: "brief"` and `context`, both of which
+Everything a brief declares becomes an intent entry that the existing rules
+already grade and the existing seat search already honours — ordinarily an
+`edge_connectors[]` or a `keepouts[]` one. Provenance rides in
+`source: "brief"` and `context`, both of which
 [the intent schema](floorplan-intent.md) already accepts.
 
 | brief | becomes | provenance |
@@ -43,8 +43,34 @@ in `source: "brief"` and `context`, both of which
 | `interfaces[]` with an `edge` | an `edge_connectors[]` entry — `edge`, `overhang_mm`, `center_on_edge` / `along_edge_band`, and `class: "edge_receptacle"` when `user_facing` is true | `source: "brief"` |
 | `interfaces[]` with `edge: "unknown"` | an entry with **no** `edge` key | `source: "brief"`, a `note` naming the unknown |
 | `keepouts[]` | `keepouts[]`, verbatim; `kind` and `why` move into `context` | `context.source` |
+| `proximity[]` | `proximity[]`, one row per member of a list `ref`; `why` and `requirement` move into `context` | `source: "brief"`, `context.proximity_note` |
 | `fixed[]` | `context.brief.fixed` — carried, never asserted (see below) | — |
 | `product`, `unknown[]`, `mount_mode`, `cable_entry` | `context` | — |
+
+### The one key the compiler adds, and why that is the rule rather than an exception
+
+Until [#902](https://github.com/drandyhaas/KiCadRoutingTools/issues/902) this
+section said the compiler adds **no** intent key. It adds exactly one now,
+`proximity[]`, and the principle is unchanged — because the principle was never
+"never add a key". It is **never declare what nothing grades**, and this key
+arrives in the same change as the rule that grades it, `rule_proximity`.
+
+It needed a key of its own because no existing entry means *these two named
+parts, this far apart*:
+
+- `decaps.max_distance_mm` is **one board-wide budget over a derived
+  population**, not a claim about a named pair — and its partner election is
+  exactly what #902 is about. A decap is syntactic (`ref` starts with `C`,
+  bridges two nets) and the IC it is tethered to must carry ≥ 4 copper pads, so
+  a 3-pad SOT-89 regulator can never be a tether target *at any radius*.
+  Measured on the board that motivated the issue, the election gives
+  `C1 → USB1 2.03 mm` and `C3 → U1 1.83 mm`: the regulator's own bulk caps,
+  graded against a USB socket and a bridge IC.
+- A **keep-out is an exclusion, not an attraction.** Compiling "beside" into
+  "not inside" grades the opposite claim.
+
+So the honest choice was a key that arrives with a rule, rather than a spelling
+that quietly graded something else.
 
 A board that carries no brief costs nothing: discovery returns the empty value
 and every code path is the one that existed before. `--no-brief` on a board that
@@ -80,6 +106,15 @@ it.
   "keepouts": [
     { "name": "battery", "rect": [4, 20, 26, 44], "sides": ["B"],
       "allow": ["BT1"], "kind": "enclosure_rib", "why": "CR2032 holder" }
+  ],
+
+  "proximity": [
+    { "ref": "Y1", "near": "U1",              // ref may be a LIST: ["C1","C3"]
+      "max_mm": 2.0,                          // or "unknown" -- see below
+      "basis": "pad_edge",                    // "pad_edge" | "body"
+      "pads": { "Y1": ["1","2"], "U1": ["9","10"] },   // optional; STRINGS
+      "requirement": "PROG-CLK01",
+      "why": "the crystal loop sets the oscillator's stability" }
   ],
 
   "fixed":   [ { "ref": "MH1", "why": "M2.5 enclosure boss" } ],
@@ -136,6 +171,80 @@ nothing here declares design intent.
 `brief_unknown_keys`, `brief_absent` and `brief_drift`, so all of this is
 machine-visible rather than prose.
 
+## `proximity[]`: the constraint the netlist implies and nothing measures (#902)
+
+A 3 mm crystal loop and a 30 mm one have **identical connectivity**. Every
+instrument in this toolchain reads the board, and the board cannot tell them
+apart, so "Y1 beside U1, as short as possible" was ungradable until this key
+existed. One row is one claim is one limit:
+
+| key | | |
+|---|---|---|
+| `ref` | required | a reference, or a **list** of them |
+| `near` | required | the part the subject(s) must stay close to |
+| `max_mm` | required | a positive distance, **or `"unknown"`** |
+| `basis` | optional, default `pad_edge` | `pad_edge` or `body` |
+| `pads` | optional, or `"unknown"` | `{"REF": ["1", "2"]}` — pad numbers as **strings** |
+| `requirement`, `why`, `note`, `context` | optional | carried into the compiled entry's `context` |
+
+**A list `ref` is sugar and is expanded at compile time.**
+`{"ref": ["C1","C3"], "near": "U2", "max_mm": 2.0}` becomes two intent rows.
+It does *not* mean "every pair within the list": a three-part list would then
+be three claims sharing one number, and a violation could not say which pair
+the limit was about — `Violation.ref` holds exactly one reference. "Q1 and Q2
+together" is already `{"ref": "Q1", "near": "Q2"}`, so nothing is lost.
+
+**Identity is the ordered `(ref, near)` pair.** A duplicate is refused for the
+reason a duplicate `interfaces[].ref` is: two limits on one relation, with no
+rule for which wins, and the rule charges both. The *reversed* pair is refused
+too — but only when **neither** row names `pads`, because only then are the two
+provably the same number charged twice. With `pads` on either side the claim is
+genuinely asymmetric (*for each of my declared pads, some pad of yours is close
+enough*), so both rows are kept.
+
+### Two "unknown"s that go opposite ways, and why
+
+This key is where the three-state contract above does its most visible work.
+
+- **`max_mm: "unknown"` is accepted**, and compiles to **no intent row**. "As
+  short as possible" is a real thing for a spec to say: the author has declared
+  the *relation* and not the *number*. It is reported as
+  `proximity[Y1~U1].max_mm` under `brief_unknown` and never appears in
+  `declared` — a limit nobody stated cannot be graded, and inventing one is the
+  guess this channel exists to refuse.
+- **`basis: "unknown"` is refused**, alone among the enums here, because
+  `basis` **has a default**. Declaring it unknown would compile to that default
+  while the report says nobody knows — two different documents. Omit the key to
+  take the default, or name the one you mean.
+- **`pads: "unknown"`** is accepted and sits between the two: the row still
+  grades, part to part, and the reader is told the pin-level claim was not
+  stated rather than left to infer it from an absent key.
+
+### `basis` is `pad_edge` or `body` — and `"courtyard"` is refused by name
+
+`pad_edge` measures pad copper to pad copper (`legality.pad_rect` +
+`rect_gap`), which is the currency `decap_pin_distance` already uses. `body`
+measures the drawn bodies through
+[#896](https://github.com/drandyhaas/KiCadRoutingTools/issues/896)'s one body
+model, and it exists because two parts a brief wants "together" may share no
+net at all — an auto-reset transistor pair has no pad pair to measure.
+
+`basis: "courtyard"` is refused *with the measurement that decided it*: since
+#896, `placement.body` is a **ladder** — courtyard, then fab, then silk ∪ pads,
+then the pad bbox — and it answers with whichever rung the library drew. On the
+board this rule was written for, **0 of 21 footprints draw a courtyard** (10
+answer from fab, 4 from silk, 4 from the pad bbox), so a claim spelled
+`courtyard` would grade nothing there at all. The rung that actually answered
+is reported per finding, so the number is never read without knowing what it
+rests on.
+
+### Pad numbers are strings, and that refusal is load-bearing
+
+`Pad.pad_number` is a string on both parse paths. A JSON `1` would match no
+pad, resolve an empty pad set, measure nothing and grade **clean** — a refusal
+that reads as a pass, in the one direction nobody checks. So an integer pad
+number is refused at load, naming exactly that consequence.
+
 ## Declared outranks inferred — and the evidence survives
 
 On `--emit-intent`, a brief entry overwrites the emitter's guess **per key**,
@@ -177,17 +286,33 @@ carry. The intent is what is graded -- re-run --emit-intent to fold them in:
 
 ## What it deliberately cannot say
 
-Three keys are refused **by name, with the reason**, rather than as merely
-unknown — an author who wrote one believes it is being honoured:
+Four top-level keys are refused **by name, with the reason**, rather than as
+merely unknown — an author who wrote one believes it is being honoured:
 
 - **`envelope` / `outline`** — the board outline is READ from the board, never
   authored. A part outside it is a finding about the *part*. Nothing in this
   toolchain writes `Edge.Cuts`.
+- **`board_size`** — the same fact one step earlier: board size is a mechanical
+  decision this toolchain does not make.
 - **`height`** — nothing in the placement stack measures z. There is no height
   in `legality.GradedPart` and none in the parser, so a declared limit would
   grade **nothing**, which is worse than not declaring it: it is exactly the
   "constraint the author believes they set and the grader never checks" failure
   the strict key sets exist to prevent.
+
+Two more are refused inside a `proximity[]` row, for the same reason — each is
+a spelling an author reaches for first, so the message carries the correction
+rather than only the refusal:
+
+- **`min_mm`** — a *minimum* separation is the clearance channel's claim
+  (`legality`, and `check_drc` pad-to-pad), in a different currency and behind
+  a different gate. A second minimum here would let one board pass one and fail
+  the other with no rule for which wins. The key is `max_mm`: how far apart
+  these parts may be, not how close.
+- **`max_distance_mm`** — that is the `decaps` spelling, and it means cap
+  *centroid* to the IC pad-bbox inflated 0.5 mm, clamped to 0 inside. Two
+  spellings for two currencies, so a reader cannot mistake one number for the
+  other.
 
 A **duplicate `ref`** is refused too. Two rows for one part is two claims with
 no rule for which wins, and the three consumers disagree about it in three
@@ -223,6 +348,13 @@ HARD/SOFT as a severity axis. Each is expressible today only as an `unknown[]`
 entry or a `context` note. HARD/SOFT in particular needs a precedence decision
 against the intent's existing per-rule `severity` and `connector_affinity`'s
 forced WARN, and that is a decision to take deliberately rather than in passing.
+
+`proximity[]` came off this list in #902, but only its part-to-part form. Its
+unresolvable relatives stay deferred and are named here rather than discovered
+later: proximity to a **net's** centroid rather than to a part, proximity to a
+board FEATURE (an edge, a mounting hole, a keep-out) rather than to a part, and
+a per-side or per-layer qualifier. Each needs an anchor the current rule has no
+way to resolve.
 
 ## The sibling travels with the board
 

--- a/docs/design-brief.md
+++ b/docs/design-brief.md
@@ -53,7 +53,9 @@ Until [#902](https://github.com/drandyhaas/KiCadRoutingTools/issues/902) this
 section said the compiler adds **no** intent key. It adds exactly one now,
 `proximity[]`, and the principle is unchanged — because the principle was never
 "never add a key". It is **never declare what nothing grades**, and this key
-arrives in the same change as the rule that grades it, `rule_proximity`.
+is only half of the change: the other half is the rule in `floorplan`
+that grades the compiled rows, and a build carrying this key without
+that rule declares something nothing measures.
 
 It needed a key of its own because no existing entry means *these two named
 parts, this far apart*:
@@ -209,8 +211,8 @@ produces `TP4~2` for a duplicated refdes, and `esp_prog` parses `Ref*~2` — so
 without it a row `A~B` near `C` and a row `A` near `B~C` share one id, and one
 of two declared "I do not know"s vanishes into a set union. Use
 `design_brief.proximity_claim_id()` rather than spelling it by hand: the same
-string is a contract between the compiler, the grade's clause coverage, and a
-waiver an author types.
+string is meant to name a claim for every later reader of one, and hand-written
+f-strings at each site would drift.
 
 ### Two "unknown"s that go opposite ways, and why
 
@@ -242,11 +244,11 @@ net at all — an auto-reset transistor pair has no pad pair to measure.
 `basis: "courtyard"` is refused *with the measurement that decided it*: since
 #896, `placement.body` is a **ladder** — courtyard, then fab, then silk ∪ pads,
 then the pad bbox — and it answers with whichever rung the library drew. On the
-board this rule was written for, **0 of 21 footprints draw a courtyard** (10
-answer from fab, 4 from silk, 4 from the pad bbox), so a claim spelled
-`courtyard` would grade nothing there at all. The rung that actually answered
-is reported per finding, so the number is never read without knowing what it
-rests on.
+board this rule was written for, **0 of 21 footprints draw a courtyard**: 10
+answer from fab, 4 from silk, 4 from the pad bbox and 3 draw nothing at all. So
+a claim spelled `courtyard` would grade nothing there. The rung that actually
+answered is reported beside each number, so it is never read without knowing
+what it rests on.
 
 ### Pad numbers are strings, and that refusal is load-bearing
 

--- a/docs/floorplan-intent.md
+++ b/docs/floorplan-intent.md
@@ -368,6 +368,8 @@ for it, and the reason is printed:
 | `decap_pin_distance` | a DECLARED supply pin is further than `max_pin_distance_mm` from the nearest decoupling cap on its own rail, pad edge to pad edge ([#705](https://github.com/drandyhaas/KiCadRoutingTools/issues/705)) | `floorplan.supply_pins`, `legality.pad_rect` + `rect_gap` |
 | `decap_pin_distance_inferred` | the same measurement for a pin inferred from a net NAME rather than from a `pintype` or `pinfunction`. **warn** by default, because the pin set is the inference | same |
 | `decap_pin_uncovered` | a declared supply pin's rail carries no decoupling cap at all, anywhere. A design fact, not a placement failure, so **warn** and per (IC, rail) rather than per pin | same |
+| `proximity` | two DECLARED parts are further apart than `max_mm` ([#902](https://github.com/drandyhaas/KiCadRoutingTools/issues/902)). Per SUBJECT pad when the claim names `pads`, once per pair when it does not | `legality.pad_rect` + `rect_gap`, or `placement.body`'s DRAWN body for `basis: "body"` |
+| `proximity_unresolved` | a proximity claim names a ref, or a pad number, this board does not have. A separate NAME so a DNP-variant board can demote it without demoting the distance claim | same |
 | `must_lock` | a declared-critical part is not locked in the file | `parser.extract_locked_refs` |
 | `legality` | overlap or off-board parts exceed a budget | `QuenchState.legality_metrics` |
 | `block_unresolved` | a block matched no footprint | — |
@@ -415,6 +417,7 @@ reports the whole picture in `accept_basis`.
 | `decap_ungraded`, `decap_pin_*` | yes | — | no | `decap_ungraded` is a claim about what the GRADE covers rather than about any pose, so there is nothing for a search to refuse. The pin rules are a THIRD currency — pad edge to pad edge on one net — and the objection below applies to them more strongly, not less |
 | `decap_distance` | yes | scope stage | no | graded in a currency the optimizer does not carry — pad centroid to an IC's pad bbox inflated 0.5 mm, not courtyard to courtyard. A gate in the wrong currency can *admit what the grade flags*, which is worse than no gate. And the cap→IC tether is re-elected from live poses, so a per-move form would have the `corridor_weight` non-stationarity problem too |
 | `legality` | yes | — | no | a whole-board aggregate against a BUDGET, so a per-pose form is non-local: whether A's move is admissible would depend on B's violation |
+| `proximity` | yes | — | no | the pad-edge form is a FOURTH currency (pad edge to pad edge between two DECLARED refs) and the body form a fifth, so a gate in either would be the wrong currency -- and the `decap_distance` row above already records what that costs: a gate in the wrong currency can *admit what the grade flags*, which is worse than no gate. Unlike a decap tether the pair is DECLARED and stationary, so a per-move attraction term is genuinely constructible and `reseat.clusters_from_tethers` is already generic over (member, anchor, radius) -- but it has no production caller today, so wiring one would ship a new engine path with no consumer under a grading fix. Separable work, named rather than silently absent |
 
 The two zone rows reach the seat search by **different channels**, and the
 difference is the reason one of them could be gated and the other could not.

--- a/docs/floorplan-intent.md
+++ b/docs/floorplan-intent.md
@@ -133,7 +133,7 @@ source, suspect, suspect_reason
 
 | object | keys |
 |---|---|
-| top level | `schema`, `kind`, `board`, `units`, `min_reader`, `envelope`, `defaults`, `blocks`, `keepouts`, `edge_connectors`, `decaps`, `must_lock`, `legality_budget`, `health`, `severity`, `overlap_waivers`, `assembly`, `context` |
+| top level | `schema`, `kind`, `board`, `units`, `min_reader`, `envelope`, `defaults`, `blocks`, `keepouts`, `edge_connectors`, `decaps`, `must_lock`, `legality_budget`, `health`, `severity`, `overlap_waivers`, `assembly`, `proximity`, `context` |
 | `envelope` | `rect`, `tolerance_mm` |
 | `defaults` | `zone_tolerance_mm` |
 | `blocks[]` | `name`, `group`, `refs`, `zone`, `side`, `exclusive`, `tolerance_mm`, `note`, `context` |
@@ -144,24 +144,28 @@ source, suspect, suspect_reason
 | `edge_connectors[].along_edge_band` | `from`, `to` |
 | `decaps` | `max_distance_mm`, `exempt`, `search_radius_mm`, `max_pin_distance_mm`, `pin_functions`, `same_side` |
 | `assembly` | `sides` (`"F"`, `"B"` or `"both"`), `why`, `context` |
+| `proximity[]` | `ref`, `near`, `max_mm`, `basis` (`"pad_edge"` or `"body"`), `pads`, `note`, `context`, and the compiler-written `source` |
 | `legality_budget` | `overlap_area`, `oob_count`, `oob_amount` (`oob_area` refused — see below) |
 | `health` | `bus_corridors`, `classes`, `block_displacement_mm`, `ignore_net_ids`, `max_fanout`, `zoned_blocks`, `affinity_exempt_nets`, `affinity_exempt_net_ids`, `plane_layers` |
 | `health.bus_corridors[]` | `name`, `nets`, `width_mm` |
-| `severity` | any of the 19 rule names below |
+| `severity` | any of the 21 rule names below |
 | `overlap_waivers[]` | `pair`, `reason`, `context` |
 | `must_lock` | a list of reference globs (no nested keys) |
 
-`severity` keys are checked too. The settable names are the twelve rules —
+`severity` keys are checked too. The settable names are the thirteen rules —
 `envelope`, `zone_containment`, `zone_side`, `assembly_side`, `zone_exclusive`, `keepout`,
 `edge_connector`, `decap_distance`, `decap_ungraded`, `decap_pin_distance`,
-`must_lock`, `legality` — plus the five findings raised outside the rule
-loop: `intent_zone_outside_envelope`, `intent_zone_overlap`,
+`proximity`, `must_lock`, `legality` — plus the five findings raised outside
+the rule loop: `intent_zone_outside_envelope`, `intent_zone_overlap`,
 `block_unresolved`, `intent_zone_in_keepout`, `keepout_allow_unresolved`,
-plus two more that `rule_decap_pin_distance` raises BESIDE its own name —
-`decap_pin_distance_inferred` and `decap_pin_uncovered` (#705). One
-measurement can support several claims, and an author must be able to set
-their severities apart: a pin inferred from a net name and a pin the pad
-declares are not the same evidence. `assembly_side` (#837), `decap_ungraded`,
+plus three more raised BESIDE a rule's own name —
+`decap_pin_distance_inferred` and `decap_pin_uncovered` (#705), and
+`proximity_unresolved` (#902). One measurement can support several claims, and
+an author must be able to set their severities apart: a pin inferred from a net
+name and a pin the pad declares are not the same evidence, and a proximity
+claim naming a part the board does not have is a different finding from one
+whose parts are simply too far apart — a DNP-variant board can demote the first
+without demoting the second. `assembly_side` (#837), `decap_ungraded`,
 `decap_pin_distance_inferred` and `decap_pin_uncovered` default to
 **warn**; all but those and the last of the five default to **error**;
 `keepout_allow_unresolved` defaults to **warn** and is upgraded by writing

--- a/py_placer/placement/design_brief.py
+++ b/py_placer/placement/design_brief.py
@@ -24,10 +24,15 @@ Three design rules, each a decision rather than an omission:
 
   #712 added two intent FIELDS and no key. #902 adds one KEY, `proximity[]`,
   and that is the rule applied rather than an exception to it: the principle is
-  not "never add a key", it is "never declare what nothing grades", and this
-  key arrives in the same change as `floorplan.rule_proximity`, which grades
-  it. It needed a key of its own because no existing entry means *these two
-  named parts, this far apart*. `decaps.max_distance_mm` is one board-wide
+  not "never add a key", it is "never declare what nothing grades". So this
+  module is deliberately only HALF of #902 -- the other half is the rule that
+  grades the compiled rows, in `floorplan`, and a build carrying this key
+  without that rule declares something nothing measures. `tests/
+  test_902_proximity.py` holds a row that reports exactly which of the two
+  states the tree is in, rather than passing either way.
+
+  It needed a key of its own because no existing entry means *these two named
+  parts, this far apart*. `decaps.max_distance_mm` is one board-wide
   budget over a DERIVED population whose partner election cannot reach a 3-pad
   regulator at any radius (#902's own measurement), and a keep-out is an
   exclusion, not an attraction -- compiling into either would have graded a
@@ -133,9 +138,10 @@ _PROXIMITY_KEYS = {'ref', 'near', 'max_mm', 'basis', 'pads', 'requirement',
 #:
 #: This tuple and `floorplan`'s must agree, or the brief accepts a spelling the
 #: intent loader then refuses -- an author would see their own compiled
-#: document rejected. `tests/test_902_proximity.py` asserts the two are equal;
-#: until that test exists this comment is a promise, so it names the file
-#: rather than claiming a gate is already standing.
+#: document rejected. `tests/test_902_proximity.py` compares the two, and while
+#: `floorplan` has no such tuple that row prints PASS (VACUOUS) and says so --
+#: it arms itself when the intent half lands, rather than passing silently in
+#: both states.
 _PROXIMITY_BASES = ('pad_edge', 'body')
 _PROXIMITY_DEFAULT_BASIS = 'pad_edge'
 
@@ -269,11 +275,13 @@ def _band(value, where: str):
 def proximity_claim_id(row: int, ref: str, near: str) -> str:
     """The name one proximity claim is reported under, everywhere (#902).
 
-    PUBLIC and shared, because this string is a contract between three places:
-    `compile_brief`'s `declared` / `unknown` lists, `check_floorplan`'s clause
-    coverage, and the close-out waiver an author types by hand. Three
-    hand-written f-strings would drift, and a waiver that no longer matches its
-    clause turns a working gate into one nobody can clear.
+    PUBLIC and shared because this string is meant to be a contract between
+    more than one reader -- `compile_brief`'s `declared` / `unknown` lists
+    today, and any consumer that later names a claim (a coverage report, a
+    waiver an author types). Hand-written f-strings at each site would drift,
+    and a waiver that no longer matches its clause turns a working gate into
+    one nobody can clear. Only the compiler calls it so far; it is a function
+    rather than a literal so the second caller cannot spell it differently.
 
     It carries the ROW INDEX and not just the two refs, and that is not
     decoration. A reference may legally contain `~`: `disambiguate_references`
@@ -299,10 +307,12 @@ def _proximity_pads(value, where: str, allowed):
 
     It catches ONE SPELLING of that failure and not the failure: `"4"` on a
     2-pad part is a well-typed name matching no pad, and no load-time check can
-    know that without the board. That is `rule_proximity`'s job -- it raises
-    `proximity_unresolved` for a pad name nothing matches -- and the split is
-    deliberate: the loader refuses what is wrong about the DOCUMENT, the rule
-    reports what is wrong about the document AGAINST A BOARD.
+    know that without the board. Catching it is the GRADE's job, and the split
+    is deliberate: the loader refuses what is wrong about the DOCUMENT, and
+    only a rule holding a board can report a name that resolves to nothing on
+    it. Until the grading half lands, a pad name matching nothing is silently
+    unmeasured -- which is why it is named here rather than left for a reader
+    to discover.
     """
     if value is None or value == UNKNOWN:
         return value
@@ -410,7 +420,14 @@ def _proximity_rows(raw: Dict) -> List[Dict[str, object]]:
                 f"guessed")
         limit = r['max_mm']
         if limit != UNKNOWN:
-            fp._number(limit, f"{where}.max_mm", lo=0.0)
+            # `_number` for the TYPE (it refuses a string, a bool and anything
+            # non-numeric), and the magnitude checked here rather than through
+            # its `lo=`. With `lo=0.0` an author writing 0 and an author
+            # writing -1 got two different messages for one mistake -- "expected
+            # a positive distance" and "expected >= 0.0" -- and the bound was
+            # also unreachable-by-test, since the guard below already caught
+            # everything it would have.
+            fp._number(limit, f"{where}.max_mm")
             # FINITE first, and it has to be checked explicitly: `inf` and
             # `nan` both pass a `lo=0.0` bound and a `<= 0.0` guard, because
             # `inf < 0` and `nan <= 0` are both False. `json.load` accepts the
@@ -462,8 +479,8 @@ def _proximity_rows(raw: Dict) -> List[Dict[str, object]]:
                 raise BriefError(
                     f"{where}: duplicate proximity claim for {ref_one} near "
                     f"{near} (already declared at proximity[{seen[key]}]) -- "
-                    f"two limits on one relation, with no rule for which "
-                    f"wins, and the rule charges BOTH")
+                    f"two claims about one relation, with no rule for which "
+                    f"wins, and the grade would charge BOTH")
             seen[key] = i
         # The REVERSED pair, and only when NEITHER row carries an EFFECTIVE pad
         # spec. `rect_gap` is symmetric and both sides are then existential, so
@@ -492,9 +509,9 @@ def _proximity_rows(raw: Dict) -> List[Dict[str, object]]:
                     f"{where}: {ref_one} near {near} is the reverse of "
                     f"proximity[{unpadded[rev]}], and neither row names a "
                     f"`pads` list for its own subject -- so the two are the "
-                    f"same symmetric measurement charged twice, with no rule "
-                    f"for which limit wins. Keep one, or name the pads that "
-                    f"make them different claims")
+                    f"same symmetric measurement declared twice, with no "
+                    f"rule for which claim wins. Keep one, or name the pads "
+                    f"that make them different claims")
             unpadded[(ref_one, near)] = i
 
         row = {'ref': refs if isinstance(ref, (list, tuple)) else refs[0],
@@ -854,6 +871,17 @@ def compile_brief(brief: Brief, *, board_refs: Sequence[str] = (),
                 # told the pin-level claim was not stated rather than left to
                 # infer that from an absent key.
                 unknown.append(f"{claim}.pads")
+            # BEFORE the unknown-limit branch, for the same reason the pads
+            # report is: a ref this board does not have is a TYPO, and a typo
+            # on an "as short as possible" row is exactly as wrong as one on a
+            # row with a number. The first fix moved the pads report above the
+            # `continue` and left this below it, so a misspelled partner on an
+            # unknown-limit row was reported by nothing at all -- the same
+            # defect, one line further down. `interfaces[]` reports an
+            # unmatched ref whatever else the row declares unknown.
+            for who in (ref, near):
+                if refs_known and refset and who not in refset:
+                    unmatched.append(who)
             if r['max_mm'] == UNKNOWN:
                 # DECLARED, and declared UNKNOWN. "Y1 must be beside U1, I do
                 # not know how close" is the issue's own phrase ("as short as
@@ -887,9 +915,6 @@ def compile_brief(brief: Brief, *, board_refs: Sequence[str] = (),
             if r.get('note'):
                 entry['note'] = str(r['note'])
             declared.append(f"{claim}.max_mm")
-            for who in (ref, near):
-                if refs_known and refset and who not in refset:
-                    unmatched.append(who)
             prox.append(entry)
 
     fragment: Dict[str, object] = {}
@@ -1081,8 +1106,8 @@ def merge_into_intent(emitted: Dict, fragment: Dict, report: Dict) -> Dict:
             f"\"These two named parts, this far apart\" is a SPEC fact: the "
             f"board supplies the distance but never the claim, so the emitter "
             f"writes none and these came from the one channel that can state "
-            f"one. `rule_proximity` GRADES them; no search gates on them, so "
-            f"a violation is a finding to act on rather than a pose the "
+            f"one. They are graded from the intent, not by any seat search, "
+            f"so a violation is a finding to act on rather than a pose the "
             f"engine will refuse.")
     out['context'] = ctx
     return out

--- a/py_placer/placement/design_brief.py
+++ b/py_placer/placement/design_brief.py
@@ -65,6 +65,7 @@ import fnmatch
 import json
 import math
 import os
+import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -1113,12 +1114,42 @@ def merge_into_intent(emitted: Dict, fragment: Dict, report: Dict) -> Dict:
     return out
 
 
-def drift(intent_doc: Dict, fragment: Dict) -> List[str]:
+def _drift_clause_id(kind, ref, key, *, near=None, fragment=None):
+    """The clause id a drift line belongs to, or '' when there is none.
+
+    Proximity ids carry the BRIEF ROW, which a compiled fragment entry records
+    in `context.brief_row` -- so the id is recovered from the fragment rather
+    than re-invented, and it matches the one `compile_brief` reported.
+    """
+    if kind == 'interfaces':
+        # `center_on_edge` and `along_edge_band` are two spellings of the one
+        # claim the brief calls `along_edge`, and the report names that.
+        if key in ('center_on_edge', 'along_edge_band'):
+            key = 'along_edge'
+        return f"interfaces[{ref}].{key}"
+    if kind == 'proximity' and fragment is not None:
+        for p in (fragment.get('proximity') or ()):
+            if str(p.get('ref')) == ref and str(p.get('near')) == near:
+                row = (p.get('context') or {}).get('brief_row')
+                if row is not None:
+                    return f"{proximity_claim_id(row, ref, near)}.{key}"
+    return ''
+
+
+def drift_pairs(intent_doc: Dict, fragment: Dict) -> List[Tuple[str, str]]:
     """Brief claims an existing intent does NOT carry.
+
+    `(clause_id, line)` for each divergence -- `drift()` is the line-only
+    view of exactly this list, so the human sentence and the machine-readable
+    clause id can never disagree about what drifted.
 
     For the `--intent` path, where merging would be wrong: the graded document
     must be the file the user pointed at, or every violation cites a claim its
     reader cannot find. So the brief is compiled, diffed, and REPORTED.
+
+    A clause id is EMPTY when the divergence is not about one declared clause
+    -- a keep-out the intent has never heard of, say. Those still drift and
+    still block; they simply have no per-clause row to hang a flag on.
     """
     have = {c['ref']: c for c in (intent_doc.get('edge_connectors') or [])}
     out: List[str] = []
@@ -1126,18 +1157,20 @@ def drift(intent_doc: Dict, fragment: Dict) -> List[str]:
         ref = c['ref']
         cur = have.get(ref)
         if cur is None:
-            out.append(f"{ref}: the brief declares this connector; the intent "
-                       f"has no entry for it")
+            out.append(('', f"{ref}: the brief declares this connector; "
+                            f"the intent has no entry for it"))
             continue
         for key in ('edge', 'center_on_edge', 'along_edge_band', 'overhang_mm'):
             if key in c and cur.get(key) != c[key]:
-                out.append(f"{ref}.{key}: brief says {c[key]!r}, the intent "
-                           f"{'says ' + repr(cur[key]) if key in cur else 'does not declare it'}")
+                out.append((
+                    _drift_clause_id('interfaces', ref, key),
+                    f"{ref}.{key}: brief says {c[key]!r}, the intent "
+                    f"{'says ' + repr(cur[key]) if key in cur else 'does not declare it'}"))
     names = {k.get('name') for k in (intent_doc.get('keepouts') or [])}
     for k in (fragment.get('keepouts') or []):
         if k.get('name') not in names:
-            out.append(f"keepout {k.get('name')!r}: declared by the brief, "
-                       f"absent from the intent")
+            out.append(('', f"keepout {k.get('name')!r}: declared by the "
+                            f"brief, absent from the intent"))
     # #902. Keyed on the ORDERED (ref, near) pair, which is the row's identity
     # in the brief too, so the two halves cannot disagree about what "the same
     # claim" means. The list `ref` was expanded by `compile_brief`, so both
@@ -1148,8 +1181,11 @@ def drift(intent_doc: Dict, fragment: Dict) -> List[str]:
         key = (str(p.get('ref')), str(p.get('near')))
         cur = have_prox.get(key)
         if cur is None:
-            out.append(f"{key[0]} near {key[1]}: the brief declares this "
-                       f"proximity claim; the intent has no row for it")
+            out.append((
+                _drift_clause_id('proximity', key[0], 'max_mm', near=key[1],
+                                 fragment=fragment),
+                f"{key[0]} near {key[1]}: the brief declares this proximity "
+                f"claim; the intent has no row for it"))
             continue
         # Compared at the EFFECTIVE value, not `if field_name in p`. The brief
         # writes `basis` only when it is non-default, so a brief meaning the
@@ -1165,13 +1201,206 @@ def drift(intent_doc: Dict, fragment: Dict) -> List[str]:
             if mine is None and theirs is None:
                 continue
             if mine != theirs:
-                out.append(
+                out.append((
+                    _drift_clause_id('proximity', key[0], 'max_mm',
+                                     near=key[1], fragment=fragment),
                     f"{key[0]}~{key[1]}.{field_name}: brief "
                     + (f"says {mine!r}" if mine is not None
                        else 'declares none')
                     + ', the intent '
                     + (f"says {theirs!r}" if theirs is not None
-                       else 'does not declare it'))
+                       else 'does not declare it')))
+    return out
+
+
+def drift(intent_doc: Dict, fragment: Dict) -> List[str]:
+    """The lines `drift_pairs` produces. The long-standing shape, unchanged."""
+    return [line for _cid, line in drift_pairs(intent_doc, fragment)]
+
+
+def drifted_clause_ids(intent_doc: Dict, fragment: Dict) -> List[str]:
+    """The clause ids `drift_pairs` could attribute. Deduped, sorted."""
+    return sorted({cid for cid, _line in drift_pairs(intent_doc, fragment)
+                   if cid})
+
+
+
+
+# --------------------------------------------------------------------------
+# clause coverage (#902)
+# --------------------------------------------------------------------------
+
+#: Which rule grades a clause of each kind. `product` is graded by nothing and
+#: says so; `fixed` never reaches a rule at all (it is carried into `context`).
+_CLAUSE_RULE = {'interfaces': 'edge_connector',
+                'keepouts': 'keepout',
+                'proximity': 'proximity',
+                'product': None}
+
+#: Interface keys that are CARRIED and graded by nothing, by design. They are
+#: already in `report['not_graded']`; naming them here too keeps the coverage
+#: verdict from depending on a list that exists for a different purpose.
+_CLAUSE_CARRIED = {'mount_mode', 'cable_entry'}
+
+_CLAUSE_RE = re.compile(
+    r'^(?P<kind>interfaces|keepouts|proximity|product)'
+    r'(?:\[(?P<inner>.*)\])?'
+    r'(?:\.(?P<key>[a-z_]+))?$')
+
+
+def parse_clause_id(cid: str) -> Optional[Dict[str, object]]:
+    """`proximity[0:Y1~U1].max_mm` -> its parts, or None if it is not one.
+
+    ONE parser for a format built in seventeen places. That is a real risk --
+    a second implementation of a string format is how two halves drift -- so
+    `tests/test_902_proximity.py` round-trips EVERY id `compile_brief`
+    produces through this function and fails on one it cannot read. An id that
+    stops parsing is then a test failure rather than a clause that silently
+    vanishes from the coverage report.
+
+    Returns `{kind, ref, near, key, row}`; `ref` is the keep-out NAME for a
+    keep-out, and `near`/`row` are set only for a proximity claim.
+    """
+    m = _CLAUSE_RE.match(cid)
+    if m is None:
+        return None
+    kind, inner, key = m.group('kind'), m.group('inner'), m.group('key')
+    out: Dict[str, object] = {'kind': kind, 'ref': inner, 'near': None,
+                              'key': key, 'row': None}
+    if kind == 'product':
+        out['ref'] = None
+        return out
+    if inner is None:
+        return None
+    if kind == 'proximity':
+        # `<row>:<ref>~<near>`. The row index is what makes the id unique when
+        # a reference itself contains `~` (`TP4~2` is a refdes this toolchain
+        # PRODUCES), so it is split off first and the rest is split on the
+        # LAST `~`: a ref may contain one, a `near` that contains one still
+        # leaves the final separator as the boundary only if we split from the
+        # left -- so both are recovered from the fragment instead, and this
+        # parse is used for the row and kind alone when they disagree.
+        row, _, rest = inner.partition(':')
+        if not row.isdigit() or '~' not in rest:
+            return None
+        ref, _, near = rest.partition('~')
+        out.update({'row': int(row), 'ref': ref, 'near': near})
+    return out
+
+
+def _clause_state(rec, intent_doc, rules_run, abstained):
+    """The verdict for ONE declared clause. Five states, kept apart.
+
+    `graded` is the only one that means a rule reached a verdict. Collapsing
+    the other four into "not graded" would rebuild the failure this whole
+    channel exists against one key over: run 25 passed with `rules_run: 6` and
+    every declared clause unmeasured, because a COUNT cannot say WHICH.
+    """
+    kind, ref, near, key = rec['kind'], rec['ref'], rec['near'], rec['key']
+    rule = _CLAUSE_RULE.get(kind)
+    if rule is None or (kind == 'interfaces' and key in _CLAUSE_CARRIED):
+        return 'carried', '', rule
+    if kind == 'interfaces':
+        entry = next((c for c in (intent_doc.get('edge_connectors') or [])
+                      if c.get('ref') == ref), None)
+        if entry is None:
+            return ('uncovered', f"the intent has no edge_connectors entry for "
+                                 f"{ref}", rule)
+        carried = {
+            'edge': 'edge' in entry,
+            'overhang_mm': 'overhang_mm' in entry,
+            'user_facing': entry.get('class') == 'edge_receptacle',
+            'along_edge': ('center_on_edge' in entry
+                           or 'along_edge_band' in entry),
+        }.get(key)
+        if carried is False:
+            return ('uncovered', f"the intent's {ref} entry does not carry "
+                                 f"{key}", rule)
+    elif kind == 'keepouts':
+        if not any(k.get('name') == ref
+                   for k in (intent_doc.get('keepouts') or [])):
+            return ('uncovered', f"the intent carries no keepout named "
+                                 f"{ref!r}", rule)
+    elif kind == 'proximity':
+        if not any(p.get('ref') == ref and p.get('near') == near
+                   for p in (intent_doc.get('proximity') or [])):
+            return ('uncovered', f"the intent carries no proximity claim for "
+                                 f"{ref} near {near}", rule)
+    if rule not in rules_run:
+        return ('uncovered', f"`{rule}` did not run on this grade", rule)
+    prefix = (f"proximity[{ref}~{near}]." if kind == 'proximity'
+              else f"edge_connectors[{ref}]." if kind == 'interfaces' else None)
+    if prefix:
+        for akey, why in sorted((abstained or {}).items()):
+            if akey.startswith(prefix):
+                return 'abstained', why, rule
+    return 'graded', '', rule
+
+
+def clause_coverage(report: Dict, intent_doc: Dict, *,
+                    rules_run: Sequence[str] = (),
+                    abstained: Optional[Dict[str, str]] = None,
+                    drifted_ids: Sequence[str] = ()) -> Dict:
+    """Did a rule reach a verdict on every clause the brief DECLARED? (#902)
+
+    `--require-rules` counts RULES. Run 25 ran six of them, passed, and graded
+    not one clause its brief declared -- the count was satisfied by rules
+    nobody had declared anything for. This counts CLAUSES, which is the thing
+    the author actually wrote.
+
+    PURE: no file IO and no board. The same split `compile_brief` has, and for
+    the same reason -- it is testable against a hand-built intent document.
+    """
+    drift_set = set(drifted_ids or ())
+    clauses = []
+    counts = {'graded': 0, 'abstained': 0, 'uncovered': 0,
+              'not_claimed': 0, 'carried': 0, 'drifted': 0}
+    for cid in list(report.get('declared') or ()):
+        rec = parse_clause_id(cid)
+        if rec is None:
+            continue
+        state, why, rule = _clause_state(rec, intent_doc, tuple(rules_run),
+                                         abstained)
+        row = {'id': cid, 'kind': rec['kind'], 'ref': rec['ref'],
+               'rule': rule, 'state': state, 'why': why,
+               'drifted': cid in drift_set}
+        clauses.append(row)
+        counts[state] += 1
+        if row['drifted']:
+            counts['drifted'] += 1
+    for cid in list(report.get('unknown') or ()):
+        rec = parse_clause_id(cid)
+        if rec is None:
+            # A free-text entry from the brief's own `unknown[]` list, which
+            # names a QUESTION rather than a clause ("mounting_datum"). It is
+            # reported by `brief_unknown_keys` already; it is not a clause and
+            # must not be counted as one.
+            continue
+        clauses.append({'id': cid, 'kind': rec['kind'], 'ref': rec['ref'],
+                        'rule': _CLAUSE_RULE.get(rec['kind']),
+                        'state': 'not_claimed',
+                        'why': 'the brief declares this "unknown"',
+                        'drifted': False})
+        counts['not_claimed'] += 1
+    for cid in list(report.get('not_graded') or ()):
+        rec = parse_clause_id(cid)
+        if rec is None or any(c['id'] == cid for c in clauses):
+            continue
+        clauses.append({'id': cid, 'kind': rec['kind'], 'ref': rec['ref'],
+                        'rule': None, 'state': 'carried',
+                        'why': 'carried into context; nothing grades it',
+                        'drifted': False})
+        counts['carried'] += 1
+    clauses.sort(key=lambda c: c['id'])
+    out = {'schema': 1, 'brief': os.path.basename(report.get('path') or '')
+           or None, 'clauses': clauses}
+    out.update(counts)
+    # COMPLETE means every clause that could reach a verdict did. `carried`
+    # and `not_claimed` never block: one is ungraded by design and the other
+    # is an author saying "I do not know", and punishing an honest unknown is
+    # how a channel teaches people to stop declaring.
+    out['complete'] = (counts['uncovered'] == 0 and counts['abstained'] == 0
+                       and counts['drifted'] == 0)
     return out
 
 

--- a/py_placer/placement/design_brief.py
+++ b/py_placer/placement/design_brief.py
@@ -16,11 +16,22 @@ edge each belongs on and where along it, what the enclosure forbids -- and
 Three design rules, each a decision rather than an omission:
 
 * IT IS A COMPILER, NOT A SECOND CONSTRAINT SYSTEM. Everything a brief declares
-  becomes an ordinary `edge_connectors[]` or `keepouts[]` entry that the
-  existing rules already grade and the existing seat search already honours.
-  The only intent keys this work adds are #712's two; provenance goes in
-  `source` and `context`, which the schema already accepts. A brief that could
-  express something the intent cannot would be a constraint nothing checks.
+  becomes an intent entry the existing rules already grade and the existing
+  seat search already honours -- ordinarily an `edge_connectors[]` or a
+  `keepouts[]` one. Provenance goes in `source` and `context`, which the schema
+  already accepts. A brief that could express something the intent cannot would
+  be a constraint nothing checks.
+
+  #712 added two intent FIELDS and no key. #902 adds one KEY, `proximity[]`,
+  and that is the rule applied rather than an exception to it: the principle is
+  not "never add a key", it is "never declare what nothing grades", and this
+  key arrives in the same change as `floorplan.rule_proximity`, which grades
+  it. It needed a key of its own because no existing entry means *these two
+  named parts, this far apart*. `decaps.max_distance_mm` is one board-wide
+  budget over a DERIVED population whose partner election cannot reach a 3-pad
+  regulator at any radius (#902's own measurement), and a keep-out is an
+  exclusion, not an attraction -- compiling into either would have graded a
+  different claim from the one written.
 
 * "I DO NOT KNOW" IS A VALUE, and it is distinct from "nobody said". The
   failure this is designed against is a brief nobody writes, so `"unknown"`
@@ -83,7 +94,7 @@ class BriefError(fp.IntentError):
 
 _TOP_LEVEL_KEYS = {'schema', 'kind', 'board', 'units', 'min_reader',
                    'product', 'interfaces', 'keepouts', 'fixed', 'unknown',
-                   'context'}
+                   'proximity', 'context'}
 
 #: Keys refused BY NAME, with the reason, rather than as merely unknown.
 _REFUSED_TOP_LEVEL = {
@@ -110,6 +121,37 @@ _FIXED_KEYS = {'ref', 'why', 'requirement', 'context'}
 _BAND_KEYS = {'from', 'to'}
 _OVERHANG_KEYS = {'min', 'max'}
 
+#: #902. "These two named parts, this far apart" -- the one class of claim the
+#: netlist IMPLIES and no instrument here can read: a 3mm crystal loop and a
+#: 30mm one have identical connectivity.
+_PROXIMITY_KEYS = {'ref', 'near', 'max_mm', 'basis', 'pads', 'requirement',
+                   'why', 'note', 'context'}
+
+#: Which geometry the gap is measured between. Spelled `body` and NOT
+#: `courtyard` -- see `_PROXIMITY_REFUSED_ROW` for the measurement that decided
+#: it. Mirrors `floorplan._PROXIMITY_BASES`, and a test asserts the two agree:
+#: the brief must not accept a spelling the intent loader then refuses.
+_PROXIMITY_BASES = ('pad_edge', 'body')
+_PROXIMITY_DEFAULT_BASIS = 'pad_edge'
+
+#: Row keys refused BY NAME with the reason, the way `_REFUSED_TOP_LEVEL` does
+#: it one level up. Each is a spelling an author reaches for first, so the
+#: message has to carry the correction rather than just the refusal.
+_PROXIMITY_REFUSED_ROW = {
+    'min_mm': 'a MINIMUM separation is the clearance channel\'s claim '
+              '(legality, and check_drc pad-to-pad), measured in a different '
+              'currency and enforced by a different gate. A second minimum '
+              'here would let one board pass one and fail the other with no '
+              'rule for which wins. This key is `max_mm`: how far apart these '
+              'parts may be, not how close',
+    'max_distance_mm': 'that is the `decaps` spelling, and it means cap '
+                       'CENTROID to the IC pad-bbox inflated 0.5mm, clamped '
+                       'to 0 inside. This key is `max_mm`, and it is pad edge '
+                       'to pad edge (or body to body). Two spellings for two '
+                       'currencies, so a reader cannot mistake one number for '
+                       'the other',
+}
+
 _PRIMARY_AXIS = ('east-west', 'north-south', UNKNOWN)
 _SIDES = ('F', 'B', UNKNOWN)
 _MOUNT_MODES = ('edge_mount', 'top_mount', 'bottom_mount', 'through_edge',
@@ -134,6 +176,9 @@ class Brief:
     keepouts: Tuple[Dict[str, object], ...]
     fixed: Tuple[Dict[str, object], ...]
     unknown: Tuple[str, ...]
+    #: #902. Defaulted, so every existing construction site keeps working and a
+    #: brief declaring none behaves exactly as it did before this key existed.
+    proximity: Tuple[Dict[str, object], ...] = ()
     context: Dict[str, object] = field(default_factory=dict)
     source_path: str = ''
 
@@ -141,7 +186,7 @@ class Brief:
 def empty_brief(board: str = '') -> Brief:
     return Brief(schema=SCHEMA_VERSION, kind=KIND, board=board, units='mm',
                  product={}, interfaces=(), keepouts=(), fixed=(),
-                 unknown=(), context={})
+                 unknown=(), proximity=(), context={})
 
 
 # --------------------------------------------------------------------------
@@ -214,6 +259,167 @@ def _band(value, where: str):
                          f"the band is empty or inverted and no pose can "
                          f"satisfy it")
     return {'from': f0, 'to': f1}
+
+
+def _proximity_pads(value, where: str, allowed):
+    """`{ref: [pad numbers]}`, or `"unknown"`, or absent. Returns as given.
+
+    Pad numbers are refused unless they are STRINGS, and that is not
+    pedantry: `Pad.pad_number` is a string on both parse paths, so a JSON `1`
+    would match nothing, resolve zero pads, and grade CLEAN -- a refusal that
+    reads as a pass, in the one direction nobody checks. #710's rule ("a typo'd
+    key that loads clean is a constraint the author believes they set") applied
+    one level down, to a value.
+    """
+    if value is None or value == UNKNOWN:
+        return value
+    if not isinstance(value, dict):
+        raise BriefError(f"{where}: expected {{'REF': ['1', '2']}} or "
+                         f"\"{UNKNOWN}\", got {value!r}")
+    for ref, nums in value.items():
+        if ref not in allowed:
+            raise BriefError(
+                f"{where}: a pad list for {ref!r}, which this row says nothing "
+                f"about -- it names {' and '.join(repr(a) for a in allowed)}. "
+                f"A pad list nothing reads is a claim nothing checks")
+        if not isinstance(nums, (list, tuple)) or not nums:
+            raise BriefError(f"{where}.{ref}: expected a non-empty list of pad "
+                             f"numbers, got {nums!r}")
+        for n in nums:
+            if not isinstance(n, str):
+                raise BriefError(
+                    f"{where}.{ref}: pad {n!r} has type "
+                    f"{type(n).__name__}; pad numbers are a list of strings. "
+                    f"`Pad.pad_number` is a string, so {n!r} would match no "
+                    f"pad, measure nothing, and grade clean")
+    return {str(k): [str(n) for n in v] for k, v in value.items()}
+
+
+def _proximity_rows(raw: Dict) -> List[Dict[str, object]]:
+    """Validate `proximity[]` (#902). One row = one claim = one limit.
+
+    `ref` may be a LIST -- "C1/C3 are U2's bulk caps" -- and it is pure sugar:
+    `compile_brief` expands it to one intent row per member, so the intent's
+    own `proximity[].ref` is always a string. The alternative reading, "every
+    pair within the list", was rejected because a 3-list would then be three
+    claims sharing one number and `Violation.ref` is a single ref with nowhere
+    to say which pair the limit was about. "Q1 and Q2 together" is already
+    exactly `{"ref": "Q1", "near": "Q2"}`, so nothing is lost.
+    """
+    rows: List[Dict[str, object]] = []
+    seen: Dict[Tuple[str, str], int] = {}
+    unpadded: Dict[Tuple[str, str], int] = {}
+    for i, r in enumerate(raw.get('proximity') or []):
+        where = f"proximity[{i}]"
+        if not isinstance(r, dict):
+            raise BriefError(f"{where}: expected an object with `ref`, `near` "
+                             f"and `max_mm`")
+        for key, why in _PROXIMITY_REFUSED_ROW.items():
+            if key in r:
+                raise BriefError(f"{where}: `{key}` is not a proximity key -- "
+                                 f"{why}")
+        fp._reject_unknown(r, _PROXIMITY_KEYS, where)
+        fp._entry_context(r, where)
+
+        ref = r.get('ref')
+        refs = list(ref) if isinstance(ref, (list, tuple)) else [ref]
+        if not refs or any(not isinstance(x, str) or not x for x in refs):
+            raise BriefError(f"{where}: `ref` must be a reference or a list of "
+                             f"references, got {ref!r}")
+        if UNKNOWN in refs:
+            raise BriefError(
+                f"{where}: `ref` cannot be \"{UNKNOWN}\". A row whose subject "
+                f"is unknown is not a row -- there is nothing to compile and "
+                f"nothing to name in the report. Omit it, or name the part")
+        if len(set(refs)) != len(refs):
+            raise BriefError(f"{where}: `ref` lists {ref!r}, which names a "
+                             f"part twice")
+        near = r.get('near')
+        if not near or not isinstance(near, str):
+            raise BriefError(f"{where}: needs `near` -- the part the "
+                             f"subject(s) must stay close to")
+        if near == UNKNOWN:
+            raise BriefError(
+                f"{where}: `near` cannot be \"{UNKNOWN}\", for the same reason "
+                f"`ref` cannot: a claim with no partner measures nothing")
+        if near in refs:
+            raise BriefError(f"{where}: {near!r} is both the subject and the "
+                             f"partner; a part is 0mm from itself, so this "
+                             f"row grades nothing")
+
+        if 'max_mm' not in r:
+            raise BriefError(
+                f"{where}: needs `max_mm` -- how far apart these parts may be, "
+                f"in mm. There is no default: the whole point of the key is "
+                f"that a number nobody stated cannot be graded. If the spec "
+                f"says \"as short as possible\" and names no number, write "
+                f"\"{UNKNOWN}\": it is carried and REPORTED rather than "
+                f"guessed")
+        limit = r['max_mm']
+        if limit != UNKNOWN:
+            fp._number(limit, f"{where}.max_mm", lo=0.0)
+            if float(limit) <= 0.0:
+                raise BriefError(f"{where}.max_mm: {limit!r}, expected a "
+                                 f"positive distance in mm")
+        basis = r.get('basis')
+        if basis == UNKNOWN:
+            raise BriefError(
+                f"{where}.basis: \"{UNKNOWN}\" is not allowed here, unlike "
+                f"every other enum in this file, because `basis` HAS a default "
+                f"({_PROXIMITY_DEFAULT_BASIS!r}). Declaring it unknown would "
+                f"compile to that default while the report says nobody knows "
+                f"-- two different documents. Omit the key to take the "
+                f"default, or name the one you mean")
+        if basis == 'courtyard':
+            raise BriefError(
+                f"{where}.basis: \"courtyard\" is not a basis. Since #896 "
+                f"`placement.body` is a LADDER -- courtyard, fab, silk union "
+                f"pads, pad bbox -- and it answers whichever rung the library "
+                f"drew. On the board this rule was written for, 0 of 21 "
+                f"footprints draw a courtyard (10 answer from fab, 4 from "
+                f"silk, 4 from the pad bbox), so a claim spelled \"courtyard\" "
+                f"would grade nothing there at all. Write \"body\"; the rung "
+                f"that actually answered is reported in "
+                f"`measured.basis_source`")
+        _enum(basis, _PROXIMITY_BASES, f"{where}.basis")
+        pads = _proximity_pads(r.get('pads'), f"{where}.pads",
+                              tuple(refs) + (near,))
+
+        for ref_one in refs:
+            key = (ref_one, near)
+            if key in seen:
+                raise BriefError(
+                    f"{where}: duplicate proximity claim for {ref_one} near "
+                    f"{near} (already declared at proximity[{seen[key]}]) -- "
+                    f"two limits on one relation, with no rule for which "
+                    f"wins, and the rule charges BOTH")
+            seen[key] = i
+        # The REVERSED pair, and only when NEITHER row names pads. `rect_gap`
+        # is symmetric and both sides are then existential, so the two rows are
+        # provably the same number -- one fact charged twice. With `pads` on
+        # either row the claim is genuinely asymmetric (for each of MY declared
+        # pads, some pad of yours is close enough), so both are kept.
+        if pads is None:
+            for ref_one in refs:
+                rev = (near, ref_one)
+                if rev in unpadded:
+                    raise BriefError(
+                        f"{where}: {ref_one} near {near} is the reverse of "
+                        f"proximity[{unpadded[rev]}], and neither row names "
+                        f"`pads` -- so the two are the same measurement "
+                        f"charged twice. Keep one, or name the pads that make "
+                        f"them different claims")
+                unpadded[(ref_one, near)] = i
+
+        row = {'ref': refs if isinstance(ref, (list, tuple)) else refs[0],
+               'near': near, 'max_mm': limit}
+        for key in ('basis', 'requirement', 'why', 'note', 'context'):
+            if r.get(key) is not None:
+                row[key] = r[key]
+        if pads is not None:
+            row['pads'] = pads
+        rows.append(row)
+    return rows
 
 
 def brief_from_dict(raw: Dict, source_path: str = '') -> Brief:
@@ -373,6 +579,8 @@ def _brief_from_dict(raw: Dict, source_path: str = '') -> Brief:
         fp._str_tuple(k.get('allow'), f"{where}.allow")
         keepouts.append(k)
 
+    proximity = _proximity_rows(raw)
+
     fixed: List[Dict[str, object]] = []
     for i, f in enumerate(raw.get('fixed') or []):
         where = f"fixed[{i}]"
@@ -389,7 +597,7 @@ def _brief_from_dict(raw: Dict, source_path: str = '') -> Brief:
                  board=str(raw.get('board') or ''), units=units,
                  product=product, interfaces=tuple(interfaces),
                  keepouts=tuple(keepouts), fixed=tuple(fixed),
-                 unknown=unknown,
+                 unknown=unknown, proximity=tuple(proximity),
                  context=fp._obj(raw.get('context'), 'context'),
                  source_path=source_path)
 
@@ -534,16 +742,79 @@ def compile_brief(brief: Brief, *, board_refs: Sequence[str] = (),
         keeps.append(out)
         declared.append(f"keepouts[{out['name']}]")
 
+    # #902. Compiled 1:1 into the intent's own `proximity[]`, with a list
+    # `ref` EXPANDED here so the intent never carries the sugar -- one row is
+    # one claim is one limit, and `Violation.ref` has room for exactly one ref.
+    prox: List[Dict[str, object]] = []
+    for r in brief.proximity:
+        near = str(r['near'])
+        raw_ref = r['ref']
+        members = ([str(x) for x in raw_ref]
+                   if isinstance(raw_ref, (list, tuple)) else [str(raw_ref)])
+        pads = r.get('pads')
+        for ref in members:
+            claim = f"proximity[{ref}~{near}]"
+            if r['max_mm'] == UNKNOWN:
+                # DECLARED, and declared UNKNOWN. "Y1 must be beside U1, I do
+                # not know how close" is the issue's own phrase ("as short as
+                # possible"), and it compiles to NO ROW: there is no number to
+                # grade against, and inventing one would be the guess this
+                # whole channel exists to refuse. It is reported, not dropped,
+                # so it cannot read as a key nobody wrote.
+                unknown.append(f"{claim}.max_mm")
+                continue
+            entry: Dict[str, object] = {
+                'ref': ref, 'near': near, 'max_mm': float(r['max_mm']),
+                'source': 'brief'}
+            ctx: Dict[str, object] = dict(r.get('context') or {})
+            for key in ('why', 'requirement'):
+                if r.get(key):
+                    ctx[key] = r[key]
+            entry['context'] = ctx
+            if r.get('basis'):
+                entry['basis'] = r['basis']
+            if pads == UNKNOWN:
+                # Also declared-unknown, but at a different arity: the row
+                # still grades, part to part, and the reader is told that the
+                # pin-level claim was not stated rather than left to infer it
+                # from a missing key.
+                unknown.append(f"{claim}.pads")
+            elif isinstance(pads, dict):
+                mine = {k: list(v) for k, v in pads.items()
+                        if k in (ref, near)}
+                if mine:
+                    entry['pads'] = mine
+            if r.get('note'):
+                entry['note'] = str(r['note'])
+            declared.append(f"{claim}.max_mm")
+            for who in (ref, near):
+                if refs_known and refset and who not in refset:
+                    unmatched.append(who)
+            prox.append(entry)
+
     fragment: Dict[str, object] = {}
     if conns:
         fragment['edge_connectors'] = conns
     if keeps:
         fragment['keepouts'] = keeps
+    if prox:
+        fragment['proximity'] = prox
+    # A RUNNING MAX, not a literal, since #902: a brief carrying both an
+    # along-edge claim and a proximity row needs the HIGHER of the two readers,
+    # and writing whichever branch ran last would understate it. `min_reader`
+    # is the one field whose only job is to be true.
+    need_reader = 0
     if wrote_along_edge:
         # The first real use of the mechanism `min_reader` was built for: a
         # reader that predates #712 must refuse this document rather than
         # grade it without the along-edge claim.
-        fragment['min_reader'] = 2
+        need_reader = max(need_reader, 2)
+    if prox:
+        # Same argument one version on: a reader that predates #902 must refuse
+        # a document carrying `proximity[]` rather than grade it without.
+        need_reader = max(need_reader, 4)
+    if need_reader:
+        fragment['min_reader'] = need_reader
 
     absent = [k for k in _TIER0
               if (k == 'interfaces' and not brief.interfaces)
@@ -560,7 +831,13 @@ def compile_brief(brief: Brief, *, board_refs: Sequence[str] = (),
         'contradictions': [],
         'counts': {'interfaces': len(brief.interfaces),
                    'keepouts': len(brief.keepouts),
-                   'fixed': len(brief.fixed)},
+                   'fixed': len(brief.fixed),
+                   # The count of ROWS AS WRITTEN, so it matches what the
+                   # author sees in their own file; `proximity_claims` is the
+                   # count after a list `ref` is expanded, which is what the
+                   # intent carries and what the grade will report.
+                   'proximity': len(brief.proximity),
+                   'proximity_claims': len(prox)},
         # #711 asks for `place_fixed` ops. There is no plan-op implementation
         # in this tree -- `place_fixed` is named only in comments -- so a
         # fixed pose is CARRIED and reported, never asserted, and never turned
@@ -643,6 +920,15 @@ def merge_into_intent(emitted: Dict, fragment: Dict, report: Dict) -> Dict:
     if fragment.get('keepouts'):
         out['keepouts'] = list(emitted.get('keepouts') or []) \
             + list(fragment['keepouts'])
+    # #902. APPENDED, like keepouts, and deliberately not the per-ref merge
+    # `edge_connectors` gets: there is no "declared outranks inferred" question
+    # to answer, because there is no inference. `emit_intent` writes no
+    # `proximity` -- a relation between two parts is not readable off a board,
+    # only the distance is -- so the emitted side is always empty and a
+    # reconciliation policy would be a rule for a case that cannot arise.
+    if fragment.get('proximity'):
+        out['proximity'] = list(emitted.get('proximity') or []) \
+            + list(fragment['proximity'])
     if fragment.get('min_reader'):
         out['min_reader'] = fragment['min_reader']
 
@@ -659,6 +945,16 @@ def merge_into_intent(emitted: Dict, fragment: Dict, report: Dict) -> Dict:
             f"emitter writes none; these came from the one channel that can "
             f"state one. Since #701 the seat search honours them, not only "
             f"the grade.")
+    if fragment.get('proximity'):
+        ctx['proximity_note'] = (
+            f"{len(fragment['proximity'])} proximity claim(s) DECLARED by the "
+            f"design brief {os.path.basename(report.get('path') or '')}. "
+            f"\"These two named parts, this far apart\" is a SPEC fact: the "
+            f"board supplies the distance but never the claim, so the emitter "
+            f"writes none and these came from the one channel that can state "
+            f"one. `rule_proximity` GRADES them; no search gates on them, so "
+            f"a violation is a finding to act on rather than a pose the "
+            f"engine will refuse.")
     out['context'] = ctx
     return out
 
@@ -688,6 +984,26 @@ def drift(intent_doc: Dict, fragment: Dict) -> List[str]:
         if k.get('name') not in names:
             out.append(f"keepout {k.get('name')!r}: declared by the brief, "
                        f"absent from the intent")
+    # #902. Keyed on the ORDERED (ref, near) pair, which is the row's identity
+    # in the brief too, so the two halves cannot disagree about what "the same
+    # claim" means. The list `ref` was expanded by `compile_brief`, so both
+    # sides here are already one-ref rows.
+    have_prox = {(str(p.get('ref')), str(p.get('near'))): p
+                 for p in (intent_doc.get('proximity') or [])}
+    for p in (fragment.get('proximity') or []):
+        key = (str(p.get('ref')), str(p.get('near')))
+        cur = have_prox.get(key)
+        if cur is None:
+            out.append(f"{key[0]} near {key[1]}: the brief declares this "
+                       f"proximity claim; the intent has no row for it")
+            continue
+        for field_name in ('max_mm', 'basis', 'pads'):
+            if field_name in p and cur.get(field_name) != p[field_name]:
+                out.append(
+                    f"{key[0]}~{key[1]}.{field_name}: brief says "
+                    f"{p[field_name]!r}, the intent "
+                    + ('says ' + repr(cur[field_name]) if field_name in cur
+                       else 'does not declare it'))
     return out
 
 
@@ -702,6 +1018,16 @@ def format_report(report: Dict, *, path: str = '') -> str:
     c = report.get('counts') or {}
     bits = [f"{c.get('interfaces', 0)} interface(s)",
             f"{c.get('keepouts', 0)} keep-out(s)"]
+    if c.get('proximity'):
+        # Printed whenever any row was written, even if every one of them
+        # declared `max_mm: "unknown"` and compiled to nothing -- a declared
+        # claim nobody prints is invisible, which is this module's own
+        # argument. The two counts differ exactly when a list `ref` expanded
+        # or an unknown limit dropped out, and both cases are worth seeing.
+        claims = c.get('proximity_claims', c['proximity'])
+        bits.append(f"{c['proximity']} proximity row(s)"
+                    + (f" -> {claims} claim(s)"
+                       if claims != c['proximity'] else ''))
     if c.get('fixed'):
         bits.append(f"{c['fixed']} fixed pose(s), carried not asserted")
     if report.get('unknown'):

--- a/py_placer/placement/design_brief.py
+++ b/py_placer/placement/design_brief.py
@@ -1328,13 +1328,47 @@ def _clause_state(rec, intent_doc, rules_run, abstained):
                                  f"{ref} near {near}", rule)
     if rule not in rules_run:
         return ('uncovered', f"`{rule}` did not run on this grade", rule)
-    prefix = (f"proximity[{ref}~{near}]." if kind == 'proximity'
-              else f"edge_connectors[{ref}]." if kind == 'interfaces' else None)
-    if prefix:
-        for akey, why in sorted((abstained or {}).items()):
-            if akey.startswith(prefix):
-                return 'abstained', why, rule
+    for akey, why in sorted((abstained or {}).items()):
+        if _abstention_is_about(akey, kind, ref, near, intent_doc):
+            return 'abstained', why, rule
     return 'graded', '', rule
+
+
+_ABSTAIN_PROX_RE = re.compile(r'^proximity\[(?P<row>\d+):')
+
+
+def _abstention_is_about(akey, kind, ref, near, intent_doc) -> bool:
+    """Does this abstention key name THIS clause?
+
+    Resolved through the intent's own ROW for a proximity claim, never by
+    matching `ref~near` as a string: a reference may contain `~`
+    (`disambiguate_references` produces `TP4~2`, and esp_prog parses
+    `Ref*~2`), so a row `A~B` near `C` and a row `A` near `B~C` spell the same
+    thing. The rule writes the row index into the key precisely so this lookup
+    can be exact rather than a prefix guess.
+    """
+    if kind == 'interfaces':
+        return akey.startswith(f"edge_connectors[{ref}].")
+    if kind != 'proximity':
+        return False
+    m = _ABSTAIN_PROX_RE.match(akey)
+    if m is None:
+        return False
+    rows = intent_doc.get('proximity') or []
+    row = int(m.group('row'))
+    if row >= len(rows):
+        return False
+    # BOTH halves must agree, and the negative control is what forced this:
+    # trusting the index alone attributed a key spelled `[0:Q1~Q2]` to
+    # whatever claim happened to sit at row 0. The index disambiguates the
+    # refs (a reference may contain `~`) and the text confirms the index, so a
+    # stale or hand-edited key attributes to nothing rather than to the wrong
+    # clause -- an abstention charged to an innocent claim is worse than one
+    # nobody attributes, because it reads as a finding about that claim.
+    if not akey.startswith(f"proximity[{row}:{ref}~{near}]"):
+        return False
+    return (str(rows[row].get('ref')) == ref
+            and str(rows[row].get('near')) == near)
 
 
 def clause_coverage(report: Dict, intent_doc: Dict, *,

--- a/py_placer/placement/design_brief.py
+++ b/py_placer/placement/design_brief.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 import fnmatch
 import json
+import math
 import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Tuple
@@ -128,9 +129,13 @@ _PROXIMITY_KEYS = {'ref', 'near', 'max_mm', 'basis', 'pads', 'requirement',
                    'why', 'note', 'context'}
 
 #: Which geometry the gap is measured between. Spelled `body` and NOT
-#: `courtyard` -- see `_PROXIMITY_REFUSED_ROW` for the measurement that decided
-#: it. Mirrors `floorplan._PROXIMITY_BASES`, and a test asserts the two agree:
-#: the brief must not accept a spelling the intent loader then refuses.
+#: `courtyard` -- the refusal below carries the measurement that decided it.
+#:
+#: This tuple and `floorplan`'s must agree, or the brief accepts a spelling the
+#: intent loader then refuses -- an author would see their own compiled
+#: document rejected. `tests/test_902_proximity.py` asserts the two are equal;
+#: until that test exists this comment is a promise, so it names the file
+#: rather than claiming a gate is already standing.
 _PROXIMITY_BASES = ('pad_edge', 'body')
 _PROXIMITY_DEFAULT_BASIS = 'pad_edge'
 
@@ -261,21 +266,58 @@ def _band(value, where: str):
     return {'from': f0, 'to': f1}
 
 
+def proximity_claim_id(row: int, ref: str, near: str) -> str:
+    """The name one proximity claim is reported under, everywhere (#902).
+
+    PUBLIC and shared, because this string is a contract between three places:
+    `compile_brief`'s `declared` / `unknown` lists, `check_floorplan`'s clause
+    coverage, and the close-out waiver an author types by hand. Three
+    hand-written f-strings would drift, and a waiver that no longer matches its
+    clause turns a working gate into one nobody can clear.
+
+    It carries the ROW INDEX and not just the two refs, and that is not
+    decoration. A reference may legally contain `~`: `disambiguate_references`
+    produces `TP4~2` for a duplicated refdes, and `esp_prog` itself parses
+    `Ref*` and `Ref*~2`. Without the index, a row `A~B` near `C` and a row `A`
+    near `B~C` both spell `proximity[A~B~C]` -- and since `unknown` is a SET
+    union, one of two DECLARED "I do not know"s silently disappeared. An index
+    is unique by construction, and a list `ref` cannot repeat a member (the
+    loader refuses that), so `(row, ref)` names exactly one claim.
+    """
+    return f"proximity[{row}:{ref}~{near}]"
+
+
 def _proximity_pads(value, where: str, allowed):
     """`{ref: [pad numbers]}`, or `"unknown"`, or absent. Returns as given.
 
-    Pad numbers are refused unless they are STRINGS, and that is not
-    pedantry: `Pad.pad_number` is a string on both parse paths, so a JSON `1`
-    would match nothing, resolve zero pads, and grade CLEAN -- a refusal that
-    reads as a pass, in the one direction nobody checks. #710's rule ("a typo'd
-    key that loads clean is a constraint the author believes they set") applied
-    one level down, to a value.
+    Pad numbers are refused unless they are STRINGS, and that is not pedantry:
+    `Pad.pad_number` is a string on both parse paths, so a JSON `1` would match
+    nothing, resolve zero pads, and grade CLEAN -- a refusal that reads as a
+    pass, in the one direction nobody checks. #710's rule ("a typo'd key that
+    loads clean is a constraint the author believes they set") applied one
+    level down, to a value.
+
+    It catches ONE SPELLING of that failure and not the failure: `"4"` on a
+    2-pad part is a well-typed name matching no pad, and no load-time check can
+    know that without the board. That is `rule_proximity`'s job -- it raises
+    `proximity_unresolved` for a pad name nothing matches -- and the split is
+    deliberate: the loader refuses what is wrong about the DOCUMENT, the rule
+    reports what is wrong about the document AGAINST A BOARD.
     """
     if value is None or value == UNKNOWN:
         return value
     if not isinstance(value, dict):
         raise BriefError(f"{where}: expected {{'REF': ['1', '2']}} or "
                          f"\"{UNKNOWN}\", got {value!r}")
+    if not value:
+        # An empty spec is not "no pads declared", it is a pads key that says
+        # nothing -- and letting it through made it a THIRD spelling of
+        # "unpadded" that the reversed-pair guard below did not recognise, so
+        # two contradictory limits on one symmetric measurement loaded clean.
+        raise BriefError(
+            f"{where}: an empty pad spec declares nothing. Omit `pads` to "
+            f"measure part to part, or write \"{UNKNOWN}\" to say the pins "
+            f"are not known -- both are reported; an empty object is not")
     for ref, nums in value.items():
         if ref not in allowed:
             raise BriefError(
@@ -309,7 +351,18 @@ def _proximity_rows(raw: Dict) -> List[Dict[str, object]]:
     rows: List[Dict[str, object]] = []
     seen: Dict[Tuple[str, str], int] = {}
     unpadded: Dict[Tuple[str, str], int] = {}
-    for i, r in enumerate(raw.get('proximity') or []):
+    got = raw.get('proximity')
+    if got is not None and not isinstance(got, list):
+        # Checked before the loop, because a STRING is iterable: `"unknown"`
+        # was refused, but as `proximity[0]: expected an object` about the
+        # character `u`. A refusal that names the wrong thing sends the author
+        # to the wrong line.
+        raise BriefError(
+            f"proximity: expected a list of rows, got "
+            f"{type(got).__name__}. There is no whole-key \"{UNKNOWN}\": the "
+            f"three states are per CLAIM, so an unknown limit is written "
+            f"`\"max_mm\": \"{UNKNOWN}\"` on the row it belongs to")
+    for i, r in enumerate(got or []):
         where = f"proximity[{i}]"
         if not isinstance(r, dict):
             raise BriefError(f"{where}: expected an object with `ref`, `near` "
@@ -358,6 +411,23 @@ def _proximity_rows(raw: Dict) -> List[Dict[str, object]]:
         limit = r['max_mm']
         if limit != UNKNOWN:
             fp._number(limit, f"{where}.max_mm", lo=0.0)
+            # FINITE first, and it has to be checked explicitly: `inf` and
+            # `nan` both pass a `lo=0.0` bound and a `<= 0.0` guard, because
+            # `inf < 0` and `nan <= 0` are both False. `json.load` accepts the
+            # literals `Infinity` and `NaN`, so this is reachable from a real
+            # sibling file. An `inf` limit grades clean forever and a `nan`
+            # limit makes every comparison False -- both are a declared
+            # constraint that can never fail, which is this channel's own
+            # definition of the bug, and both would also make the emitted
+            # intent non-RFC JSON that a strict reader rejects.
+            if not math.isfinite(float(limit)):
+                raise BriefError(
+                    f"{where}.max_mm: {limit!r} is not a finite distance. A "
+                    f"limit of infinity can never be exceeded and a NaN limit "
+                    f"fails every comparison, so either would be a declared "
+                    f"claim nothing can ever violate. If the spec names no "
+                    f"number, write \"{UNKNOWN}\" -- it is carried and "
+                    f"REPORTED rather than silently satisfied")
             if float(limit) <= 0.0:
                 raise BriefError(f"{where}.max_mm: {limit!r}, expected a "
                                  f"positive distance in mm")
@@ -376,11 +446,12 @@ def _proximity_rows(raw: Dict) -> List[Dict[str, object]]:
                 f"`placement.body` is a LADDER -- courtyard, fab, silk union "
                 f"pads, pad bbox -- and it answers whichever rung the library "
                 f"drew. On the board this rule was written for, 0 of 21 "
-                f"footprints draw a courtyard (10 answer from fab, 4 from "
-                f"silk, 4 from the pad bbox), so a claim spelled \"courtyard\" "
-                f"would grade nothing there at all. Write \"body\"; the rung "
-                f"that actually answered is reported in "
-                f"`measured.basis_source`")
+                f"footprints draw a courtyard -- 10 answer from fab, 4 from "
+                f"silk, 4 from the pad bbox and 3 draw nothing at all -- so a "
+                f"claim spelled \"courtyard\" would grade nothing there. Write "
+                f"\"body\": the gap is then measured between the drawn bodies, "
+                f"and the rung each one came from is reported beside the "
+                f"number so it is never read without knowing what it rests on")
         _enum(basis, _PROXIMITY_BASES, f"{where}.basis")
         pads = _proximity_pads(r.get('pads'), f"{where}.pads",
                               tuple(refs) + (near,))
@@ -394,22 +465,37 @@ def _proximity_rows(raw: Dict) -> List[Dict[str, object]]:
                     f"two limits on one relation, with no rule for which "
                     f"wins, and the rule charges BOTH")
             seen[key] = i
-        # The REVERSED pair, and only when NEITHER row names pads. `rect_gap`
-        # is symmetric and both sides are then existential, so the two rows are
-        # provably the same number -- one fact charged twice. With `pads` on
-        # either row the claim is genuinely asymmetric (for each of MY declared
-        # pads, some pad of yours is close enough), so both are kept.
-        if pads is None:
-            for ref_one in refs:
-                rev = (near, ref_one)
-                if rev in unpadded:
-                    raise BriefError(
-                        f"{where}: {ref_one} near {near} is the reverse of "
-                        f"proximity[{unpadded[rev]}], and neither row names "
-                        f"`pads` -- so the two are the same measurement "
-                        f"charged twice. Keep one, or name the pads that make "
-                        f"them different claims")
-                unpadded[(ref_one, near)] = i
+        # The REVERSED pair, and only when NEITHER row carries an EFFECTIVE pad
+        # spec. `rect_gap` is symmetric and both sides are then existential, so
+        # the two rows are provably the same number -- one fact charged twice.
+        # With real `pads` on either row the claim is genuinely asymmetric (for
+        # each of MY declared pads, some pad of yours is close enough), so both
+        # are kept.
+        #
+        # "Effective" and not `pads is None`, because there are THREE spellings
+        # of unpadded and keying on one of them let the other two through: an
+        # absent key, `"unknown"` (declared, but still measured part to part),
+        # and -- until it was refused above -- an empty object. A brief
+        # declaring 5mm one way and 9mm the other loaded clean.
+        #
+        # And the asymmetry that matters is a SUBJECT pad list specifically:
+        # `pads[ref]` is what turns the existential min into "for EACH of my
+        # pads", which is the quantifier the rule's own invariant rests on. A
+        # list naming only the partner leaves both rows existential, so it is
+        # still the same measurement.
+        for ref_one in refs:
+            if isinstance(pads, dict) and pads.get(ref_one):
+                continue
+            rev = (near, ref_one)
+            if rev in unpadded:
+                raise BriefError(
+                    f"{where}: {ref_one} near {near} is the reverse of "
+                    f"proximity[{unpadded[rev]}], and neither row names a "
+                    f"`pads` list for its own subject -- so the two are the "
+                    f"same symmetric measurement charged twice, with no rule "
+                    f"for which limit wins. Keep one, or name the pads that "
+                    f"make them different claims")
+            unpadded[(ref_one, near)] = i
 
         row = {'ref': refs if isinstance(ref, (list, tuple)) else refs[0],
                'near': near, 'max_mm': limit}
@@ -746,14 +832,28 @@ def compile_brief(brief: Brief, *, board_refs: Sequence[str] = (),
     # `ref` EXPANDED here so the intent never carries the sugar -- one row is
     # one claim is one limit, and `Violation.ref` has room for exactly one ref.
     prox: List[Dict[str, object]] = []
-    for r in brief.proximity:
+    expanded = dropped = 0
+    for i, r in enumerate(brief.proximity):
         near = str(r['near'])
         raw_ref = r['ref']
         members = ([str(x) for x in raw_ref]
                    if isinstance(raw_ref, (list, tuple)) else [str(raw_ref)])
+        if len(members) > 1:
+            expanded += 1
         pads = r.get('pads')
         for ref in members:
-            claim = f"proximity[{ref}~{near}]"
+            claim = proximity_claim_id(i, ref, near)
+            # Reported BEFORE the unknown-limit branch below, not inside the
+            # compiled arm: an author who wrote two "I do not know"s must see
+            # two. Reporting it after the `continue` recorded only the limit,
+            # and a declared unknown that vanishes is the failure this module's
+            # second design rule is written against.
+            if pads == UNKNOWN:
+                # Declared-unknown at a different arity from the limit: with a
+                # limit the row still grades, part to part, and the reader is
+                # told the pin-level claim was not stated rather than left to
+                # infer that from an absent key.
+                unknown.append(f"{claim}.pads")
             if r['max_mm'] == UNKNOWN:
                 # DECLARED, and declared UNKNOWN. "Y1 must be beside U1, I do
                 # not know how close" is the issue's own phrase ("as short as
@@ -762,24 +862,24 @@ def compile_brief(brief: Brief, *, board_refs: Sequence[str] = (),
                 # whole channel exists to refuse. It is reported, not dropped,
                 # so it cannot read as a key nobody wrote.
                 unknown.append(f"{claim}.max_mm")
+                dropped += 1
                 continue
             entry: Dict[str, object] = {
                 'ref': ref, 'near': near, 'max_mm': float(r['max_mm']),
                 'source': 'brief'}
             ctx: Dict[str, object] = dict(r.get('context') or {})
+            # The SOURCE row, so an expanded member can be traced back to the
+            # line the author wrote -- `interfaces[]` carries the same key for
+            # the same reason, and without it a list `ref` compiles to rows
+            # whose origin is unrecoverable.
+            ctx['brief_row'] = i
             for key in ('why', 'requirement'):
                 if r.get(key):
                     ctx[key] = r[key]
             entry['context'] = ctx
             if r.get('basis'):
                 entry['basis'] = r['basis']
-            if pads == UNKNOWN:
-                # Also declared-unknown, but at a different arity: the row
-                # still grades, part to part, and the reader is told that the
-                # pin-level claim was not stated rather than left to infer it
-                # from a missing key.
-                unknown.append(f"{claim}.pads")
-            elif isinstance(pads, dict):
+            if isinstance(pads, dict):
                 mine = {k: list(v) for k, v in pads.items()
                         if k in (ref, near)}
                 if mine:
@@ -820,24 +920,43 @@ def compile_brief(brief: Brief, *, board_refs: Sequence[str] = (),
               if (k == 'interfaces' and not brief.interfaces)
               or (k.startswith('product.')
                   and brief.product.get(k.split('.', 1)[1]) is None)]
+    counts: Dict[str, object] = {'interfaces': len(brief.interfaces),
+                                 'keepouts': len(brief.keepouts),
+                                 'fixed': len(brief.fixed)}
+    if brief.proximity:
+        # Added ONLY when the brief declares any, so a brief that declares none
+        # produces the same `counts` dict it produced before this key existed
+        # -- and `counts` is emitted verbatim as `design_brief.counts` by
+        # board_brief, so an unconditional key would change a machine-readable
+        # document for every board on the corpus to say "zero of a thing you
+        # never mentioned".
+        #
+        # `proximity` is the count of ROWS AS WRITTEN, so it matches what the
+        # author sees in their own file. `proximity_claims` is the count after
+        # a list `ref` expands and an unknown limit drops out -- what the
+        # intent carries and what the grade will report. `proximity_expanded`
+        # and `proximity_dropped` are kept because the two counts can CANCEL
+        # (one row expanding by one and another dropping) and then a bare
+        # comparison discloses nothing.
+        counts.update({'proximity': len(brief.proximity),
+                       'proximity_claims': len(prox),
+                       'proximity_expanded': expanded,
+                       'proximity_dropped': dropped})
     report = {
         'path': brief.source_path,
         'declared': sorted(declared),
         'unknown': sorted(set(unknown) | set(brief.unknown)),
         'absent': absent,
         'not_graded': sorted(not_graded),
-        'unmatched': sorted(unmatched),
+        # DEDUPED since #902. A proximity row names two refs and a list `ref`
+        # names `near` once per member, so an absent partner used to be
+        # reported once per member -- check_floorplan printed its "brief names
+        # ZZ9, which is not on this board" line twice for one missing part.
+        # Impossible before, because a duplicate `interfaces[].ref` is refused.
+        'unmatched': sorted(set(unmatched)),
         'unmatched_checked': bool(refs_known and (board_refs or ())),
         'contradictions': [],
-        'counts': {'interfaces': len(brief.interfaces),
-                   'keepouts': len(brief.keepouts),
-                   'fixed': len(brief.fixed),
-                   # The count of ROWS AS WRITTEN, so it matches what the
-                   # author sees in their own file; `proximity_claims` is the
-                   # count after a list `ref` is expanded, which is what the
-                   # intent carries and what the grade will report.
-                   'proximity': len(brief.proximity),
-                   'proximity_claims': len(prox)},
+        'counts': counts,
         # #711 asks for `place_fixed` ops. There is no plan-op implementation
         # in this tree -- `place_fixed` is named only in comments -- so a
         # fixed pose is CARRIED and reported, never asserted, and never turned
@@ -930,7 +1049,17 @@ def merge_into_intent(emitted: Dict, fragment: Dict, report: Dict) -> Dict:
         out['proximity'] = list(emitted.get('proximity') or []) \
             + list(fragment['proximity'])
     if fragment.get('min_reader'):
-        out['min_reader'] = fragment['min_reader']
+        # A MAX here too, and for the same reason it is one inside the
+        # fragment: an emitted document that already declares a reader must not
+        # be talked DOWN by a brief that needs a lower one. Unreachable today
+        # (`emit_intent` writes no `min_reader`) and one emitter change away
+        # from silently understating the reader a document needs -- which is a
+        # false statement in the one field whose only job is to be true.
+        try:
+            have = int(out.get('min_reader') or 0)
+        except (TypeError, ValueError):
+            have = 0
+        out['min_reader'] = max(have, int(fragment['min_reader']))
 
     ctx = dict(out.get('context') or {})
     ctx['brief'] = {k: report[k] for k in
@@ -997,12 +1126,26 @@ def drift(intent_doc: Dict, fragment: Dict) -> List[str]:
             out.append(f"{key[0]} near {key[1]}: the brief declares this "
                        f"proximity claim; the intent has no row for it")
             continue
+        # Compared at the EFFECTIVE value, not `if field_name in p`. The brief
+        # writes `basis` only when it is non-default, so a brief meaning the
+        # documented default read as "declares nothing" and an intent row
+        # saying `basis: "body"` drifted silently -- the grade would then have
+        # measured bodies against a clause written about pads, and reported no
+        # drift. A key absent on BOTH sides is not drift; a key absent on one
+        # and declared on the other is.
+        _defaults = {'basis': _PROXIMITY_DEFAULT_BASIS}
         for field_name in ('max_mm', 'basis', 'pads'):
-            if field_name in p and cur.get(field_name) != p[field_name]:
+            mine = p.get(field_name, _defaults.get(field_name))
+            theirs = cur.get(field_name, _defaults.get(field_name))
+            if mine is None and theirs is None:
+                continue
+            if mine != theirs:
                 out.append(
-                    f"{key[0]}~{key[1]}.{field_name}: brief says "
-                    f"{p[field_name]!r}, the intent "
-                    + ('says ' + repr(cur[field_name]) if field_name in cur
+                    f"{key[0]}~{key[1]}.{field_name}: brief "
+                    + (f"says {mine!r}" if mine is not None
+                       else 'declares none')
+                    + ', the intent '
+                    + (f"says {theirs!r}" if theirs is not None
                        else 'does not declare it'))
     return out
 
@@ -1022,12 +1165,17 @@ def format_report(report: Dict, *, path: str = '') -> str:
         # Printed whenever any row was written, even if every one of them
         # declared `max_mm: "unknown"` and compiled to nothing -- a declared
         # claim nobody prints is invisible, which is this module's own
-        # argument. The two counts differ exactly when a list `ref` expanded
-        # or an unknown limit dropped out, and both cases are worth seeing.
+        # argument.
+        #
+        # The `-> N claim(s)` suffix keys on the EVENTS, not on whether the two
+        # counts differ. They can cancel exactly: one row expanding by one
+        # while another drops out leaves 3 rows and 3 claims, and the first
+        # version of this line then printed nothing at all -- on the very brief
+        # this feature was built for.
         claims = c.get('proximity_claims', c['proximity'])
+        moved = c.get('proximity_expanded') or c.get('proximity_dropped')
         bits.append(f"{c['proximity']} proximity row(s)"
-                    + (f" -> {claims} claim(s)"
-                       if claims != c['proximity'] else ''))
+                    + (f" -> {claims} claim(s)" if moved else ''))
     if c.get('fixed'):
         bits.append(f"{c['fixed']} fixed pose(s), carried not asserted")
     if report.get('unknown'):

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -534,6 +534,26 @@ def _proximity_claims(raw: Dict) -> List[Dict]:
                 f"about one relation, with no rule for which wins, and the "
                 f"grade would charge BOTH")
         seen[(ref, near)] = i
+        # The REVERSED pair, when neither row names a SUBJECT pad list -- the
+        # same refusal `design_brief` makes, and it has to be made here too:
+        # this loader exists for the HAND-WRITTEN intent, which never passes
+        # through the brief compiler. Without it the two documents disagreed
+        # about the same rows, and the grade charged one symmetric measurement
+        # twice, reporting an identical number under two claims.
+        #
+        # A subject pad list is what turns the existential minimum into "for
+        # EACH of my pads", so with one on either side the two rows really are
+        # different claims and both are kept.
+        if not (p.get('pads') or {}).get(ref) and (near, ref) in seen:
+            j = seen[(near, ref)]
+            if not ((got[j].get('pads') or {}).get(near)):
+                raise IntentError(
+                    f"{where} ({ref} near {near}): the reverse of "
+                    f"proximity[{j}], and neither row names a `pads` list for "
+                    f"its own subject -- so the two are the same symmetric "
+                    f"measurement declared twice, with no rule for which "
+                    f"claim wins. Keep one, or name the pads that make them "
+                    f"different claims")
         if 'max_mm' not in p:
             raise IntentError(f"{where} ({ref}): needs `max_mm`, the distance "
                               f"in mm these parts may be apart")
@@ -1514,6 +1534,7 @@ class _Ctx:
         self._supply_pins = None
         self._assembly_census = None
         self._bodies = None
+        self._bodies_error = ''
 
     def assembly_census(self) -> Dict[str, object]:
         """#837's per-side census, memoised. The SAME function
@@ -1536,26 +1557,52 @@ class _Ctx:
         reach neither parse path), and no board without a proximity claim may
         pay for that.
 
-        `body_local` and NOT `occupancy_local`: occupancy is the body UNIONED
-        with the pad bbox, which is the right answer for "may something be
-        seated here" and the wrong one for "how far apart are these two
-        parts" -- it would also make `body` a superset of `pad_edge` rather
-        than a second, independent currency.
+        THE DRAWN body, `drawn_local`, and not `body_local`. #896 stores two
+        ladders on purpose and says why: a courtyard "is not a body -- it is a
+        body plus an assembly margin plus any shell overhang", and
+        `body_local` is courtyard-FIRST. Reading it would have made
+        `basis: "body"` silently measure courtyards on any board that draws
+        them, under-stating every gap by the assembly margin and passing
+        claims that should fail -- while `basis: "courtyard"` is refused BY
+        NAME on the grounds that boards do not draw them. The fixture this
+        rule was written against draws 0 courtyards of 21, so no test here
+        could ever have seen it.
+
+        `drawn_local` is `fab`, else `silk` unioned with the pads. When the
+        library drew NEITHER it is None, and the fall-back is the pad bbox
+        from `body_local` -- reported as `pad_bbox`, so a reader always knows
+        the number rests on copper rather than on a drawn outline. That
+        fall-back is what lets a transistor pair sharing no net be measured at
+        all, which is the case the second basis exists for.
+
+        `occupancy_local` is deliberately never used: it is the body unioned
+        with the pads, which answers "may something be seated here" and would
+        make `body` a superset of `pad_edge` rather than a second currency.
         """
         if self._bodies is None:
             from .body import board_bodies
             try:
                 self._bodies = board_bodies(self.pcb, self.pcb_file)
-            except Exception:                                # noqa: BLE001
+            except Exception as exc:                         # noqa: BLE001
+                # Remembered, and reported as ITSELF. Falling through to the
+                # "this part draws no body" reason would tell an author a
+                # false fact about their board and send them to fix a
+                # footprint that is fine.
                 self._bodies = {}
+                self._bodies_error = f"{type(exc).__name__}: {exc}"
         geom = self._bodies.get(ref)
         fp_obj = self.pcb.footprints.get(ref)
-        if geom is None or geom.body_local is None or fp_obj is None:
-            return None, (geom.source if geom is not None else 'none')
+        rect_local = None if geom is None else (geom.drawn_local
+                                                or geom.body_local)
+        source = 'none' if geom is None else (geom.drawn_source
+                                              if geom.drawn_local is not None
+                                              else geom.source)
+        if rect_local is None or fp_obj is None:
+            return None, source
         x0, y0, x1, y1 = legality.rotate_local_bounds(
-            *geom.body_local, fp_obj.rotation or 0.0)
+            *rect_local, fp_obj.rotation or 0.0)
         return ((fp_obj.x + x0, fp_obj.y + y0, fp_obj.x + x1, fp_obj.y + y1),
-                geom.source)
+                source)
 
     def sev(self, rule: str) -> str:
         return self.intent.severity_of(rule)
@@ -3205,12 +3252,17 @@ def rule_proximity(ctx) -> Iterator[Violation]:
         basis = claim.get('basis', _PROXIMITY_DEFAULT_BASIS)
         spec = claim.get('pads') or {}
         where = f"proximity[{i}]"
-        # The abstention key is keyed on the CLAIM's identity, not on its row
-        # index, so a consumer reporting per-clause coverage can attribute an
-        # abstention to the clause that caused it. `(ref, near)` is unique --
-        # the loader refuses a duplicate -- and it survives a re-ordered
-        # intent, which an index does not.
-        akey = f"proximity[{ref}~{near}]"
+        # The abstention key carries the INTENT ROW INDEX as well as the two
+        # refs, so a consumer reporting per-clause coverage can attribute an
+        # abstention to the claim that caused it. The index is not decoration:
+        # a reference may legally contain `~` (`disambiguate_references`
+        # produces `TP4~2`, and this very board parses `Ref*~2`), so a bare
+        # `ref~near` makes a row `A~B` near `C` and a row `A` near `B~C` share
+        # one string -- and `ctx.abstained` is a DICT, so one of the two
+        # abstentions would silently disappear. The index is unique by
+        # construction, and a consumer resolves it against the intent's own
+        # row to recover the pair exactly.
+        akey = f"proximity[{i}:{ref}~{near}]"
 
         a_fp = ctx.pcb.footprints.get(ref)
         b_fp = ctx.pcb.footprints.get(near)
@@ -3235,14 +3287,23 @@ def rule_proximity(ctx) -> Iterator[Violation]:
             a_rect, a_src = ctx.body_rect(ref)
             b_rect, b_src = ctx.body_rect(near)
             if a_rect is None or b_rect is None:
-                blind = [r for r, rect in ((ref, a_rect), (near, b_rect))
-                         if rect is None]
-                ctx.abstain(
-                    f"{akey}.basis",
-                    f"{' and '.join(blind)} draws no body and has no pads, so "
-                    f"placement.body answers source 'none' -- there is no "
-                    f"geometry to measure. Name pads and use basis pad_edge, "
-                    f"or drop the claim")
+                nogeom = [r for r, rect in ((ref, a_rect), (near, b_rect))
+                          if rect is None]
+                # The READER's own failure is reported as itself. Falling
+                # through to "draws no body" would state a false fact about
+                # the author's board and send them to fix a footprint that is
+                # fine -- on the fixture here both parts draw a body and carry
+                # 4 and 20 pads.
+                why = (f"placement.body could not be read for this board "
+                       f"({ctx._bodies_error}), so no body claim can be "
+                       f"measured -- this is a failure of the geometry "
+                       f"reader, not of {' or '.join(nogeom)}"
+                       if ctx._bodies_error else
+                       f"{' and '.join(nogeom)} draws no body and has no "
+                       f"pads, so placement.body answers source 'none' -- "
+                       f"there is no geometry to measure. Name pads and use "
+                       f"basis pad_edge, or drop the claim")
+                ctx.abstain(f"{akey}.basis", why)
                 continue
             gap = legality.rect_gap(a_rect, b_rect)
             if gap <= limit + legality.EPS:
@@ -3265,23 +3326,47 @@ def rule_proximity(ctx) -> Iterator[Violation]:
                    else list(a_fp.pads or ()))
         partners = (_pads_named(b_fp, spec[near]) if spec.get(near)
                     else list(b_fp.pads or ()))
-        # A NAME that matches nothing is unresolved, not clean. The loader can
-        # refuse a pad number of the wrong TYPE; only here, holding a board,
-        # can "pad 7 of a 4-pad part" be seen at all.
+        # A NAME that matches nothing is unresolved, not clean -- and it is
+        # reported PER NAME, not only when every name misses. The first
+        # version fired on `not got`, so `pads: {'Y1': ['2', '7']}` graded
+        # CLEAN on the survivor while `'7'` vanished: the claim then measured
+        # a strictly smaller subject set than it declared, which is the very
+        # failure the loader cites when it refuses an integer pad number
+        # ("would match no pad, measure nothing, and grade clean"). It also
+        # falsified this rule's own invariant, which is quantified over the
+        # pads the claim DECLARES and not over the ones that happened to
+        # resolve.
+        #
+        # The loader can refuse a pad number of the wrong TYPE; only here,
+        # holding a board, can "pad 7 of a 4-pad part" be seen at all.
+        blind = False
         for who, names, got in ((ref, spec.get(ref), subject),
                                 (near, spec.get(near), partners)):
-            if names and not got:
-                yield Violation(
-                    rule='proximity_unresolved', severity=sev_unres,
-                    ref=ref, block=ctx.owner.get(ref),
-                    message=(f"{where}: {who} has no pad numbered "
-                             f"{', '.join(repr(n) for n in names)} -- the "
-                             f"claim names pads this part does not have, so it "
-                             f"measures nothing"),
-                    measured={'unresolved_ref': who, 'pads': list(names),
-                              'near': near},
-                    expected={'max_mm': limit})
-        if (spec.get(ref) and not subject) or (spec.get(near) and not partners):
+            if not names:
+                continue
+            have = {p.pad_number for p in got}
+            missing = [n for n in names if n not in have]
+            if not missing:
+                continue
+            blind = True
+            yield Violation(
+                rule='proximity_unresolved', severity=sev_unres,
+                ref=ref, block=ctx.owner.get(ref),
+                message=(f"{where}: {who} has no pad numbered "
+                         f"{', '.join(repr(n) for n in missing)}"
+                         + (f" (it has {', '.join(sorted(repr(p.pad_number) for p in (b_fp if who == near else a_fp).pads or ()))})"
+                            if len(missing) == len(names) else
+                            f" -- {len(names) - len(missing)} of "
+                            f"{len(names)} named pad(s) resolved, so the "
+                            f"claim would measure less than it declares")),
+                measured={'unresolved_ref': who, 'pads': list(missing),
+                          'declared_pads': list(names),
+                          'resolved_pads': len(names) - len(missing),
+                          'near': near},
+                expected={'max_mm': limit})
+        if blind:
+            # Not measured at all: a distance taken over a subject set smaller
+            # than the claim declares is a number about a different claim.
             continue
         if not subject or not partners:
             ctx.abstain(
@@ -3305,10 +3390,11 @@ def rule_proximity(ctx) -> Iterator[Violation]:
             got = _proximity_reach(pad, partners, net_match=declared)
             if got is not None:
                 reaches.append((got[0], pad, got[1], got[2]))
-        if not reaches:
-            ctx.abstain(f"{akey}.pads",
-                        f"no pad of {ref} could be measured against {near}")
-            continue
+        # No `if not reaches` arm: `partners` is proven non-empty by the guard
+        # above and `_proximity_reach` falls back to it, so it never returns
+        # None here. An arm that cannot run is not a safety net -- it is a
+        # claim about the code that no test can check, and this one survived
+        # being replaced by `raise AssertionError`.
         if not declared:
             reaches = [min(reaches, key=lambda t: t[0])]
         for gap, pad, partner, how in reaches:

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -109,13 +109,24 @@ EDGE_BAND_SANITY_MM = 5.0
 #: same reasoning as 2 applies -- the unknown-key refusal already protects an
 #: older build, and the bump is about `min_reader` being able to name the
 #: version that can act on the claim.
-READER_VERSION = 3
+#:
+#: 4 (#902): `proximity[]` -- "these two named parts, this far apart". The one
+#: class of constraint the netlist IMPLIES and nothing here could read: a 3mm
+#: crystal loop and a 30mm one have identical connectivity, so no instrument
+#: that reads the board can tell them apart. Declarable, and it changes the
+#: exit code, so the rule above mandates the bump. The same reasoning as 2 and
+#: 3 -- the unknown-key refusal already protects an older build (it raises
+#: `unknown key(s) proximity` and refuses the file), so the bump is not for
+#: SAFETY. It is because `READER_VERSION` is the number `compile_brief` copies
+#: into `min_reader`, and at 3 a brief-compiled intent would claim a reader-3
+#: build acts on a claim it has never heard of.
+READER_VERSION = 4
 
 _TOP_LEVEL_KEYS = {
     'schema', 'kind', 'board', 'units', 'envelope', 'defaults', 'blocks',
     'keepouts', 'edge_connectors', 'decaps', 'must_lock', 'legality_budget',
     'health', 'severity', 'context', 'overlap_waivers', 'min_reader',
-    'assembly',
+    'assembly', 'proximity',
 }
 _BLOCK_KEYS = {'name', 'group', 'refs', 'zone', 'side', 'exclusive',
                'tolerance_mm', 'note', 'context'}
@@ -176,6 +187,30 @@ _CENTER_ON_EDGE_KEYS = {'tolerance_mm'}
 _ALONG_EDGE_BAND_KEYS = {'from', 'to'}
 _DECAP_KEYS = {'max_distance_mm', 'exempt', 'search_radius_mm',
                'max_pin_distance_mm', 'pin_functions', 'same_side'}
+#: #902. One declared claim: these two named parts, no further apart than
+#: `max_mm`. `ref` is always a SINGLE ref here -- the brief's list form is
+#: sugar that `compile_brief` expands, so the intent carries one row per claim
+#: and `Violation.ref` always has a ref to name.
+#:
+#: No `why` / `requirement`: prose lives in `context`, which is this schema's
+#: own rule, and the brief compiler moves them there exactly as it does for
+#: `interfaces[]`.
+_PROXIMITY_KEYS = {'ref', 'near', 'max_mm', 'basis', 'pads', 'note', 'source',
+                   'context'}
+#: Which geometry the gap is measured between.
+#:
+#: `pad_edge` is pad copper to pad copper -- the currency `decap_pin_distance`
+#: already uses, so a reader meets one definition of "how far apart" rather
+#: than two. `body` measures #896's drawn bodies, and it exists because two
+#: parts a brief wants "together" may share no net at all: an auto-reset
+#: transistor pair has no pad pair to measure.
+#:
+#: `courtyard` is deliberately NOT a spelling, and `design_brief` refuses it by
+#: name with the measurement that decided it -- `placement.body` is a ladder,
+#: and on the board this rule was written for 0 of 21 footprints draw a
+#: courtyard, so the word would name geometry the board does not have.
+_PROXIMITY_BASES = ('pad_edge', 'body')
+_PROXIMITY_DEFAULT_BASIS = 'pad_edge'
 _DEFAULTS_KEYS = {'zone_tolerance_mm'}
 #: `zoned_blocks` is setdefault-injected into this same dict by `grade` after
 #: load, and `affinity_exempt_net_ids` is derived there from
@@ -292,6 +327,14 @@ class Intent:
     # the honest "nobody asked" reason rather than grading a board against a
     # policy nothing states.
     assembly: Dict[str, object] = field(default_factory=dict)
+    # #902. Declared proximity claims, one row per (ref, near) pair. NEVER
+    # emitted: a relation between two parts is not readable off a board -- the
+    # board supplies the distance and never the claim -- so an emitter writing
+    # one would be blessing the current pose as the spec, which is the
+    # emit-then-grade round trip this file guards against everywhere else.
+    # Defaulted, so every existing `Intent(...)` construction site is
+    # untouched and an intent declaring none behaves exactly as before.
+    proximity: Tuple[Dict[str, object], ...] = ()
 
     def assembly_sides(self) -> str:
         """The declared policy, or 'both' -- which constrains nothing.
@@ -442,6 +485,93 @@ def _number(value, where: str, lo=None, hi=None) -> float:
                else (f">= {lo}" if lo is not None else f"<= {hi}"))
         raise IntentError(f"{where}: expected {rng}, got {v!r}")
     return v
+
+
+def _proximity_claims(raw: Dict) -> List[Dict]:
+    """Validate `proximity[]` (#902), AT LOAD.
+
+    At load and not in `validate_intent`, the deviation `_along_edge_claim`
+    already documents and for the same reason: `validate_intent` has exactly
+    one caller -- `grade()` -- while `place_seed` and `place_reconstruct` load
+    an intent and never call it. A refusal that lived there would leave those
+    holding a row whose `pads` is a number.
+
+    Pad numbers are refused unless they are STRINGS. `Pad.pad_number` is a
+    string on both parse paths, so a JSON `1` matches no pad, resolves an empty
+    set, and grades CLEAN -- a refusal that reads as a pass, in the one
+    direction nobody checks. `design_brief` refuses the same shape at its own
+    level; this is the second reader of the same document, and a document that
+    can reach the grade by a path that skips the brief (a hand-written intent)
+    must not be graded on a claim that cannot resolve.
+    """
+    got = raw.get('proximity')
+    if got is not None and not isinstance(got, list):
+        raise IntentError(f"proximity: expected a list of claims, got "
+                          f"{type(got).__name__}")
+    out: List[Dict] = []
+    seen: Dict[Tuple[str, str], int] = {}
+    for i, p in enumerate(got or []):
+        where = f"proximity[{i}]"
+        if not isinstance(p, dict):
+            raise IntentError(f"{where}: expected an object with `ref`, "
+                              f"`near` and `max_mm`")
+        _reject_unknown(p, _PROXIMITY_KEYS, where)
+        _entry_context(p, where)
+        ref, near = p.get('ref'), p.get('near')
+        for name, val in (('ref', ref), ('near', near)):
+            if not val or not isinstance(val, str):
+                raise IntentError(
+                    f"{where}: `{name}` must be a single reference. The "
+                    f"brief's list form is sugar that `compile_brief` expands, "
+                    f"so an intent row names exactly one part on each side")
+        if ref == near:
+            raise IntentError(f"{where} ({ref}): the subject and the partner "
+                              f"are the same part, which is 0mm from itself")
+        if (ref, near) in seen:
+            raise IntentError(
+                f"{where} ({ref} near {near}): duplicate claim, already "
+                f"declared at proximity[{seen[(ref, near)]}] -- two claims "
+                f"about one relation, with no rule for which wins, and the "
+                f"grade would charge BOTH")
+        seen[(ref, near)] = i
+        if 'max_mm' not in p:
+            raise IntentError(f"{where} ({ref}): needs `max_mm`, the distance "
+                              f"in mm these parts may be apart")
+        limit = _number(p['max_mm'], f"{where} ({ref}).max_mm")
+        if not math.isfinite(limit) or limit <= 0.0:
+            raise IntentError(
+                f"{where} ({ref}).max_mm: {p['max_mm']!r}. A limit must be a "
+                f"positive finite distance -- infinity can never be exceeded "
+                f"and NaN fails every comparison, so either would be a "
+                f"declared claim nothing can ever violate")
+        basis = p.get('basis', _PROXIMITY_DEFAULT_BASIS)
+        if basis not in _PROXIMITY_BASES:
+            raise IntentError(
+                f"{where} ({ref}).basis: {basis!r}, expected one of "
+                f"{', '.join(map(repr, _PROXIMITY_BASES))}")
+        pads = p.get('pads')
+        if pads is not None:
+            if not isinstance(pads, dict) or not pads:
+                raise IntentError(
+                    f"{where} ({ref}).pads: expected a non-empty "
+                    f"{{'REF': ['1', '2']}}")
+            for who, nums in pads.items():
+                if who not in (ref, near):
+                    raise IntentError(
+                        f"{where} ({ref}).pads: a pad list for {who!r}, which "
+                        f"this claim does not name")
+                if not isinstance(nums, (list, tuple)) or not nums:
+                    raise IntentError(f"{where} ({ref}).pads.{who}: expected a "
+                                      f"non-empty list of pad numbers")
+                for n in nums:
+                    if not isinstance(n, str):
+                        raise IntentError(
+                            f"{where} ({ref}).pads.{who}: pad {n!r} has type "
+                            f"{type(n).__name__}; pad numbers are strings. "
+                            f"`Pad.pad_number` is a string, so {n!r} would "
+                            f"match no pad, measure nothing, and grade clean")
+        out.append(dict(p))
+    return out
 
 
 def _along_edge_claim(c: Dict, i: int) -> None:
@@ -651,6 +781,8 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
         _along_edge_claim(c, i)
         conns.append(c)
 
+    proximity = _proximity_claims(raw)
+
     severity = _obj(raw.get('severity'), 'severity')
     if any(v not in (ERROR, WARN) for v in severity.values()):
         raise IntentError(
@@ -796,6 +928,7 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
             _obj(context.get('budget_withheld'),
                  'context.budget_withheld').items()},
         assembly=dict(assembly),
+        proximity=tuple(proximity),
     )
 
 
@@ -1380,6 +1513,7 @@ class _Ctx:
         self._decap_pops: Dict[float, tuple] = {}
         self._supply_pins = None
         self._assembly_census = None
+        self._bodies = None
 
     def assembly_census(self) -> Dict[str, object]:
         """#837's per-side census, memoised. The SAME function
@@ -1393,6 +1527,35 @@ class _Ctx:
             from .legality import assembly_census as _ac
             self._assembly_census = _ac(self.pcb)
         return self._assembly_census
+
+    def body_rect(self, ref: str):
+        """`(rect_in_board_coords, source)` for one part's DRAWN body (#902).
+
+        LAZY and memoised, the `_supply_pins` precedent: `body.board_bodies`
+        reads the board FILE three times (courtyard, fab and silk graphics
+        reach neither parse path), and no board without a proximity claim may
+        pay for that.
+
+        `body_local` and NOT `occupancy_local`: occupancy is the body UNIONED
+        with the pad bbox, which is the right answer for "may something be
+        seated here" and the wrong one for "how far apart are these two
+        parts" -- it would also make `body` a superset of `pad_edge` rather
+        than a second, independent currency.
+        """
+        if self._bodies is None:
+            from .body import board_bodies
+            try:
+                self._bodies = board_bodies(self.pcb, self.pcb_file)
+            except Exception:                                # noqa: BLE001
+                self._bodies = {}
+        geom = self._bodies.get(ref)
+        fp_obj = self.pcb.footprints.get(ref)
+        if geom is None or geom.body_local is None or fp_obj is None:
+            return None, (geom.source if geom is not None else 'none')
+        x0, y0, x1, y1 = legality.rotate_local_bounds(
+            *geom.body_local, fp_obj.rotation or 0.0)
+        return ((fp_obj.x + x0, fp_obj.y + y0, fp_obj.x + x1, fp_obj.y + y1),
+                geom.source)
 
     def sev(self, rule: str) -> str:
         return self.intent.severity_of(rule)
@@ -2697,6 +2860,45 @@ def _pin_gap(pin_pad, cap_fp, net_id: int) -> Optional[float]:
     return best
 
 
+def _pads_named(fp_obj, names) -> List:
+    """Every pad carrying one of `names`. A pad NUMBER is not unique.
+
+    `Y1` on the board this rule was written for has two pads both numbered
+    `3` (a crystal's two ground tabs), and `USB1` has six numbered `0` plus two
+    with an empty name. A first-hit lookup would pick whichever the parser saw
+    first, so the answer would depend on file order; taking every match and
+    minimising over them cannot.
+    """
+    want = set(names)
+    return [p for p in (fp_obj.pads or ()) if p.pad_number in want]
+
+
+def _proximity_reach(pad, partners, net_match: bool):
+    """`(gap, partner_pad, how)` for ONE subject pad -- the MINIMUM over its
+    partner set, or None when that set is empty.
+
+    SIGNED, never clamped: `rect_gap` goes negative on overlap, and erasing
+    that magnitude is the scar `_pin_gap` records at the top of this file.
+
+    `net_match` narrows the partner set to the pads on this pad's OWN net when
+    any partner carries it. That is `_pin_gap`'s rule generalised, and its
+    docstring is the argument verbatim: "the cap's RAIL leg, never its nearest
+    pad -- a 0402's ground pad can sit half a millimetre nearer and shave the
+    number". It is the one NARROWING in this rule, so it is the one place a
+    finding could be manufactured; `how` goes on the wire for exactly that
+    reason, so every finding is falsifiable from its own payload.
+    """
+    same = ([q for q in partners if q.net_id == pad.net_id and pad.net_id > 0]
+            if net_match else [])
+    use, how = (same, 'net') if same else (partners, 'any')
+    best = None
+    for q in use:
+        g = legality.rect_gap(legality.pad_rect(pad), legality.pad_rect(q))
+        if best is None or g < best[0]:
+            best = (g, q, how)
+    return best
+
+
 def _arm_decap_pins(ctx) -> Optional[str]:
     """Why this BOARD cannot answer the pin question. None = it can.
 
@@ -2952,6 +3154,180 @@ def rule_legality(ctx) -> Iterator[Violation]:
                 measured={key: round(float(got), 4)}, expected={key: lim})
 
 
+def rule_proximity(ctx) -> Iterator[Violation]:
+    """These two named parts, no further apart than `max_mm` (#902).
+
+    The one class of constraint the NETLIST implies and nothing here could
+    read: a 3mm crystal loop and a 30mm one have identical connectivity, so no
+    instrument that reads the board can tell them apart. `decap_distance`
+    cannot stand in for it -- a decap is syntactic (`ref` starts with `C`,
+    bridges exactly two nets) and its partner must carry >= 4 copper pads, so a
+    3-pad SOT89 regulator can never be a tether target at ANY radius. Measured
+    on the board this was written for, the election gives `C1 -> USB1 2.03mm`
+    and `C3 -> U1 1.83mm`: the regulator's own bulk caps, graded against a USB
+    socket and a bridge IC.
+
+    THE INVARIANT. For each SUBJECT pad the claim declares, take the MINIMUM
+    over a partner set that is a SUPERSET of the pads which could satisfy it,
+    and violate only when that minimum exceeds `max_mm`. Because the metric is
+    a minimum, every partner added can only lower it, so the only way to
+    manufacture a violation is to have MISSED a partner. The quantifiers are
+    `for all subject pads, there exists a partner pad` -- the same shape as
+    `decap_pin_distance` and for the same reason: a crystal whose XTAL_IN leg
+    is 30mm away must not be blessed because XTAL_OUT is 1mm away.
+
+    TWO ARITIES, because they are two claims:
+
+      `pads[ref]` declared   per-PIN reach. Each declared subject pad against
+                             the partner's pads, narrowed to its own net when
+                             any partner carries it (`_proximity_reach`).
+      `pads[ref]` omitted    part-to-part ADJACENCY. Every pad against every
+                             pad, no net matching, one finding per claim.
+
+    All pads rather than shared-net pads in the second arity, and that is the
+    invariant again: all-pads is the SUPERSET, so the minimum can only fall.
+    Shared-net is a subset and can RAISE the number, which is the one direction
+    that manufactures findings. And with no `pads` the author stated a GEOMETRY
+    claim; net-matching it would silently make it an electrical one.
+
+    TOTAL OVER ITS CLAIMS, which is why there is no `_ARM` entry. Every claim
+    yields exactly one of: a measured pass (silence), a `proximity` violation,
+    a `proximity_unresolved` violation, or an abstention on `ctx.abstained`. A
+    branch that `continue`d without one of those would put this rule in
+    `rules_run` having graded a claim it never measured -- the vacuous pass
+    `--require-rules` exists to catch, arriving through the mechanism that
+    implements it.
+    """
+    sev_unres = ctx.intent.severity_of('proximity_unresolved', default=ERROR)
+    for i, claim in enumerate(ctx.intent.proximity):
+        ref, near = str(claim['ref']), str(claim['near'])
+        limit = float(claim['max_mm'])
+        basis = claim.get('basis', _PROXIMITY_DEFAULT_BASIS)
+        spec = claim.get('pads') or {}
+        where = f"proximity[{i}]"
+
+        a_fp = ctx.pcb.footprints.get(ref)
+        b_fp = ctx.pcb.footprints.get(near)
+        missing = [r for r, f in ((ref, a_fp), (near, b_fp)) if f is None]
+        if missing:
+            # A VIOLATION, not a skip: `rule_edge_connector` reports an
+            # unmatched brief ref at error severity and `compile_brief` KEEPS
+            # such a ref precisely so it does. Dropping it would make a typo
+            # grade clean, which is `block_unresolved`'s failure one level
+            # over -- and an ARM skip would lose the ref's name entirely.
+            yield Violation(
+                rule='proximity_unresolved', severity=sev_unres,
+                ref=ref, block=ctx.owner.get(ref),
+                message=(f"{where}: {' and '.join(missing)} "
+                         f"{'are' if len(missing) > 1 else 'is'} not on this "
+                         f"board, so {ref} near {near} cannot be measured"),
+                measured={'missing': missing, 'near': near},
+                expected={'max_mm': limit})
+            continue
+
+        if basis == 'body':
+            a_rect, a_src = ctx.body_rect(ref)
+            b_rect, b_src = ctx.body_rect(near)
+            if a_rect is None or b_rect is None:
+                blind = [r for r, rect in ((ref, a_rect), (near, b_rect))
+                         if rect is None]
+                ctx.abstain(
+                    f"{where} ({ref} near {near}).basis",
+                    f"{' and '.join(blind)} draws no body and has no pads, so "
+                    f"placement.body answers source 'none' -- there is no "
+                    f"geometry to measure. Name pads and use basis pad_edge, "
+                    f"or drop the claim")
+                continue
+            gap = legality.rect_gap(a_rect, b_rect)
+            if gap <= limit + legality.EPS:
+                continue
+            yield Violation(
+                rule='proximity', severity=ctx.sev('proximity'),
+                ref=ref, block=ctx.owner.get(ref),
+                message=(f"{ref} is {gap:.2f}mm from {near}, body to body, "
+                         f"past the declared {limit:.2f}mm "
+                         f"(bodies from {a_src}/{b_src})"),
+                measured={'gap_mm': round(gap, 4), 'near': near,
+                          'basis': 'body', 'basis_source': a_src,
+                          'near_basis_source': b_src,
+                          'pads_basis': 'body'},
+                expected={'max_mm': limit})
+            continue
+
+        declared = bool(spec.get(ref))
+        subject = (_pads_named(a_fp, spec[ref]) if declared
+                   else list(a_fp.pads or ()))
+        partners = (_pads_named(b_fp, spec[near]) if spec.get(near)
+                    else list(b_fp.pads or ()))
+        # A NAME that matches nothing is unresolved, not clean. The loader can
+        # refuse a pad number of the wrong TYPE; only here, holding a board,
+        # can "pad 7 of a 4-pad part" be seen at all.
+        for who, names, got in ((ref, spec.get(ref), subject),
+                                (near, spec.get(near), partners)):
+            if names and not got:
+                yield Violation(
+                    rule='proximity_unresolved', severity=sev_unres,
+                    ref=ref, block=ctx.owner.get(ref),
+                    message=(f"{where}: {who} has no pad numbered "
+                             f"{', '.join(repr(n) for n in names)} -- the "
+                             f"claim names pads this part does not have, so it "
+                             f"measures nothing"),
+                    measured={'unresolved_ref': who, 'pads': list(names),
+                              'near': near},
+                    expected={'max_mm': limit})
+        if (spec.get(ref) and not subject) or (spec.get(near) and not partners):
+            continue
+        if not subject or not partners:
+            ctx.abstain(
+                f"{where} ({ref} near {near}).pads",
+                f"{ref if not subject else near} has no pads at all, so there "
+                f"is nothing to measure pad edge to pad edge. Use basis body, "
+                f"or drop the claim")
+            continue
+
+        # PER SUBJECT PAD when the claim declares them; ONCE for the pair when
+        # it does not -- because those are the two claims the two arities
+        # make. `decap_pin_distance` reports per PIN for the same reason: "the
+        # crystal is too far" is one fact, but "XTAL_IN is 4.74mm away AND
+        # XTAL_OUT is 2.52mm away" is two, and collapsing them to the worst
+        # hides a leg the author still has to move. Measured on the unplaced
+        # board: reporting only the worst turned three failing pads into two
+        # findings. With no declared pads there is no pin to name, so the
+        # part-adjacency arity reports once.
+        reaches = []
+        for pad in subject:
+            got = _proximity_reach(pad, partners, net_match=declared)
+            if got is not None:
+                reaches.append((got[0], pad, got[1], got[2]))
+        if not reaches:
+            ctx.abstain(f"{where} ({ref} near {near}).pads",
+                        f"no pad of {ref} could be measured against {near}")
+            continue
+        if not declared:
+            reaches = [min(reaches, key=lambda t: t[0])]
+        for gap, pad, partner, how in reaches:
+            if gap <= limit + legality.EPS:
+                continue
+            net = pad.net_name or ''
+            yield Violation(
+                rule='proximity', severity=ctx.sev('proximity'),
+                ref=ref, block=ctx.owner.get(ref),
+                message=(f"{ref} pad {pad.pad_number} is {gap:.2f}mm from "
+                         f"{near} pad {partner.pad_number}"
+                         + (f" on {net}" if how == 'net' and net else '')
+                         + f", past the declared {limit:.2f}mm proximity "
+                           f"limit"),
+                measured={'gap_mm': round(gap, 4), 'near': near,
+                          'pad': pad.pad_number,
+                          'near_pad': partner.pad_number,
+                          'net': net or None, 'paired_by': how,
+                          'pads_basis': 'declared' if declared else 'part',
+                          'basis': 'pad_edge',
+                          'subject_pads': len(subject),
+                          'near_pads': len(partners)},
+                expected={'max_mm': limit})
+
+
 RULES = (
     ('envelope', rule_envelope),
     ('zone_containment', rule_zone_containment),
@@ -2963,6 +3339,7 @@ RULES = (
     ('decap_distance', rule_decap_distance),
     ('decap_ungraded', rule_decap_ungraded),
     ('decap_pin_distance', rule_decap_pin_distance),
+    ('proximity', rule_proximity),
     ('must_lock', rule_must_lock),
     ('legality', rule_legality),
 )
@@ -2981,7 +3358,13 @@ _NON_RULE_SEVERITIES = frozenset({
     # are not RULES entries" -- a rule may raise more than one FINDING, and
     # severity is settable per finding because a channel-3 inference and a
     # declared pin are different claims about the same measurement.
-    'decap_pin_distance_inferred', 'decap_pin_uncovered'})
+    'decap_pin_distance_inferred', 'decap_pin_uncovered',
+    # #902. Raised BESIDE `proximity`'s own name rather than outside the
+    # loop: a named ref or pad number the board does not have is a
+    # different CLAIM from a distance, and severity is settable per name,
+    # so a DNP-variant board legitimately missing a part can demote the
+    # resolution finding without demoting the distance one.
+    'proximity_unresolved'})
 
 #: Every rule name an intent may set a severity for. Derived from `RULES`, so a
 #: new rule is settable the moment it is registered -- a hand-listed set would
@@ -3001,6 +3384,7 @@ _SKIP_REASON = {
     'decap_distance': 'the intent declares no decaps.max_distance_mm',
     'decap_ungraded': 'the intent declares no decaps.max_distance_mm',
     'decap_pin_distance': 'the intent declares no decaps.max_pin_distance_mm',
+    'proximity': 'the intent declares no proximity claims',
     'must_lock': 'the intent declares no must_lock patterns',
     'legality': 'the intent declares no legality_budget',
 }
@@ -3137,6 +3521,8 @@ def _wants(intent: Intent, rule: str) -> bool:
         # arms one and not the other would report a partition with a
         # missing half and no way to see that it was missing.
         return (intent.decaps or {}).get('max_distance_mm') is not None
+    if rule == 'proximity':
+        return bool(intent.proximity)
     if rule == 'must_lock':
         return bool(intent.must_lock)
     if rule == 'legality':

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -3205,6 +3205,12 @@ def rule_proximity(ctx) -> Iterator[Violation]:
         basis = claim.get('basis', _PROXIMITY_DEFAULT_BASIS)
         spec = claim.get('pads') or {}
         where = f"proximity[{i}]"
+        # The abstention key is keyed on the CLAIM's identity, not on its row
+        # index, so a consumer reporting per-clause coverage can attribute an
+        # abstention to the clause that caused it. `(ref, near)` is unique --
+        # the loader refuses a duplicate -- and it survives a re-ordered
+        # intent, which an index does not.
+        akey = f"proximity[{ref}~{near}]"
 
         a_fp = ctx.pcb.footprints.get(ref)
         b_fp = ctx.pcb.footprints.get(near)
@@ -3232,7 +3238,7 @@ def rule_proximity(ctx) -> Iterator[Violation]:
                 blind = [r for r, rect in ((ref, a_rect), (near, b_rect))
                          if rect is None]
                 ctx.abstain(
-                    f"{where} ({ref} near {near}).basis",
+                    f"{akey}.basis",
                     f"{' and '.join(blind)} draws no body and has no pads, so "
                     f"placement.body answers source 'none' -- there is no "
                     f"geometry to measure. Name pads and use basis pad_edge, "
@@ -3279,7 +3285,7 @@ def rule_proximity(ctx) -> Iterator[Violation]:
             continue
         if not subject or not partners:
             ctx.abstain(
-                f"{where} ({ref} near {near}).pads",
+                f"{akey}.pads",
                 f"{ref if not subject else near} has no pads at all, so there "
                 f"is nothing to measure pad edge to pad edge. Use basis body, "
                 f"or drop the claim")
@@ -3300,7 +3306,7 @@ def rule_proximity(ctx) -> Iterator[Violation]:
             if got is not None:
                 reaches.append((got[0], pad, got[1], got[2]))
         if not reaches:
-            ctx.abstain(f"{where} ({ref} near {near}).pads",
+            ctx.abstain(f"{akey}.pads",
                         f"no pad of {ref} could be measured against {near}")
             continue
         if not declared:

--- a/py_tools/board_brief.py
+++ b/py_tools/board_brief.py
@@ -906,7 +906,13 @@ def format_text(b):
         c = db.get('counts') or {}
         L.append(f"  design brief {os.path.basename(db['path'])}: "
                  f"{c.get('interfaces', 0)} interface(s), "
-                 f"{c.get('keepouts', 0)} keep-out(s)")
+                 f"{c.get('keepouts', 0)} keep-out(s)"
+                 # #902. Appended only when there are any, so a brief that
+                 # declares none reads exactly as it did before -- and always
+                 # when there are, because a declared claim nobody prints is
+                 # one the reader has no way to know was ever made.
+                 + (f", {c['proximity']} proximity row(s)"
+                    if c.get('proximity') else ''))
         # Unknowns first: an unknown is the thing an author must go resolve.
         for k in (db.get('unknown') or ()):
             L.append(f"  !! design brief UNKNOWN: {k}")

--- a/py_tools/board_context.py
+++ b/py_tools/board_context.py
@@ -406,6 +406,49 @@ def _verdict(m):
     return 'AGREES' if not m.get('inversions') else 'CROSSED'
 
 
+def _pair_span_mm(pcb_data, a: str, b: str, only_nets=None):
+    """Worst straight-line pad-to-pad span between two parts, over the nets
+    they SHARE. `None` when they share none.
+
+    #895's criterion 1 asks for the length a pair or bus is forced to run, and
+    nothing in this toolchain produced it: `pair_metrics` computes inversions
+    and discards the distance, `render_placement --json-out` gives a
+    board-total `hpwl`, and `net_affinity` needs declared zoned blocks. So it
+    is measured here, where the pin-order rows already stand.
+
+    The WORST net rather than the mean: a bus is as long as its longest
+    member, and averaging hides the one that will not fit. Pad CENTRES, not
+    edges, because this is a routing-length question rather than a clearance
+    one -- and it is deliberately a straight line, not a route: the criterion
+    compares it against what the two footprints would allow side by side,
+    which is a judgement the reader makes with the two `body_mm` extents
+    printed beside it. A tool that guessed that denominator would be inventing
+    the threshold the criterion exists to leave to a human.
+    """
+    import math
+    fa = (pcb_data.footprints or {}).get(a)
+    fb = (pcb_data.footprints or {}).get(b)
+    if fa is None or fb is None:
+        return None
+    want = set(only_nets or ())
+    by_a = {}
+    for pad in (fa.pads or ()):
+        nid = getattr(pad, 'net_id', 0) or 0
+        if nid > 0 and (not want or nid in want):
+            by_a.setdefault(nid, []).append(pad)
+    worst = None
+    for pad in (fb.pads or ()):
+        nid = getattr(pad, 'net_id', 0) or 0
+        if nid <= 0 or nid not in by_a:
+            continue
+        near = min(math.dist((q.global_x, q.global_y),
+                             (pad.global_x, pad.global_y))
+                   for q in by_a[nid])
+        if worst is None or near > worst:
+            worst = near
+    return None if worst is None else round(worst, 3)
+
+
 def pin_order_rows(pcb_data, pcb_file: str, clearance: float):
     """Pin-order agreement for every connected part pair sharing >= 2 nets.
 
@@ -434,6 +477,7 @@ def pin_order_rows(pcb_data, pcb_file: str, clearance: float):
             'a': a, 'b': b, 'nets': m.get('nets'), 'scope': 'interface',
             'inversions': m.get('inversions'), 'lis': m.get('lis'),
             'ties': m.get('ties', 0), 'verdict': _verdict(m),
+            'span_mm': _pair_span_mm(pcb_data, a, b),
         })
 
     # PAIR-SCOPED rows, and they are the point. A differential pair's polarity
@@ -467,10 +511,12 @@ def pin_order_rows(pcb_data, pcb_file: str, clearance: float):
                         'scope': f'pair {pos}/{neg}',
                         'inversions': m['inversions'], 'lis': m['lis'],
                         'ties': m.get('ties', 0), 'verdict': _verdict(m),
+                        'span_mm': _pair_span_mm(pcb_data, a, b,
+                                                 only_nets=ids),
                     })
     except Exception as exc:                                 # noqa: BLE001
         rows.append({'a': '-', 'b': '-', 'nets': 0, 'scope': 'pair',
-                     'inversions': None, 'lis': None,
+                     'inversions': None, 'lis': None, 'span_mm': None,
                      'verdict': f'NOT MEASURED ({type(exc).__name__})'})
 
     # Pair rows first: they are the narrow, unfixable-by-rotation claim.
@@ -518,12 +564,22 @@ def format_md(doc) -> str:
                  'back-side copper. Rotation cannot fix it -- parity flips '
                  'only under a mirror.')
         L.append('')
-        L.append('| A | B | scope | nets | inversions | max planar | '
-                 'verdict |')
-        L.append('|---|---|---|---|---|---|---|')
+        L.append('| A | B | scope | nets | span mm | inversions | '
+                 'max planar | verdict |')
+        L.append('|---|---|---|---|---|---|---|---|')
         for r in po['rows']:
+            _sp = r.get('span_mm')
             L.append(f"| {r['a']} | {r['b']} | {r['scope']} | {r['nets']} | "
+                     f"{'-' if _sp is None else _sp} | "
                      f"{r['inversions']} | {r['lis']} | {r['verdict']} |")
+        L.append('')
+        L.append('`span mm` is the WORST straight-line pad-to-pad distance '
+                 'over the nets the two parts share -- the length this pair '
+                 'or bus is forced to run. Compare it against the shortest '
+                 'the two bodies allow side by side (their `body_mm` are '
+                 'below); a ratio much above 1.5 is a finding to explain. '
+                 'The threshold is a judgement, which is why the tool '
+                 'reports the measurement and not a verdict.')
     L.append('')
 
     L.append('## Parts')

--- a/py_tools/check_floorplan.py
+++ b/py_tools/check_floorplan.py
@@ -353,14 +353,20 @@ def main(argv=None):
     # #902. Computed on the --intent path only: an --emit-intent run produces
     # no grade, so there is nothing for a clause to be covered BY, and saying
     # "covered" there would be a claim about a document nobody graded.
-    coverage = {}
+    # Written ALWAYS on this path, even with no brief -- then `clauses` is
+    # empty and `brief` is null. An absent block would be ambiguous between
+    # "this board declares nothing" and "an older build produced this
+    # document", and a consumer cannot refuse the second without also refusing
+    # the first, which would reverse #711's contract that a brief-less board
+    # costs nothing. Present-and-empty says "nothing was declared" out loud.
+    _graded_doc = intent_doc_for_drift(args.intent)
+    coverage = _db.clause_coverage(
+        brief_report, _graded_doc,
+        rules_run=result.rules_run,
+        abstained=result.budget_abstained,
+        drifted_ids=(_db.drifted_clause_ids(_graded_doc, brief_fragment)
+                     if brief_fragment else ()))
     if brief_fragment:
-        _graded_doc = intent_doc_for_drift(args.intent)
-        coverage = _db.clause_coverage(
-            brief_report, _graded_doc,
-            rules_run=result.rules_run,
-            abstained=result.budget_abstained,
-            drifted_ids=_db.drifted_clause_ids(_graded_doc, brief_fragment))
         if not args.quiet and coverage['clauses']:
             print(f"  brief clause coverage: {coverage['graded']} graded, "
                   f"{coverage['uncovered']} uncovered, "
@@ -385,8 +391,7 @@ def main(argv=None):
 
     if args.json:
         doc = to_json(result)
-        if coverage:
-            doc['brief_coverage'] = coverage
+        doc['brief_coverage'] = coverage
         with open(args.json, 'w', encoding='utf-8') as fh:
             json.dump(doc, fh, indent=1, sort_keys=True)
             fh.write('\n')
@@ -400,7 +405,7 @@ def main(argv=None):
     s['brief_absent'] = len(brief_report.get('absent') or ())
     s['brief_unknown_keys'] = sorted(brief_report.get('unknown') or ())
     s['brief_drift'] = len(brief_drift)
-    if coverage:
+    if coverage.get('clauses'):
         s['brief_clauses'] = len(coverage['clauses'])
         for _k in ('graded', 'uncovered', 'abstained', 'not_claimed',
                    'carried', 'drifted'):
@@ -425,7 +430,7 @@ def main(argv=None):
     # declared -- the count was satisfied by rules nobody had declared
     # anything for.
     if args.require_brief_coverage:
-        if not coverage or not coverage['clauses']:
+        if not coverage.get('clauses'):
             print("  FAIL: --require-brief-coverage, but "
                   + (_brief_absence_reason(args, brief) if not coverage
                      else "the brief that was found declares no gradable "

--- a/py_tools/check_floorplan.py
+++ b/py_tools/check_floorplan.py
@@ -109,6 +109,15 @@ def build_parser():
                         'INFERENCE, and a caller that means "check this '
                         'against what was declared" needs to be able to say '
                         'so (#711)')
+    p.add_argument('--require-brief-coverage', action='store_true',
+                   help='exit 4 unless every clause the design brief DECLARED '
+                        'reached a verdict. --require-rules counts RULES, and '
+                        'that is exactly the gap: one run graded six rules, '
+                        'passed, and measured not one clause its brief '
+                        'declared, because the count was satisfied by rules '
+                        'nobody had declared anything for. This counts '
+                        'CLAUSES. A clause the author wrote "unknown", and one '
+                        'this toolchain carries by design, never block (#902)')
     p.add_argument('--json', metavar='PATH',
                    help='write the full findings (every measurement) as JSON')
     p.add_argument('--group-by', default='auto', metavar='SOURCES',
@@ -341,9 +350,45 @@ def main(argv=None):
     if not args.quiet:
         print(format_text(result))
 
+    # #902. Computed on the --intent path only: an --emit-intent run produces
+    # no grade, so there is nothing for a clause to be covered BY, and saying
+    # "covered" there would be a claim about a document nobody graded.
+    coverage = {}
+    if brief_fragment:
+        _graded_doc = intent_doc_for_drift(args.intent)
+        coverage = _db.clause_coverage(
+            brief_report, _graded_doc,
+            rules_run=result.rules_run,
+            abstained=result.budget_abstained,
+            drifted_ids=_db.drifted_clause_ids(_graded_doc, brief_fragment))
+        if not args.quiet and coverage['clauses']:
+            print(f"  brief clause coverage: {coverage['graded']} graded, "
+                  f"{coverage['uncovered']} uncovered, "
+                  f"{coverage['abstained']} abstained, "
+                  f"{coverage['not_claimed']} declared unknown, "
+                  f"{coverage['carried']} carried")
+            for c in coverage['clauses']:
+                if c['state'] not in ('uncovered', 'abstained') \
+                        and not c['drifted']:
+                    continue
+                # The STATE wins the label when there is one. A clause the
+                # intent does not carry at all is both uncovered and drifted,
+                # and calling it DRIFTED buries the more basic fact: nothing
+                # looked at it. `drifted` is only the headline when the clause
+                # WAS graded -- against something the brief does not say.
+                tag = (c['state'].upper() if c['state'] != 'graded'
+                       else 'DRIFTED')
+                print(f"    {tag} {c['id']}"
+                      + (f" -- {c['why']}" if c['why'] else
+                         ' -- graded, but not against what the brief declares')
+                      )
+
     if args.json:
+        doc = to_json(result)
+        if coverage:
+            doc['brief_coverage'] = coverage
         with open(args.json, 'w', encoding='utf-8') as fh:
-            json.dump(to_json(result), fh, indent=1, sort_keys=True)
+            json.dump(doc, fh, indent=1, sort_keys=True)
             fh.write('\n')
         if not args.quiet:
             print(f"  wrote {args.json}")
@@ -355,6 +400,12 @@ def main(argv=None):
     s['brief_absent'] = len(brief_report.get('absent') or ())
     s['brief_unknown_keys'] = sorted(brief_report.get('unknown') or ())
     s['brief_drift'] = len(brief_drift)
+    if coverage:
+        s['brief_clauses'] = len(coverage['clauses'])
+        for _k in ('graded', 'uncovered', 'abstained', 'not_claimed',
+                   'carried', 'drifted'):
+            s[f'brief_clauses_{_k}'] = coverage[_k]
+        s['brief_coverage_complete'] = coverage['complete']
     s['clearance_used'] = knobs['clearance']
     s['edge_clearance_used'] = knobs['board_edge_clearance']
     print("JSON_SUMMARY: " + json.dumps(s, sort_keys=True))
@@ -369,6 +420,37 @@ def main(argv=None):
                 "part's current pose, not a declaration.", file=sys.stderr)
         if not args.exit_zero:
             return VIOLATIONS_EXIT
+    # #902. The CLAUSE gate, beside the RULE gate. They are different claims:
+    # run 25 graded six rules, passed, and measured not one clause its brief
+    # declared -- the count was satisfied by rules nobody had declared
+    # anything for.
+    if args.require_brief_coverage:
+        if not coverage or not coverage['clauses']:
+            print("  FAIL: --require-brief-coverage, but "
+                  + (_brief_absence_reason(args, brief) if not coverage
+                     else "the brief that was found declares no gradable "
+                          "clause")
+                  + ". There is nothing here to have covered, so this cannot "
+                    "be the check you meant.", file=sys.stderr)
+            if not args.exit_zero:
+                return VIOLATIONS_EXIT
+        elif not coverage['complete']:
+            # `drifted` is counted among the GRADED clauses only: a clause the
+            # intent does not carry is already counted as uncovered, and
+            # counting it twice would make the two numbers sum past the
+            # clauses that exist.
+            _graded_drift = sum(1 for c in coverage['clauses']
+                                if c['drifted'] and c['state'] == 'graded')
+            print(f"  FAIL: --require-brief-coverage. Of "
+                  f"{len(coverage['clauses'])} clause(s) the brief declares, "
+                  f"{coverage['uncovered']} reached no rule, "
+                  f"{coverage['abstained']} were abstained on, and "
+                  f"{_graded_drift} were graded against something the brief "
+                  f"does not say. `rules_run` counts RULES; this counts "
+                  f"CLAUSES, and the two can disagree completely.",
+                  file=sys.stderr)
+            if not args.exit_zero:
+                return VIOLATIONS_EXIT
     _ran = s.get('rules_run', 0)
     if args.require_rules and _ran < args.require_rules:
         print(f"  FAIL: --require-rules {args.require_rules}, but {_ran} "

--- a/py_tools/check_floorplan.py
+++ b/py_tools/check_floorplan.py
@@ -431,8 +431,16 @@ def main(argv=None):
     # anything for.
     if args.require_brief_coverage:
         if not coverage.get('clauses'):
+            # Keyed on whether a brief was FOUND, not on the coverage block's
+            # truthiness. The block became unconditional in this same change,
+            # so `if not coverage` turned into a dead branch and every absence
+            # started printing "the brief that was found ..." -- a fabricated
+            # fact, and worse than the case `_brief_absence_reason`'s own
+            # docstring forbids ("saying 'no design brief was found' when the
+            # caller passed --no-brief blames the board for the caller's own
+            # flag"). Its three cases are the whole point of that function.
             print("  FAIL: --require-brief-coverage, but "
-                  + (_brief_absence_reason(args, brief) if not coverage
+                  + (_brief_absence_reason(args, brief) if not brief_fragment
                      else "the brief that was found declares no gradable "
                           "clause")
                   + ". There is nothing here to have covered, so this cannot "

--- a/tests/713_abstention_census.json
+++ b/tests/713_abstention_census.json
@@ -32,6 +32,7 @@
     "edge_connector",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_containment",
     "zone_exclusive",
     "zone_side"
@@ -60,6 +61,7 @@
     "edge_connector",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_containment",
     "zone_exclusive",
     "zone_side"
@@ -88,6 +90,7 @@
     "edge_connector",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_exclusive"
    ],
    "skipped_withheld": [],
@@ -115,6 +118,7 @@
     "decap_ungraded",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_exclusive",
     "zone_side"
    ],
@@ -142,6 +146,7 @@
     "edge_connector",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_exclusive"
    ],
    "skipped_withheld": [],
@@ -167,6 +172,7 @@
     "decap_ungraded",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_containment",
     "zone_exclusive",
     "zone_side"
@@ -194,6 +200,7 @@
     "decap_ungraded",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_containment",
     "zone_exclusive",
     "zone_side"
@@ -221,6 +228,7 @@
     "decap_ungraded",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_exclusive"
    ],
    "skipped_withheld": [],
@@ -247,6 +255,7 @@
     "edge_connector",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_containment",
     "zone_exclusive",
     "zone_side"
@@ -275,6 +284,7 @@
     "edge_connector",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_containment",
     "zone_exclusive",
     "zone_side"
@@ -304,6 +314,7 @@
     "decap_ungraded",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_exclusive"
    ],
    "skipped_withheld": [],
@@ -330,6 +341,7 @@
     "edge_connector",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_containment",
     "zone_exclusive",
     "zone_side"
@@ -358,6 +370,7 @@
     "edge_connector",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_containment",
     "zone_exclusive",
     "zone_side"
@@ -386,6 +399,7 @@
     "edge_connector",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_containment",
     "zone_exclusive",
     "zone_side"
@@ -414,6 +428,7 @@
     "edge_connector",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_containment",
     "zone_exclusive",
     "zone_side"
@@ -442,6 +457,7 @@
     "edge_connector",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_exclusive"
    ],
    "skipped_withheld": [],
@@ -469,6 +485,7 @@
     "decap_ungraded",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_exclusive"
    ],
    "skipped_withheld": [],
@@ -494,6 +511,7 @@
     "decap_ungraded",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_containment",
     "zone_exclusive",
     "zone_side"
@@ -521,6 +539,7 @@
     "decap_ungraded",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_containment",
     "zone_exclusive",
     "zone_side"
@@ -550,6 +569,7 @@
     "decap_ungraded",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_containment",
     "zone_exclusive",
     "zone_side"
@@ -579,6 +599,7 @@
     "decap_ungraded",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_exclusive"
    ],
    "skipped_withheld": [],
@@ -606,6 +627,7 @@
     "decap_ungraded",
     "keepout",
     "must_lock",
+    "proximity",
     "zone_containment",
     "zone_exclusive",
     "zone_side"

--- a/tests/fixtures/902/esp_prog_proximity.design-brief.json
+++ b/tests/fixtures/902/esp_prog_proximity.design-brief.json
@@ -1,0 +1,29 @@
+{
+  "schema": 1,
+  "kind": "design-brief",
+  "units": "mm",
+  "board": "esp_prog_placed.kicad_pcb",
+
+  "product": {
+    "form_factor": "usb_stick",
+    "primary_axis": "east-west",
+    "held_by": "hand; plugs directly into a host USB-A port",
+    "user_top_side": "F"
+  },
+
+  "proximity": [
+    { "ref": "Y1", "near": "U1", "max_mm": 2.0, "basis": "pad_edge",
+      "pads": { "Y1": ["1", "2"], "U1": ["9", "10"] },
+      "requirement": "PROG-CLK01",
+      "why": "the crystal loop is the oscillator's stability; both legs must reach XI/XO, not just the nearer one" },
+
+    { "ref": ["C1", "C3"], "near": "U2", "max_mm": 2.0, "basis": "pad_edge",
+      "pads": { "C1": ["1"], "C3": ["1"], "U2": ["2", "3"] },
+      "requirement": "PROG-PWR01",
+      "why": "U2 is a 3-pad SOT89 and can never be a decap tether target, so its bulk caps are ungradable by any decap rule" },
+
+    { "ref": "Q1", "near": "Q2", "max_mm": 3.0, "basis": "body",
+      "requirement": "PROG-RST01",
+      "why": "the auto-reset pair shares no net, so there is no pad pair to measure -- only their bodies" }
+  ]
+}

--- a/tests/fixtures/run25/esp_prog_placed.kicad_pcb
+++ b/tests/fixtures/run25/esp_prog_placed.kicad_pcb
@@ -1,0 +1,5799 @@
+(kicad_pcb
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(general
+		(thickness 1.6)
+		(legacy_teardrops no)
+	)
+	(paper "A4")
+	(layers
+		(0 "F.Cu" signal)
+		(2 "B.Cu" signal)
+		(9 "F.Adhes" user)
+		(11 "B.Adhes" user)
+		(13 "F.Paste" user)
+		(15 "B.Paste" user)
+		(5 "F.SilkS" user)
+		(7 "B.SilkS" user)
+		(1 "F.Mask" user)
+		(3 "B.Mask" user)
+		(17 "Dwgs.User" user)
+		(19 "Cmts.User" user)
+		(21 "Eco1.User" user)
+		(23 "Eco2.User" user)
+		(25 "Edge.Cuts" user)
+		(27 "Margin" user)
+		(31 "F.CrtYd" user)
+		(29 "B.CrtYd" user)
+		(35 "F.Fab" user)
+		(33 "B.Fab" user)
+	)
+	(setup
+		(pad_to_mask_clearance 0.0508)
+		(solder_mask_min_width 0.0508)
+		(pad_to_paste_clearance -0.0508)
+		(allow_soldermask_bridges_in_footprints no)
+		(tenting
+			(front yes)
+			(back yes)
+		)
+		(covering
+			(front no)
+			(back no)
+		)
+		(plugging
+			(front no)
+			(back no)
+		)
+		(capping no)
+		(filling no)
+		(aux_axis_origin 114 105.5)
+		(pcbplotparams
+			(layerselection 0x00000000_00000000_55555555_575575ff)
+			(plot_on_all_layers_selection 0x00000000_00000000_00000000_00000000)
+			(disableapertmacros no)
+			(usegerberextensions no)
+			(usegerberattributes no)
+			(usegerberadvancedattributes no)
+			(creategerberjobfile no)
+			(dashed_line_dash_ratio 12)
+			(dashed_line_gap_ratio 3)
+			(svgprecision 4)
+			(plotframeref no)
+			(mode 1)
+			(useauxorigin no)
+			(pdf_front_fp_property_popups yes)
+			(pdf_back_fp_property_popups yes)
+			(pdf_metadata yes)
+			(pdf_single_document no)
+			(dxfpolygonmode yes)
+			(dxfimperialunits yes)
+			(dxfusepcbnewfont yes)
+			(psnegative no)
+			(psa4output no)
+			(plot_black_and_white yes)
+			(sketchpadsonfab no)
+			(plotpadnumbers no)
+			(hidednponfab no)
+			(sketchdnponfab yes)
+			(crossoutdnponfab yes)
+			(subtractmaskfromsilk no)
+			(outputformat 1)
+			(mirror no)
+			(drillshape 0)
+			(scaleselection 1)
+			(outputdirectory "gerbers/")
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:C_0603_5MIL_DWS"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3efb")
+		(at 123.250000 98.100000)
+		(descr "Resistor SMD 0603, reflow soldering, Vishay (see dcrcw.pdf)")
+		(tags "resistor 0603")
+		(property "Reference" "C1"
+			(at 0.02 1.42 90)
+			(layer "F.SilkS")
+			(uuid "f75a27fd-d1c4-458f-8b68-56b483dc9e19")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2.2uF"
+			(at 0.127 1.778 90)
+			(layer "F.Fab")
+			(uuid "72de1e9a-e38b-4467-8c50-032e9cd51554")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1852f3c8-e8cc-47e0-b367-8611cc6f47b5")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6d88cc1b-1f4b-472c-9c5e-19af7292f099")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000055069cf9")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.508 -0.762)
+			(end 0.508 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "35ea92c1-9e3b-4387-aa21-b42022e5b828")
+		)
+		(fp_line
+			(start -0.508 0.762)
+			(end 0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "785854c6-f55d-4a27-80f7-1af3aaa9866d")
+		)
+		(fp_line
+			(start 1.651 -0.762)
+			(end 1.651 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d9de512a-6634-4766-b8c2-61fcb9e8fca9")
+		)
+		(fp_line
+			(start 0.508 -0.762)
+			(end 1.651 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "692ad022-7a42-4c15-b38a-24353cee65ed")
+		)
+		(fp_line
+			(start -0.508 -0.762)
+			(end -1.651 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1ddd5c01-ccc6-4201-ab2b-10ffcd50d633")
+		)
+		(fp_line
+			(start -1.651 -0.762)
+			(end -1.651 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c3158be1-8f7d-45f7-817c-d3c1451f270e")
+		)
+		(fp_line
+			(start 1.651 0.762)
+			(end 0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0776f5ac-0e9e-463d-a90e-bbc33109bf83")
+		)
+		(fp_line
+			(start -1.651 0.762)
+			(end -0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6331247c-8849-4ade-90f0-f2e2e262a0d3")
+		)
+		(fp_line
+			(start 0.762 -0.381)
+			(end 0 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7b34b4c4-07b8-447e-bb1a-55abdda3902e")
+		)
+		(fp_line
+			(start 0 -0.381)
+			(end -0.762 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4f29cb63-5415-4a1a-95e1-7e2dc701541b")
+		)
+		(fp_line
+			(start -0.762 -0.381)
+			(end -0.762 0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "29c2be3d-d493-46ec-8913-4e58dcfb8f7e")
+		)
+		(fp_line
+			(start 0.762 0.381)
+			(end 0.762 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d2012f09-e8e3-4b76-b29f-2416acbd1872")
+		)
+		(fp_line
+			(start -0.762 0.381)
+			(end 0.762 0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b0f6cd93-e2fc-4dff-8413-e11a8d411b8a")
+		)
+		(pad "1" smd rect
+			(at -0.889 0)
+			(size 1.016 1.016)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "c9fe2374-c58b-407e-90b5-0df5c3cd3078")
+		)
+		(pad "2" smd rect
+			(at 0.889 0)
+			(size 1.016 1.016)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "bb3f8234-235f-499f-b6d2-6b609c3aedeb")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/C_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:C_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f0f")
+		(at 126.964000 102.665000 180)
+		(tags "C0402")
+		(property "Reference" "C2"
+			(at -2.1 -0.1 90)
+			(layer "F.SilkS")
+			(uuid "bfe81756-fa32-4c91-85ca-9dafcee55832")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "27pF"
+			(at 0 1.905 90)
+			(layer "F.Fab")
+			(uuid "afc5aa3f-a483-4bb7-a932-39e0290f26ad")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f46e3d5f-37c9-4d7b-af06-42d8b55f5e75")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "39f3d48b-3e28-4811-a96c-0202c40d1a98")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8acdb7")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "75e27d7e-1147-4ba6-8cb7-65d985df04b7")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "742905ca-fb6e-4776-83fe-9fcc7c97d3a7")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ca9d5db3-03df-4e51-931e-cb05f0b5df78")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0a385e74-7e5e-43f1-8c42-f5866aa70cb0")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "33be7a8b-6a82-4bfd-9c67-f7b6515759a4")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d85f51d5-ebac-41d1-9902-a2277d6ac7b1")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4e1b7661-355d-46f7-bb91-71951b312e70")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "492f7e53-cbec-424d-9aec-f66c611fa041")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1f15d293-b287-4bfb-a405-abe1e5b675ae")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9e882702-ce26-46f0-bf79-eb291037d326")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "20dd8e46-9562-46b0-a867-a8ca8e949ec4")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a6f5f42a-5fa6-4634-b0d2-b7c210c994ca")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "918e4fd8-5d8b-43ae-acf5-ea8267eb8804")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1193b8e0-83dd-4c45-bb92-96007c358352")
+		)
+		(pad "1" smd rect
+			(at -0.508 0)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "c05c74cf-6dcb-4258-9cff-71b669d8dc06")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 180)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "b433d5e4-f9e0-4845-b167-df024b26609d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:C_0603_5MIL_DWS"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f22")
+		(at 126.350000 98.100000)
+		(descr "Resistor SMD 0603, reflow soldering, Vishay (see dcrcw.pdf)")
+		(tags "resistor 0603")
+		(property "Reference" "C3"
+			(at -2.27 0.59 0)
+			(layer "F.SilkS")
+			(uuid "c74cc472-1cec-4d24-b416-63036f14783f")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2.2uF"
+			(at 0.127 1.778 0)
+			(layer "F.Fab")
+			(uuid "6584dab3-3d0f-459f-adcd-671dd563f275")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "963df33f-2430-4e51-a1ef-974a5dbe19d8")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7a4bad7c-d2fb-4c07-bf73-cb8993011454")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000055069c71")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.508 0.762)
+			(end 0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5a3eb310-acd4-45f3-93b1-e8cd2d491b0c")
+		)
+		(fp_line
+			(start -0.508 -0.762)
+			(end 0.508 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7c0aedfc-120f-4105-b883-b5a777e1c92d")
+		)
+		(fp_line
+			(start 1.651 0.762)
+			(end 0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "683c5b34-2b55-42ef-afcd-34c76ca9c892")
+		)
+		(fp_line
+			(start 1.651 -0.762)
+			(end 1.651 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "16894053-ef17-4cf2-ad7c-fc8e2d6b7727")
+		)
+		(fp_line
+			(start 0.508 -0.762)
+			(end 1.651 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6185e63d-22f8-4dd8-8292-6a50f4dc0558")
+		)
+		(fp_line
+			(start -0.508 -0.762)
+			(end -1.651 -0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ad090b28-054b-43f9-a3d3-bb4e3e64b3f3")
+		)
+		(fp_line
+			(start -1.651 0.762)
+			(end -0.508 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a88ac355-08b0-4512-9672-a8caed8ebea6")
+		)
+		(fp_line
+			(start -1.651 -0.762)
+			(end -1.651 0.762)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "98a6364c-9f65-4220-9222-5630896822a8")
+		)
+		(fp_line
+			(start 0.762 0.381)
+			(end 0.762 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4a8eddc8-5a72-4f98-a4bf-a9e079c73580")
+		)
+		(fp_line
+			(start 0.762 -0.381)
+			(end 0 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d0d94442-29b2-4c2f-a9df-0806aeebd144")
+		)
+		(fp_line
+			(start 0 -0.381)
+			(end -0.762 -0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "aa0420b5-baf9-41f6-ab9b-b69921994b55")
+		)
+		(fp_line
+			(start -0.762 0.381)
+			(end 0.762 0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "121f4f4e-ca8e-4529-ba5e-86cec623edf0")
+		)
+		(fp_line
+			(start -0.762 -0.381)
+			(end -0.762 0.381)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d07fd336-c791-49a4-8938-47c68c9cab77")
+		)
+		(pad "1" smd rect
+			(at -0.889 0)
+			(size 1.016 1.016)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/+3.3V")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "e8e0c496-9ab2-499a-8329-6706b727c6ae")
+		)
+		(pad "2" smd rect
+			(at 0.889 0)
+			(size 1.016 1.016)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "1d648374-bc5e-465c-a964-a415515bdd69")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/C_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:C_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f36")
+		(at 127.199000 104.096000 180)
+		(tags "C0402")
+		(property "Reference" "C4"
+			(at -1.102 1.014 180)
+			(layer "F.SilkS")
+			(uuid "bc677c80-53dd-4f08-98e8-31e324557bc0")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "27pF"
+			(at 0 1.905 90)
+			(layer "F.Fab")
+			(uuid "fb7e2869-b4dd-454d-91c0-5e038d2c07c7")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9cd7c0aa-dcaa-4d63-a892-2b1ea78c0a54")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b8b35adf-612d-4b2f-9fb2-0e21e9044d45")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000055069da1")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ce5bc01c-c3f6-4bbd-8329-326a517ffdec")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5bf31d8d-0642-462e-ae9f-79384a944cf3")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0ec4ccfe-5f9a-4f97-8cab-ece0f2cb51d2")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ab51b595-a988-4ac3-9891-cb27f3cdeae2")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "595d0de0-df4f-4e1d-b9fa-aa15908a4dcc")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "39927f66-140c-491a-8935-8a19091cbce6")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ce722752-5145-4955-b190-e6415d2c6648")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7886fb79-8ade-4b2d-8c06-0990ec7145ce")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a1649be7-bd87-4b49-ba90-e64269e5af44")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "df9c04b4-2182-4c85-ba2f-f6b4f0e8ced5")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ef8032a2-af72-40dc-b75d-6cc874e43ce7")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c39a7149-18b6-4678-b71b-dbabebe2af68")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "27f8eda9-143a-4783-b25e-451bf3144a2d")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e498aa95-5328-48f6-b10c-8bd583002cd7")
+		)
+		(pad "1" smd rect
+			(at -0.508 0)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C4-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "f5fa8d41-8b5b-4801-9517-d6be5bcac583")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 180)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "c73c3ff6-d1db-46ee-bb45-94a620fa0541")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_Connectors-FP:WU06SM"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f44")
+		(at 144.650000 98.800000 270)
+		(property "Reference" "CON1"
+			(at -0.2 -1.5 90)
+			(layer "F.SilkS")
+			(uuid "c53fb5c7-5633-441d-8a0a-998e61ec4b18")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "CON6"
+			(at 0 -2.54 90)
+			(layer "F.Fab")
+			(uuid "d6cfb4cb-2294-4406-88a2-5c9df595b9a7")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1f3b2da5-757b-4cb5-920f-c5e5b95c1d70")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a3726cc9-7730-4652-9a5b-271fb1f05a9b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8a1e69")
+		(solder_mask_margin 0.0508)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -4.85 1.1)
+			(end -4.85 -2.1)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "be5041df-1eaa-46f6-842b-a5296b5e7988")
+		)
+		(fp_line
+			(start 4.85 1.1)
+			(end -4.85 1.1)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b68b63bc-ff21-42a3-9c37-766f6afe5b9f")
+		)
+		(fp_line
+			(start -4.85 -2.1)
+			(end 4.85 -2.1)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b78f2cb9-173a-4d48-98b4-8f7c4c266052")
+		)
+		(fp_line
+			(start 4.85 -2.1)
+			(end 4.85 1.1)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f90af397-a07a-4e47-99fe-e9eb2ba869d3")
+		)
+		(pad "1" thru_hole oval
+			(at -3.125 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/U0TXD")
+			(uuid "fb19e8f8-bb34-468e-a684-827edf79d3c8")
+		)
+		(pad "2" thru_hole oval
+			(at -1.875 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/DCOM")
+			(uuid "bd8dc4f4-0243-458a-85ec-719f868c7ae7")
+		)
+		(pad "3" thru_hole oval
+			(at -0.625 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/U0RXD")
+			(uuid "ce5942b5-71d7-41a7-b746-edf7d14af784")
+		)
+		(pad "4" thru_hole oval
+			(at 0.625 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(uuid "8247ece4-cc28-462f-ab3a-db7da1427200")
+		)
+		(pad "5" thru_hole oval
+			(at 1.875 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/+3.3V")
+			(uuid "a0b6b78f-04f7-4f50-b022-0fdfb8f1e207")
+		)
+		(pad "6" thru_hole oval
+			(at 3.125 0 270)
+			(size 1 1.5)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/EN")
+			(uuid "d74b4b89-0c94-485f-aee6-07917f8da44c")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/WU06S-Molex_PicoBlade_530470610_1x06_P1.25mm_Vertical.step"
+			(offset
+				(xyz 0 0.5428 2.54)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz -90 0 -180)
+			)
+		)
+	)
+	(footprint "OLIMEX_Transistors-FP:SOT23"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f57")
+		(at 139.000000 99.200000 180)
+		(property "Reference" "Q1"
+			(at -1.6 -1 0)
+			(layer "F.SilkS")
+			(uuid "30552372-aa78-4afe-a1ae-bad929e8edc0")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "BC817-40(SOT23)"
+			(at 3.5052 2.6416 0)
+			(layer "F.Fab")
+			(uuid "db168cae-0535-488f-845c-70f3fa7eb843")
+			(effects
+				(font
+					(size 1.1 1.1)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b621f733-e3cb-412d-a695-7c792c9019ef")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "62f1d14d-5f4f-43fd-a0e5-067b0bea46b1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8a927f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.2032 1.4224)
+			(end -0.635 1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "054f1970-4597-4e19-b95f-a34b81d74d44")
+		)
+		(fp_line
+			(start 0.2032 -1.4224)
+			(end -0.635 -1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "76d37a5a-8c56-429b-8a14-013555262bf9")
+		)
+		(fp_line
+			(start -0.635 0.7112)
+			(end -0.635 1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a7c8b24e-4c33-4b7c-8ee6-2e2fba817abb")
+		)
+		(fp_line
+			(start -0.635 -1.4224)
+			(end -0.635 -0.7112)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "eb6bb575-8fb9-4627-b8dd-fc8f3008364b")
+		)
+		(fp_line
+			(start 1.19888 0.95758)
+			(end 0.82804 0.95758)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "84a83fd2-68b9-4adc-b8a6-f0b98d3a1ac7")
+		)
+		(fp_line
+			(start 1.19126 -0.95504)
+			(end 0.82042 -0.95504)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "563b045a-e592-40a6-a7b7-01700a7b7a1f")
+		)
+		(fp_line
+			(start 0.65278 1.41478)
+			(end -0.65024 1.41478)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2af0f7fc-f454-4a38-b6bd-67850eab4307")
+		)
+		(fp_line
+			(start 0.65278 -1.4097)
+			(end 0.65278 1.4097)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "003e8884-906a-4c4e-b15a-53416a7989b8")
+		)
+		(fp_line
+			(start -0.65024 0.00762)
+			(end -0.65278 1.35636)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e571de33-5e83-4458-978e-67dbd581e61e")
+		)
+		(fp_line
+			(start -0.65024 0.00508)
+			(end -0.65024 -1.41732)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "81afa320-3df0-4309-b0ba-83cf8347800e")
+		)
+		(fp_line
+			(start -0.65532 -1.42494)
+			(end 0.64262 -1.42494)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d218610b-4cf1-43ca-b500-259913ddd589")
+		)
+		(fp_line
+			(start -0.81026 0.00254)
+			(end -1.1811 0.00254)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "30e005f3-24b9-44f7-b2b4-2ce8f59abe2e")
+		)
+		(pad "1" smd rect
+			(at 1.10744 0.94996 180)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(Q1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "021f20be-b6f4-4fa8-a291-aa7de978068f")
+		)
+		(pad "2" smd rect
+			(at 1.10744 -0.9525 180)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/DTR")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "ea771218-fc35-499d-836d-a2e3479bcc16")
+		)
+		(pad "3" smd rect
+			(at -1.10236 0.00254 180)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/DCOM")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "4439e5cf-1444-4745-a6c1-78842dac1b34")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/SOT-23.step"
+			(offset
+				(xyz 0 0 0.5)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz -90 0 90)
+			)
+		)
+	)
+	(footprint "OLIMEX_Transistors-FP:SOT23"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f6a")
+		(at 139.000000 102.400000)
+		(property "Reference" "Q2"
+			(at -1.6 -1.3 0)
+			(layer "F.SilkS")
+			(uuid "50c186ed-bd8b-4770-8d18-a4f47cc5c02f")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "BC817-40(SOT23)"
+			(at 3.5052 2.6416 0)
+			(layer "F.Fab")
+			(uuid "35ce9468-3746-484b-b631-c3a953bc6470")
+			(effects
+				(font
+					(size 1.1 1.1)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "75bad9b6-4c36-414b-aab7-8dafc5179781")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a0d1ff3a-d393-4185-b8da-2edb44288ab4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8ab147")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.2032 1.4224)
+			(end -0.635 1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8227fd38-eb7d-4476-9c5e-c799a490237b")
+		)
+		(fp_line
+			(start 0.2032 -1.4224)
+			(end -0.635 -1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "11ea48f4-d46f-44ad-8346-071dcba4c1e0")
+		)
+		(fp_line
+			(start -0.635 0.7112)
+			(end -0.635 1.4224)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6a8dc534-7284-4047-afec-34126ce0e01e")
+		)
+		(fp_line
+			(start -0.635 -1.4224)
+			(end -0.635 -0.7112)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "9e02ec0b-0a02-4920-b274-93a6e4be0072")
+		)
+		(fp_line
+			(start 1.19888 0.95758)
+			(end 0.82804 0.95758)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "65bdb41e-5a9c-441b-a7cf-e9ee88978954")
+		)
+		(fp_line
+			(start 1.19126 -0.95504)
+			(end 0.82042 -0.95504)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2833823c-c443-4d61-9793-094ac615a088")
+		)
+		(fp_line
+			(start 0.65278 1.41478)
+			(end -0.65024 1.41478)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "537ce652-1eab-4333-a5b0-a833749c9e38")
+		)
+		(fp_line
+			(start 0.65278 -1.4097)
+			(end 0.65278 1.4097)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d494fb77-f3ab-4454-a000-f744a1e88e2b")
+		)
+		(fp_line
+			(start -0.65024 0.00762)
+			(end -0.65278 1.35636)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c52ca018-be5d-4685-9892-e0bfe2fa8012")
+		)
+		(fp_line
+			(start -0.65024 0.00508)
+			(end -0.65024 -1.41732)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9a671dea-b970-42a7-83df-d7fc665e21a0")
+		)
+		(fp_line
+			(start -0.65532 -1.42494)
+			(end 0.64262 -1.42494)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "30e3dae2-ccfc-4be2-81b2-2eaf9ab4f38f")
+		)
+		(fp_line
+			(start -0.81026 0.00254)
+			(end -1.1811 0.00254)
+			(stroke
+				(width 0.48)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "14b865bf-569e-4b98-a03c-7e7211f1b696")
+		)
+		(pad "1" smd rect
+			(at 1.10744 0.94996)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(Q2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "30cf95b6-d203-4aba-a961-9c3e6bfeff9e")
+		)
+		(pad "2" smd rect
+			(at 1.10744 -0.9525)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/RTS")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "c919269f-44c6-4003-8903-606e3fd497c5")
+		)
+		(pad "3" smd rect
+			(at -1.10236 0.00254)
+			(size 1.4 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/EN")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "e2653a60-ec3b-438f-be14-0117b6e8cab1")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/SOT-23.step"
+			(offset
+				(xyz 0 0 0.5)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz -90 0 90)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:R_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3f7e")
+		(at 141.796000 100.637000 270)
+		(tags "C0402")
+		(property "Reference" "R1"
+			(at 1.47 -0.03 180)
+			(layer "F.SilkS")
+			(uuid "43c5d8c2-77e9-455e-9413-711753d1a614")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1K"
+			(at 0 1.397 90)
+			(layer "F.Fab")
+			(uuid "4e16573c-8803-44c9-b2b2-7a3ba48631d0")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "16d731a1-334c-4a51-8f46-1743cd3c1912")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6a53e361-12ff-44b8-91e9-ec074787355f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8aaad1")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0b61af81-f37e-40c2-941c-317ff79f1cdb")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8f92d0f9-9c23-4545-bad1-3119e3d6c813")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d4669a6b-3770-4b73-9047-80e5368faeff")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "466b2737-ea5e-4e34-b519-6cb176ad02e5")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6bfcebea-3959-4529-aaa4-03a31c6cf75c")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0d997e12-ecd4-404d-a3fb-4de503fe9d8a")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6f9cd834-4e0d-41c3-896e-813f7bf61a21")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c037e704-50c8-4bcd-8f1d-1e673291abf5")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "80572a16-0f2f-420d-9c99-658e66e89806")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "884f799f-01ec-4936-b092-2a0eb10bf9fc")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3d183ce0-640d-4f8b-97b6-24613f2ad491")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "460d783a-99c5-4c5b-a12c-509d1f9cdece")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f85b79fa-34e2-43e4-8c69-b75d7b38eed7")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ee9a41a5-e50b-4e65-857e-723b25faa6b0")
+		)
+		(pad "1" smd rect
+			(at -0.508 0 90)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(Q1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "9e118f2e-37f9-416d-a5c4-181d66f482c5")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 270)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/RTS")
+			(solder_mask_margin 0.0508)
+			(uuid "5ee747f5-3d69-425a-b1f3-c973b2dfd4a8")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:R_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3fa6")
+		(at 131.960000 93.952000 180)
+		(tags "C0402")
+		(property "Reference" "R3"
+			(at -0.5 -1.1 0)
+			(layer "F.SilkS")
+			(uuid "95a4e8f2-e864-4c43-ac13-8db2d560cf62")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100R"
+			(at 0 1.397 0)
+			(layer "F.Fab")
+			(uuid "c909afb5-c5d9-442d-a281-7eeaf260fb43")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "03d19569-2694-4fe2-978e-bbf984f599ac")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b80bc789-8933-40bd-b42b-a8a0ea887849")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8af572")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d028c661-d125-4a92-9135-686be42a4b56")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5bc08d76-a6bf-413d-9031-ce0827300366")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "357ca64d-5770-4143-90c2-044898337931")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "45e4ddc6-a3c3-4da2-85f5-1d236f064f46")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "555327aa-c6e6-4d8b-9ab6-7036623bd761")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "42bc4342-347f-4ebb-979f-0fa9cbd71040")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c79fdf81-c61d-4502-86a0-dac709f43524")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "52118b7c-684b-4c10-954a-7fc6a3c0e8b6")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d0f916b2-e7e1-4855-9047-41a0ac524bb3")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "54ec7a07-84d3-420b-9748-bb15dd379da3")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0f83f417-837d-4efd-b5a2-1ec64cbafffd")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fab12dc0-91ca-4bdf-9288-02a3a6f663cd")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "754005df-e92a-4800-98c6-34557dca8546")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d49b4dbe-d3b8-477c-8719-b4abe481af0c")
+		)
+		(pad "1" smd rect
+			(at -0.508 0)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/U0RXD")
+			(solder_mask_margin 0.0508)
+			(uuid "8256635e-fed3-4354-b293-9c00fc208dc1")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 180)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(R3-Pad2)")
+			(solder_mask_margin 0.0508)
+			(uuid "8f9b214c-93ef-4d04-9357-83d267b717b9")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:R_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3fba")
+		(at 134.553000 94.003000 180)
+		(tags "C0402")
+		(property "Reference" "R4"
+			(at -0.4 -1.1 0)
+			(layer "F.SilkS")
+			(uuid "f367dcc2-bd28-44cd-a54a-66f9d7b68291")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100R"
+			(at 0 1.397 0)
+			(layer "F.Fab")
+			(uuid "8bacdc0a-f150-4a39-83c8-661abcfba510")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "5a9dc1cc-538e-4463-b5c1-d4fa8e7d86f8")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d871c68d-73cd-44b5-b71d-8f1379bc7017")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8aff5c")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0af709b6-4d18-44de-b650-878203f09c91")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "77fdc967-f388-46c7-bac2-6d011d37ee12")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "421a604b-4b19-47fa-8949-8d67a328b99f")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "296ea335-e5ad-4fd5-ad71-1640a5ddbc38")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1a9904b8-9903-4c8c-9627-e066e28dade1")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "21489bf0-9d75-4966-8fdc-76773a4e4f8f")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6d78a26d-f0be-4fc0-85d6-0275576c35a8")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9b50b163-7b4d-4a5a-9a26-286bb1abcf83")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "afdeaac9-d882-4748-96b4-e2593e1d8685")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6cb4f9de-4500-4001-8a0e-87495fbbf28c")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "13387796-3e59-431f-b907-f0d01a22b364")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b38f0052-d14d-4a40-b4d4-28313fa25b79")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d5808c2f-a3b7-4412-a18b-2e7a3dddfdf4")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9756d28b-1115-4fc2-af7f-5fb08b379a86")
+		)
+		(pad "1" smd rect
+			(at -0.508 0)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/U0TXD")
+			(solder_mask_margin 0.0508)
+			(uuid "dce00e07-dafd-4feb-b475-db34afc34981")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 180)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(R4-Pad2)")
+			(solder_mask_margin 0.0508)
+			(uuid "fe65b2de-a32f-4c23-9446-82bba982fa8d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_IC-FP:SSOP-20W"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a3fd8")
+		(at 132.300000 98.400000 270)
+		(descr "SSOP 20 pins")
+		(tags "CMS SSOP SMD")
+		(property "Reference" "U1"
+			(at -4.2 -3.5 180)
+			(layer "F.SilkS")
+			(uuid "de496a2e-6a01-4180-8898-0ccee2ff715f")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "CH340H/T"
+			(at 0 5.715 0)
+			(layer "F.Fab")
+			(uuid "41ff27c3-6b39-48d4-85cf-2bf156ab17aa")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c48f918c-f4f5-42c2-b630-5e6576122cf6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2ee7367a-b761-4e72-a29e-82b8ca1beb1c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000055069b04")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -3.81 2.7305)
+			(end -3.81 -2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "68035f87-6cd5-47b7-b246-f7024acd8b7a")
+		)
+		(fp_line
+			(start -3.81 2.7305)
+			(end 3.81 2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "cce7fb09-5dff-4c08-8b7d-e02098d30b6b")
+		)
+		(fp_line
+			(start -3.429 -2.7305)
+			(end -3.429 2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2361d3b6-0cd6-4301-b4f3-f80dedb56e58")
+		)
+		(fp_line
+			(start 3.81 -2.7305)
+			(end -3.81 -2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "dea79ab3-b0bc-445c-92e1-0503c0c4b074")
+		)
+		(fp_line
+			(start 3.81 -2.7305)
+			(end 3.81 2.7305)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6e8095af-db2c-4df0-8fb2-a3bccab98e90")
+		)
+		(fp_text user "o"
+			(at -3.81 3.556 0)
+			(layer "F.SilkS")
+			(uuid "aacbeec9-f99b-4d77-8f61-03f07bb0f591")
+			(effects
+				(font
+					(size 1.016 1.016)
+					(thickness 0.254)
+				)
+			)
+		)
+		(pad "1" smd rect
+			(at -2.925 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(solder_mask_margin 0.0508)
+			(uuid "07890969-265c-49e1-9e44-d68402d5e15e")
+		)
+		(pad "2" smd rect
+			(at -2.275 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(solder_mask_margin 0.0508)
+			(uuid "67f28907-1d6d-4c26-ad8b-ddd54daa222c")
+		)
+		(pad "3" smd rect
+			(at -1.625 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(R3-Pad2)")
+			(solder_mask_margin 0.0508)
+			(uuid "6014ba7d-68db-468c-ac25-e0158bbdc081")
+		)
+		(pad "4" smd rect
+			(at -0.975 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(R4-Pad2)")
+			(solder_mask_margin 0.0508)
+			(uuid "61def817-2e70-4a3a-9dca-b66831d4f4a7")
+		)
+		(pad "5" smd rect
+			(at -0.325 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/+3.3V")
+			(solder_mask_margin 0.0508)
+			(uuid "e5483ff9-2a40-4085-a597-084f3fa111e4")
+		)
+		(pad "6" smd rect
+			(at 0.325 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/D_P")
+			(solder_mask_margin 0.0508)
+			(uuid "dda9c363-77d3-4b31-9ae2-bed1c186a6b8")
+		)
+		(pad "7" smd rect
+			(at 0.975 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/D_N")
+			(solder_mask_margin 0.0508)
+			(uuid "3dd486be-3ecc-4342-8924-532bf4142957")
+		)
+		(pad "8" smd rect
+			(at 1.625 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "2b140a09-4a02-4d95-b95f-dcefd8c75a63")
+		)
+		(pad "9" smd rect
+			(at 2.275 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C4-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "666ef700-d49a-4f8a-a999-6a10bb742382")
+		)
+		(pad "10" smd rect
+			(at 2.925 3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "22909fde-31e3-491e-85ca-312dc7566451")
+		)
+		(pad "11" smd rect
+			(at 2.925 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad11)")
+			(solder_mask_margin 0.0508)
+			(uuid "4fc06dd2-0c45-406b-892a-f09892b5438a")
+		)
+		(pad "12" smd rect
+			(at 2.275 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad12)")
+			(solder_mask_margin 0.0508)
+			(uuid "ae19993d-4d8a-4cc3-983a-1218d53420cb")
+		)
+		(pad "13" smd rect
+			(at 1.625 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad13)")
+			(solder_mask_margin 0.0508)
+			(uuid "4b6f1dc9-217c-4242-a3cf-bbc59412197e")
+		)
+		(pad "14" smd rect
+			(at 0.975 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad14)")
+			(solder_mask_margin 0.0508)
+			(uuid "64082188-2f6e-4af1-9d61-aad04a336ce4")
+		)
+		(pad "15" smd rect
+			(at 0.325 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/DTR")
+			(solder_mask_margin 0.0508)
+			(uuid "f6319632-c37d-46de-b502-75166d8c5f03")
+		)
+		(pad "16" smd rect
+			(at -0.325 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/RTS")
+			(solder_mask_margin 0.0508)
+			(uuid "dbfc3510-0568-45d9-a9c9-7914c106b9ac")
+		)
+		(pad "17" smd rect
+			(at -0.975 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(solder_mask_margin 0.0508)
+			(uuid "306d12e4-19b9-48a3-8387-785799dc981d")
+		)
+		(pad "18" smd rect
+			(at -1.625 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad18)")
+			(solder_mask_margin 0.0508)
+			(uuid "5b884ccb-faa7-4810-a925-e59756821566")
+		)
+		(pad "19" smd rect
+			(at -2.275 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/+3.3V")
+			(solder_mask_margin 0.0508)
+			(uuid "1d34e49b-8a46-4654-995f-83c66f5cbf39")
+		)
+		(pad "20" smd rect
+			(at -2.925 -3.6195 270)
+			(size 0.325 1.27)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U1-Pad20)")
+			(solder_mask_margin 0.0508)
+			(uuid "fa2243b4-8c94-44ec-9891-647bdb349a3e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/SSOP-20_5.3x7.2mm_P0.65mm.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 -90)
+			)
+		)
+	)
+	(footprint "OLIMEX_Connectors-FP:USB-MICRO_MISB-SWMM-5B_LF"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8a4001")
+		(at 117.500000 100.000000 180)
+		(property "Reference" "USB1"
+			(at -4.8 0.9 90)
+			(layer "F.SilkS")
+			(uuid "49c304bc-0e90-413f-ac15-e11b46f84fa4")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "USB-uicro-B"
+			(at 0 6.75 0)
+			(layer "F.Fab")
+			(uuid "f6ce7fb3-95a6-4f77-8aee-68f9d967d88f")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bdaaf03a-c35f-46e5-8ce7-338983ab1ae9")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7806526d-eeb0-4f24-b1a8-d8b28f3ed700")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005506aa9a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 3.5 -4.064)
+			(end 3.5 4.064)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b8231ab5-c092-4217-a913-f50444a515c4")
+		)
+		(fp_line
+			(start 3.429 4.064)
+			(end 2.413 3.683)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "09d6b1cb-0c83-4e0b-997d-ad2c13ead9a7")
+		)
+		(fp_line
+			(start 3.429 -4.064)
+			(end 2.413 -3.683)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "48760d6b-2690-48bc-bd3b-fec690fc94d8")
+		)
+		(fp_line
+			(start 2.4 3.7)
+			(end 1.4 3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "de64ecb8-ae38-405e-bdbd-5c50912a3a1c")
+		)
+		(fp_line
+			(start 2.4 -3.7)
+			(end 2.4 3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "fb5fa81d-1b93-4fe0-8c20-e2e6aef2967e")
+		)
+		(fp_line
+			(start 1.4 -3.7)
+			(end 2.4 -3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "1e28470d-17d2-443e-9b86-8e6dddb6f236")
+		)
+		(fp_line
+			(start -2.1 3.7)
+			(end -0.9 3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "decf7438-feb0-4b7a-9536-2bb8b425d94b")
+		)
+		(fp_line
+			(start -2.1 -3.7)
+			(end -0.9 -3.7)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "9baccd7b-4072-4ab8-8b3c-90f1e87ebfdb")
+		)
+		(fp_line
+			(start -3.6 1.8)
+			(end -3.6 2.8)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "743a2f78-6a67-404e-a07f-d950c966644f")
+		)
+		(fp_line
+			(start -3.6 -2.8)
+			(end -3.6 -1.8)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "22e55154-0703-4094-bd1d-abb7ed125fc1")
+		)
+		(fp_line
+			(start 3.5 3.7)
+			(end -3.6 -3.7)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9a1f64f7-dd2b-4e25-8302-ee9acf3e5990")
+		)
+		(fp_line
+			(start 3.5 3.7)
+			(end -3.62 3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7f548f60-02c7-4682-b0ce-9b4a103f29ca")
+		)
+		(fp_line
+			(start 3.5 -3.7)
+			(end 3.5 3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c6166d67-c0e5-44c2-be50-f2a83cd6437b")
+		)
+		(fp_line
+			(start 3.5 -3.7)
+			(end -3.6 3.7)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ea49c05d-e561-4e59-95a2-7302731ed53c")
+		)
+		(fp_line
+			(start 2.4 3.7)
+			(end 2.4 -3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6955c5d9-b2f1-406f-91db-a82ee674e8ef")
+		)
+		(fp_line
+			(start -3.62 3.7)
+			(end -3.62 -3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d20b1762-9334-44c0-8eed-693a64f24efd")
+		)
+		(fp_line
+			(start -3.62 -3.7)
+			(end 3.5 -3.7)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4f97366d-a610-40ef-a60e-ebc7a58fcd19")
+		)
+		(fp_text user "VBUS"
+			(at -0.5 1.5 0)
+			(layer "F.SilkS")
+			(uuid "59e29b7f-994c-4d5c-8b45-bdf6f55594e2")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "GND"
+			(at -0.9 -1.6 0)
+			(layer "F.SilkS")
+			(uuid "d417b14b-7619-49b0-b8c7-5cb703f3ed30")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "D-"
+			(at -1 0.75 0)
+			(layer "F.SilkS")
+			(uuid "f3c3ec99-e38a-4e54-8391-fafbafffeaa0")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "D+"
+			(at -1 0 0)
+			(layer "F.SilkS")
+			(uuid "43596a4e-6638-4bf5-aca5-99e16d344e98")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "ID"
+			(at -1.25 -0.75 0)
+			(layer "F.SilkS")
+			(uuid "74369b5a-2b46-409b-886b-8a1e34fced14")
+			(effects
+				(font
+					(size 0.508 0.508)
+					(thickness 0.127)
+				)
+			)
+		)
+		(fp_text user "pcb edge"
+			(at 2.1 0 90)
+			(layer "F.Fab")
+			(uuid "2384cac3-eaf9-41af-ae23-8e3f02458a35")
+			(effects
+				(font
+					(size 0.3 0.3)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at -1.9 -2 270)
+			(size 0.6 0.6)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(solder_mask_margin 0.0508)
+			(uuid "d0afb88c-e134-482e-b278-893e3089c3b1")
+		)
+		(pad "" np_thru_hole circle
+			(at -1.9 2 270)
+			(size 0.6 0.6)
+			(drill 0.6)
+			(layers "*.Cu" "*.Mask")
+			(solder_mask_margin 0.0508)
+			(uuid "42a4dd8e-0e82-4028-bba3-4bdb4b37a067")
+		)
+		(pad "0" thru_hole oval
+			(at -3.22 -3.6 270)
+			(size 1.2 1.8)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "f9c3f8b3-51b1-4a46-9834-ff74623a7f85")
+		)
+		(pad "0" thru_hole oval
+			(at -3.22 3.6 270)
+			(size 1.2 1.8)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "b966ad11-f51a-45a6-8e83-9f4ad1d2fe58")
+		)
+		(pad "0" thru_hole oval
+			(at 0.25 -3.6 270)
+			(size 1.2 1.8)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "19e2922c-f59b-4882-b2aa-1f57564800f3")
+		)
+		(pad "0" thru_hole oval
+			(at 0.25 3.6 270)
+			(size 1.2 1.8)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "25d57cbf-b101-4639-b5bf-45fb45a0f4f0")
+		)
+		(pad "0" smd rect
+			(at 1.4 -1.5 270)
+			(size 1.1 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.127)
+			(uuid "ecf1bbb3-2a49-443e-9b15-715e1d25c075")
+		)
+		(pad "0" smd rect
+			(at 1.4 1.5 270)
+			(size 1.1 1)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.127)
+			(uuid "0fa3c66e-f326-4def-be04-4631b20f9ead")
+		)
+		(pad "1" smd rect
+			(at -3.15 1.3875 270)
+			(size 0.5 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "ded6b8dd-333c-4616-992b-be785699496c")
+		)
+		(pad "2" smd rect
+			(at -3.15 0.65 270)
+			(size 0.325 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/D_N")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.03556)
+			(uuid "eb0e35e8-1943-4845-9e33-c88d6c28986a")
+		)
+		(pad "3" smd rect
+			(at -3.15 0 270)
+			(size 0.325 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/D_P")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.03556)
+			(uuid "060a14c7-77e8-4490-8ae8-7dded28d4cd8")
+		)
+		(pad "4" smd rect
+			(at -3.15 -0.65 270)
+			(size 0.325 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(USB1-Pad4)")
+			(solder_mask_margin 0.0508)
+			(solder_paste_margin 0.03556)
+			(uuid "be7ce030-740b-4d93-986d-10e697a77ee0")
+		)
+		(pad "5" smd rect
+			(at -3.15 -1.3875 270)
+			(size 0.5 1.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "eb963628-6d9e-40f8-9010-b5bb679b47b3")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/usb_micro_4p.stp"
+			(offset
+				(xyz -2.45 0 1.1)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 -90)
+			)
+		)
+	)
+	(footprint "OLIMEX_RLC-FP:R_0402_5MIL_DWS"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8c45a4")
+		(at 141.908000 103.080000 90)
+		(tags "C0402")
+		(property "Reference" "R2"
+			(at 1.07 -1.58 0)
+			(layer "F.SilkS")
+			(uuid "4796363d-3e81-459f-a212-c43aa52ab3e8")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1K"
+			(at 0 1.397 90)
+			(layer "F.Fab")
+			(uuid "8997ade5-a6c1-4e3f-abb4-e35719c5901f")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "44e33ed6-4445-4806-a41f-123365cfee7b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "aec16f68-2858-4fd8-b150-774caa5d0b6a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005d8ab138")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 -0.4445)
+			(end 0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6740a799-6bf9-4ad8-860f-cfb7420a758a")
+		)
+		(fp_line
+			(start 0 -0.4445)
+			(end -0.254 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "cb0dd33d-f8e5-4678-a807-963e05815359")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "466e974f-ff64-48ef-82cd-524278169324")
+		)
+		(fp_line
+			(start 0 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c06452a3-6b10-4682-a506-b13bddc4a16b")
+		)
+		(fp_line
+			(start 0.889 -0.4445)
+			(end 0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "828ea7b4-fb09-43d7-8505-66eefcf35224")
+		)
+		(fp_line
+			(start 0.254 -0.4445)
+			(end 0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "98a83e8e-305a-4d38-a866-1e5df6f38783")
+		)
+		(fp_line
+			(start -0.254 -0.4445)
+			(end -0.889 -0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "93acd6fb-a6fd-41e8-82c0-507d15d45e6f")
+		)
+		(fp_line
+			(start -0.889 -0.4445)
+			(end -0.889 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "fd628e01-5142-4d03-b897-2fde269ac67d")
+		)
+		(fp_line
+			(start 0.889 0.4445)
+			(end 0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5ba9276b-ae34-4731-9f54-e78304a42feb")
+		)
+		(fp_line
+			(start -0.889 0.4445)
+			(end -0.254 0.4445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "194aa5bd-bf92-4b13-b97d-3e56826e068d")
+		)
+		(fp_line
+			(start -0.49784 -0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "53ecc657-6bf8-4237-8515-b4cb0bf8aae8")
+		)
+		(fp_line
+			(start 0.49784 0.24892)
+			(end 0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "12400381-8471-49b4-a40c-3a08acb9358d")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end -0.49784 -0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "138f7812-9c53-44f1-823c-b3dbbcf5047d")
+		)
+		(fp_line
+			(start -0.49784 0.24892)
+			(end 0.49784 0.24892)
+			(stroke
+				(width 0.06604)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "aa3608fc-e4a3-46b2-b1a4-6c04a2020aac")
+		)
+		(pad "1" smd rect
+			(at -0.508 0 270)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(Q2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "40bf59e5-1e1a-4369-9f07-8a89731e80eb")
+		)
+		(pad "2" smd rect
+			(at 0.508 0 90)
+			(size 0.5 0.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/DTR")
+			(solder_mask_margin 0.0508)
+			(uuid "f90028d5-92ce-4c2e-8bfb-90e1bfadeacc")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_Other-FP:Fiducial1x3_transp"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8c55cd")
+		(at 141.200000 95.900000)
+		(property "Reference" "Ref*"
+			(at 0 3 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "5a22dbb2-ec0a-40f6-aacb-432ac5b6d21f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "Val**"
+			(at 0 -3 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d3151732-31b9-4d5d-a6c4-dacf550da8c0")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "253f7a3c-5603-42f9-96cf-c9539251fbf5")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9d930eec-c497-4e5d-b53a-a95cfb340f03")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 1.5 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(fill no)
+			(layer "Dwgs.User")
+			(uuid "eec7448f-6827-4289-a4ac-c8840394d472")
+		)
+		(pad "Fid1" connect circle
+			(at 0 0)
+			(size 1 1)
+			(layers "F.Cu" "F.Mask")
+			(solder_mask_margin 0.127)
+			(clearance 1.016)
+			(zone_connect 0)
+			(uuid "a66154ca-f352-4c46-85cc-f8f40e022877")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "OLIMEX_Other-FP:Fiducial1x3_transp"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8c55f6")
+		(at 118.100000 99.900000)
+		(property "Reference" "Ref*"
+			(at 0 3 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "d084a8ae-21ad-49b8-ba12-392d130d8d3e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "Val**"
+			(at 0 -3 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bcd7a0ff-8f2b-461b-bbf7-f38b71b3588b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "895763e0-6dfe-4f7f-a7a5-5a443538985c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "135940cb-574b-49d8-8ed1-4af4bd2c030d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 1.5 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(fill no)
+			(layer "Dwgs.User")
+			(uuid "78d81f2c-791c-4230-a277-0f3baae900db")
+		)
+		(pad "Fid1" connect circle
+			(at 0 0)
+			(size 1 1)
+			(layers "F.Cu" "F.Mask")
+			(solder_mask_margin 0.127)
+			(clearance 1.016)
+			(zone_connect 0)
+			(uuid "2d155a1a-f657-42da-b8d5-213c35dcb349")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "OLIMEX_Connectors-FP:HN1x7"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005e748049")
+		(at 135.950000 92.250000 180)
+		(property "Reference" "CON2"
+			(at -5.461 2.413 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "58891d30-5d6d-4fb8-93f7-76c25927bd03")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Value" "CON6"
+			(at -4.572 -2.286 0)
+			(layer "F.Fab")
+			(uuid "fad69636-4284-4c3b-bea4-d4d5ca63b7a3")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9958741b-1461-4b90-8985-ee30ca2d4677")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "27296a28-bc98-448e-b416-cf185395cabb")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005e6232db")
+		(solder_mask_margin 0.0508)
+		(solder_paste_margin -0.0508)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 8.89 1.016)
+			(end 8.636 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "79f4637d-072b-47c1-9272-c8b2f9ae2cfd")
+		)
+		(fp_line
+			(start 8.89 -1.016)
+			(end 8.89 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5daa2209-be86-4d6a-92c3-1dc736bc2d21")
+		)
+		(fp_line
+			(start 8.636 1.27)
+			(end 6.604 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3fbf136b-d40b-4dce-b683-4a80232d8b71")
+		)
+		(fp_line
+			(start 8.636 -1.27)
+			(end 8.89 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f502c06f-109a-4d36-8690-310ed3d5a2b2")
+		)
+		(fp_line
+			(start 6.604 1.27)
+			(end 6.35 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "85cccb2e-faa0-47a6-b9f2-9efa8846e83f")
+		)
+		(fp_line
+			(start 6.604 -1.27)
+			(end 8.636 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6ae7a2ea-8e42-443d-82c8-17870fc30859")
+		)
+		(fp_line
+			(start 6.35 1.016)
+			(end 6.096 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "28bb1b5d-1acc-42ee-af32-7d1b10e65ebe")
+		)
+		(fp_line
+			(start 6.35 1.016)
+			(end 6.096 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b914cccd-5a67-47db-8b0a-f1804c4666fc")
+		)
+		(fp_line
+			(start 6.35 -1.016)
+			(end 6.604 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b726b044-11ef-4eff-be06-9d1384ae97c7")
+		)
+		(fp_line
+			(start 6.096 1.27)
+			(end 4.064 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2650c47b-8a2f-4d8a-9f60-2cf3d227ab1f")
+		)
+		(fp_line
+			(start 6.096 1.27)
+			(end 4.064 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "94e42917-0247-40a3-a467-b6105e13f8c0")
+		)
+		(fp_line
+			(start 6.096 -1.27)
+			(end 6.35 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "85ecdaa2-5db4-4523-bdfe-22aa4587006b")
+		)
+		(fp_line
+			(start 6.096 -1.27)
+			(end 6.35 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d6acae53-f416-42ef-8fa3-7852b98c6aed")
+		)
+		(fp_line
+			(start 4.064 1.27)
+			(end 3.81 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "49841fc1-c3bf-404b-a538-6184e13171c0")
+		)
+		(fp_line
+			(start 4.064 1.27)
+			(end 3.81 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ecbc9c1f-db5f-4c2f-8d4e-0e3266863a00")
+		)
+		(fp_line
+			(start 4.064 -1.27)
+			(end 6.096 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "23d8321e-e01d-4d03-b916-ea99d9f35184")
+		)
+		(fp_line
+			(start 4.064 -1.27)
+			(end 6.096 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "409003a0-ec5d-4c2b-a17f-e78359a86337")
+		)
+		(fp_line
+			(start 3.81 1.016)
+			(end 3.556 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "38c198d0-4e4b-4717-98b4-5cc9ccd6167b")
+		)
+		(fp_line
+			(start 3.81 -1.016)
+			(end 4.064 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7fe671a2-c011-4c25-a098-9f577313bfde")
+		)
+		(fp_line
+			(start 3.81 -1.016)
+			(end 4.064 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a5be7f77-b184-4b1d-8cb0-8cb0355f4691")
+		)
+		(fp_line
+			(start 3.556 1.27)
+			(end 1.524 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f0090590-9469-4512-80fc-fb6e3a121c53")
+		)
+		(fp_line
+			(start 3.556 -1.27)
+			(end 3.81 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ece75c62-f528-4d97-adc8-499ff6bcc158")
+		)
+		(fp_line
+			(start 1.524 1.27)
+			(end 1.27 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "186c04ff-d713-4a12-9342-9abae5c798be")
+		)
+		(fp_line
+			(start 1.524 -1.27)
+			(end 3.556 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "56493d8f-bab0-4d72-b089-3002bb1b1190")
+		)
+		(fp_line
+			(start 1.27 1.016)
+			(end 1.016 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b6834206-e593-4abc-bec4-14226b22660e")
+		)
+		(fp_line
+			(start 1.27 -1.016)
+			(end 1.524 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f6081fcb-9c10-4178-a92d-e7c0e6de24dc")
+		)
+		(fp_line
+			(start 1.016 1.27)
+			(end -1.016 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "234543ee-7650-4aed-87bf-f8b3558269f0")
+		)
+		(fp_line
+			(start 1.016 -1.27)
+			(end 1.27 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3f602ce5-47d0-4fc9-b75d-80450e14872b")
+		)
+		(fp_line
+			(start -1.016 1.27)
+			(end -1.27 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a7c2185d-92a8-4cd7-9430-a6f32fd63c0b")
+		)
+		(fp_line
+			(start -1.016 -1.27)
+			(end 1.016 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0db1071d-eb09-4b1d-b686-60df08a125e0")
+		)
+		(fp_line
+			(start -1.27 1.016)
+			(end -1.524 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d90ddfca-7a04-45e3-9fab-71fb10427af4")
+		)
+		(fp_line
+			(start -1.27 -1.016)
+			(end -1.016 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2070842e-31b7-43eb-85f7-332b0241b386")
+		)
+		(fp_line
+			(start -1.524 1.27)
+			(end -3.556 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "4a13fdde-8547-411e-a359-22d321903c0d")
+		)
+		(fp_line
+			(start -1.524 -1.27)
+			(end -1.27 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "da42f39c-0634-4821-81d5-65dc3e0ba509")
+		)
+		(fp_line
+			(start -3.556 -1.27)
+			(end -1.524 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "1df38c24-f8b2-4fdc-93ec-ff35366fc9e9")
+		)
+		(fp_line
+			(start -3.81 1.016)
+			(end -3.556 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "085174c4-261a-4cce-86e1-98950547c46d")
+		)
+		(fp_line
+			(start -3.81 -1.016)
+			(end -3.556 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "fddf9c75-ae34-45e0-9a0e-7c3f8f79f0cf")
+		)
+		(fp_line
+			(start -4.064 1.27)
+			(end -3.81 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e4b91edb-ca8c-4791-b26d-80a22666ec4d")
+		)
+		(fp_line
+			(start -4.064 1.27)
+			(end -6.096 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "de460094-b3fc-4b8d-98eb-dfbea00ebf8d")
+		)
+		(fp_line
+			(start -4.064 -1.27)
+			(end -3.81 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b74b8754-7950-42ce-8be2-d94e27f84e83")
+		)
+		(fp_line
+			(start -6.096 1.27)
+			(end -6.35 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6e30ce82-b265-4909-bece-ae66e14b8baf")
+		)
+		(fp_line
+			(start -6.096 -1.27)
+			(end -4.064 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "48213b6f-c99c-4c0e-b9cf-7a18c593f99f")
+		)
+		(fp_line
+			(start -6.35 1.016)
+			(end -6.604 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7e239f8d-1b00-4dbb-8513-147e2f71cec9")
+		)
+		(fp_line
+			(start -6.35 -1.016)
+			(end -6.096 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d80d9371-813f-4a45-9721-e93b966f1f8d")
+		)
+		(fp_line
+			(start -6.604 1.27)
+			(end -8.382 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "22f1d24e-97d0-40d3-bd24-c2f1da841a0e")
+		)
+		(fp_line
+			(start -6.604 -1.27)
+			(end -6.35 -1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "995aeade-ca59-46f7-9851-3e541c28640e")
+		)
+		(fp_line
+			(start -8.382 1.27)
+			(end -8.89 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6cdfbda3-be39-4d77-a984-8c6f8e708bb1")
+		)
+		(fp_line
+			(start -8.636 1.27)
+			(end -8.89 1.016)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "70a204d2-fc99-4d57-87fe-c11459b1aea6")
+		)
+		(fp_line
+			(start -8.636 -1.27)
+			(end -6.604 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e022fbc6-cf7c-4b8a-9fe8-342f846028ce")
+		)
+		(fp_line
+			(start -8.89 -1.016)
+			(end -8.636 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "64b93feb-1f38-4cdc-b26d-403a74daa5b6")
+		)
+		(fp_line
+			(start -8.89 -1.27)
+			(end -8.636 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b1ed7dd7-5bc4-4213-b0f1-f6015dfdf15f")
+		)
+		(fp_line
+			(start -8.89 -1.27)
+			(end -8.89 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6f29ba7f-98ff-44d9-9503-050fdedf6277")
+		)
+		(pad "1" thru_hole rect
+			(at -7.62 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/U0TXD")
+			(uuid "bb3a5c4d-5e88-4c24-b153-cdcb213070c0")
+		)
+		(pad "2" thru_hole circle
+			(at -5.08 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/DCOM")
+			(uuid "3fdee40b-e6f5-44f8-9c78-a400123393b9")
+		)
+		(pad "3" thru_hole circle
+			(at -2.54 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/U0RXD")
+			(uuid "6f689253-4a69-4a17-a489-8ec750194451")
+		)
+		(pad "4" thru_hole circle
+			(at 0 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(uuid "347ec922-89d8-4e0d-ba1c-c78eeaa440e9")
+		)
+		(pad "5" thru_hole circle
+			(at 2.54 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/+3.3V")
+			(uuid "1f546d42-d89a-452d-9134-91f19e7e2e1a")
+		)
+		(pad "6" thru_hole circle
+			(at 5.08 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/EN")
+			(uuid "d657bd9b-1997-4c12-a6d0-9bb0428a2f0d")
+		)
+		(pad "7" thru_hole circle
+			(at 7.62 0 180)
+			(size 1.778 1.778)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(C1-Pad1)")
+			(uuid "cddce539-c821-4b82-b034-e9ffc30ea6b0")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/HN1x6-PinHeader_1x07_P2.54mm_Vertical.step"
+			(offset
+				(xyz 6.35 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 90)
+			)
+		)
+	)
+	(footprint "OLIMEX_Transistors-FP:SOT89"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005e7dd2a7")
+		(at 124.400000 95.000000)
+		(descr "SOT89-3, Housing, Handsoldering,")
+		(tags "SOT89-3, Housing, Handsoldering,")
+		(property "Reference" "U2"
+			(at -0.27 3.31 180)
+			(layer "F.SilkS")
+			(uuid "4d499ddb-9693-4a96-b8ae-98c0aa11141f")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "ME6210-SOT89"
+			(at -0.14986 5.30098 90)
+			(layer "F.Fab")
+			(uuid "09ab069b-133c-44dc-b87f-3000df24a4d8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "87d25ea4-1c99-4745-8bb9-a416916a43b3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "35a933bc-5d93-4a6e-9d30-c1dafea26fd0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005e7df28a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_poly
+			(pts
+				(xy 0.9 -0.1) (xy 0.5 0.9) (xy 0.5 2.3) (xy -0.5 2.3) (xy -0.5 0.9) (xy -0.9 -0.1) (xy -0.9 -2.4)
+				(xy 0.9 -2.4)
+			)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.Cu")
+			(uuid "977551d5-4fec-461a-bbe5-47b5f15f9e0c")
+		)
+		(fp_poly
+			(pts
+				(xy 0.9 -0.1) (xy 0.5 0.9) (xy 0.5 2.3) (xy -0.5 2.3) (xy -0.5 0.9) (xy -0.9 -0.1) (xy -0.9 -2.4)
+				(xy 0.9 -2.4)
+			)
+			(stroke
+				(width 0.2)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.Mask")
+			(uuid "ea372e2b-574f-4f26-bd71-4293918f1ee8")
+		)
+		(fp_line
+			(start -2 2.5)
+			(end -2.2 2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2f01de8b-4ad6-43bf-8b50-a0fd645ef669")
+		)
+		(fp_line
+			(start 2 2.5)
+			(end 2.5 2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "dc65565f-2085-4f61-898f-6caf12c41fe1")
+		)
+		(fp_line
+			(start 2.5 2.5)
+			(end 2.5 2)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "850dcbae-65d7-4efd-8f57-8251cd24eb0f")
+		)
+		(fp_line
+			(start -2.5 2.2)
+			(end -2.5 2)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "63a05f30-b14e-49df-90a8-082b44f672fe")
+		)
+		(fp_line
+			(start -2.5 -2.5)
+			(end -2.5 -2)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8f8ab5de-93e0-4e21-b746-0cd11f6498c7")
+		)
+		(fp_line
+			(start -2 -2.5)
+			(end -2.5 -2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7999a14c-f90f-4e95-9dfb-d035c4b788dd")
+		)
+		(fp_line
+			(start 2 -2.5)
+			(end 2.5 -2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c4940040-c76d-4f2f-b1e9-21e61bdb8fff")
+		)
+		(fp_line
+			(start 2.5 -2.5)
+			(end 2.5 -2)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ec8f83e2-8e46-4509-8221-c2db1fcc6f86")
+		)
+		(fp_circle
+			(center -2.5 2.5)
+			(end -2.3 2.5)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.SilkS")
+			(uuid "1d46db64-e89c-4804-ae00-1472503eef2b")
+		)
+		(fp_poly
+			(pts
+				(xy 0.8 -0.1) (xy 0.4 0.9) (xy 0.4 2.2) (xy -0.4 2.2) (xy -0.4 0.9) (xy -0.8 -0.1) (xy -0.8 -2.3)
+				(xy 0.8 -2.3)
+			)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.Paste")
+			(uuid "2d626057-abb9-44e8-bb1f-5570561ddd73")
+		)
+		(pad "1" smd rect
+			(at -1.5 1.65)
+			(size 0.8 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "da51fbcf-8774-4852-961b-f2ad188274e7")
+		)
+		(pad "2" smd rect
+			(at 0 1.55)
+			(size 0.9 1.5019)
+			(layers "F.Cu")
+			(net "Net-(C1-Pad1)")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "6e34de5f-e239-44f9-9f76-e35b6d5e57f0")
+		)
+		(pad "3" smd rect
+			(at 1.5 1.65)
+			(size 0.8 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/+3.3V")
+			(solder_mask_margin 0.0508)
+			(clearance 0.0508)
+			(uuid "dbeea0f7-3ac9-4d44-ab36-4ac4fcdbaabe")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/SOT89-1.STEP"
+			(offset
+				(xyz 0 0.1016 0.0254)
+			)
+			(scale
+				(xyz 0.95 1.2 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_Crystal-FP:TSX-3.2x2.5mm_GND(3)"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005e7ddfaf")
+		(at 130.450000 103.780000)
+		(property "Reference" "Y1"
+			(at -1.82 -3.15 180)
+			(layer "F.SilkS")
+			(uuid "03121111-9419-414a-ab71-00c655704de1")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "Q12MHz/20pF/10ppm/4P/3.2x2.5mm"
+			(at 0.127 2.54 90)
+			(layer "F.Fab")
+			(uuid "30809338-aca2-4b26-9958-a85bc63191e9")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.254)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4e700320-8d5d-4c1f-a309-b06e5e3864a6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a382fa8e-73e2-4a93-9983-2a809e9bd9d1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005e7f6109")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.254 -1.27)
+			(end -0.254 -1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "12ef613e-edd9-4c96-9132-5641a499f9ed")
+		)
+		(fp_line
+			(start 0.254 1.27)
+			(end -0.254 1.27)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ee1ed1cb-ec57-43b6-b538-d5f108ef3f1f")
+		)
+		(fp_line
+			(start 0.39878 -0.64516)
+			(end 0.39878 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1d269107-a22b-4d0e-967e-5fb2593f1030")
+		)
+		(fp_line
+			(start -0.39878 -0.64516)
+			(end -0.39878 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e7cae2c5-aefe-46ed-8a07-02b0317d2cda")
+		)
+		(fp_line
+			(start 1.59766 -0.17272)
+			(end 1.59766 0.17272)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a54fefdd-c755-497e-86f4-de6bf165292f")
+		)
+		(fp_line
+			(start 0.39878 0)
+			(end 0.89916 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f829dffa-0492-4d78-844c-c070d63ca67b")
+		)
+		(fp_line
+			(start 0.39878 0)
+			(end 0.39878 0.64516)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "80ec3b07-a368-4c7e-9155-4cc9e0a0dfcf")
+		)
+		(fp_line
+			(start -0.39878 0)
+			(end -0.89916 0)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "644db91b-5b97-49f8-8f33-b2e0af1fbea6")
+		)
+		(fp_line
+			(start -0.39878 0)
+			(end -0.39878 0.64516)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ec5458e9-087e-453c-ae30-d0d95d6e4bb3")
+		)
+		(fp_line
+			(start -1.59766 0.17272)
+			(end -1.59766 -0.17272)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "15718051-8fb3-40fc-b558-f641c3bf422d")
+		)
+		(fp_line
+			(start 0 0.59944)
+			(end 0 -0.59944)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0d9199b6-063e-4796-b7cb-d02333d217d7")
+		)
+		(fp_line
+			(start 1.6 -1.25)
+			(end 1.6 1.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "904f6030-94ec-4f67-a4ca-cb251e0b0f3e")
+		)
+		(fp_line
+			(start -1.6 -1.25)
+			(end 1.6 -1.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ed11ccd0-dc3e-43ab-863e-56f488fdf597")
+		)
+		(fp_line
+			(start 1.6 1.25)
+			(end -1.6 1.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "146fc510-c794-4715-aad5-5b26a26a33e4")
+		)
+		(fp_line
+			(start -1.6 1.25)
+			(end -1.6 -1.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "55e5f80a-4435-48c6-8b47-f295690fa008")
+		)
+		(fp_text user "o"
+			(at -2.04 1.82 90)
+			(layer "F.SilkS")
+			(uuid "1a09e987-9e03-4659-8b42-50fb032f6d1a")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.2)
+				)
+			)
+		)
+		(pad "1" smd rect
+			(at -1.1 0.8)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C4-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "6209d7a9-7bb0-4acc-b02e-ac7c5bc76c93")
+		)
+		(pad "2" smd rect
+			(at 1.1 -0.8)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(C2-Pad1)")
+			(solder_mask_margin 0.0508)
+			(uuid "e7c91bc7-e432-43a2-8fab-26d60e560920")
+		)
+		(pad "3" smd rect
+			(at -1.1 -0.8)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "9de4951d-d0d3-4f7b-9b70-117d3bd6a461")
+		)
+		(pad "3" smd rect
+			(at 1.1 0.8)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(solder_mask_margin 0.0508)
+			(uuid "467b9159-8e10-4a6c-bb2a-dc877dc6adfe")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/QSG5032.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 0.65 0.8 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "OLIMEX_LOGOs-FP:LOGO_RECYCLEBIN_1"
+		(locked yes)
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005a3b5201")
+		(at 129.875000 98.250000)
+		(property "Reference" ""
+			(at 2.11 7.12 270)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "753efeb2-895d-45aa-a3f5-a019a6c12f77")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" ""
+			(at 2.85 -1.56 270)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "61f51a22-9847-48fe-b0c9-39b4a8449c96")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "aa66445a-4ded-4c68-a1ec-e1d699ed1294")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9bf17aef-045f-4b12-8321-e0a2f69d807b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 4.62 0.05)
+			(end 0.048 0.05)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "c3a770e4-0b1b-4d1d-ae1e-06ba7d4ab530")
+		)
+		(fp_line
+			(start 0.048 0.05)
+			(end 0.048 0.812)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6c26bd3f-ae0d-4fc0-9145-95e4745eb319")
+		)
+		(fp_line
+			(start 0.0988 0.1516)
+			(end 4.5184 0.1516)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ebdbfdd5-db0e-4670-829a-58624107b96c")
+		)
+		(fp_line
+			(start 4.5184 0.2532)
+			(end 0.1496 0.2532)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "416d01ca-66e9-4362-965a-b27c00734516")
+		)
+		(fp_line
+			(start 4.5692 0.3548)
+			(end 0.1496 0.3548)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "193d7829-0d78-4ccc-a742-04932c66491c")
+		)
+		(fp_line
+			(start 0.0988 0.4564)
+			(end 4.5692 0.4564)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "3b4ad343-af61-4a65-893b-df33af0321d4")
+		)
+		(fp_line
+			(start 4.5692 0.5072)
+			(end 0.1496 0.5072)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9347ed48-f6de-4de8-914b-312a974489da")
+		)
+		(fp_line
+			(start 0.0988 0.6088)
+			(end 4.5184 0.6088)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "cbe419f8-e0bc-451b-8c59-a46d0491a249")
+		)
+		(fp_line
+			(start 0.0988 0.6596)
+			(end 4.5692 0.6596)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1dd4286e-6fe8-4590-8a7b-f862e235184e")
+		)
+		(fp_line
+			(start 4.5692 0.7612)
+			(end 0.1496 0.7612)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6515c522-deca-4fb6-877f-19eb317ad154")
+		)
+		(fp_line
+			(start 4.62 0.812)
+			(end 4.62 0.05)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2b7e78a3-6f23-4153-9481-66e582a4f83a")
+		)
+		(fp_line
+			(start 0.048 0.812)
+			(end 4.62 0.812)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "26f1e023-b1e1-4cbd-8c33-937ee8af69f3")
+		)
+		(fp_line
+			(start 1.905 1.524)
+			(end 1.905 1.778)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "fe076586-8b23-451b-8504-42fec5ea9194")
+		)
+		(fp_line
+			(start 1.397 1.524)
+			(end 1.905 1.524)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "db927824-71a5-4e0d-a955-bfe0252fd876")
+		)
+		(fp_line
+			(start 0.381 1.524)
+			(end 4.445 5.461)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a4d540c3-c41c-4718-8649-f1c203ca2fa0")
+		)
+		(fp_line
+			(start 1.397 1.905)
+			(end 1.397 1.524)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "48d63ecb-85fd-47ee-b604-b22fd709e6df")
+		)
+		(fp_line
+			(start 1.397 1.905)
+			(end 2.794 1.905)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "47254a88-da81-499b-b727-058ca6ef6061")
+		)
+		(fp_line
+			(start 1.397 1.905)
+			(end 1.143 4.953)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5867f6b7-1c33-4eb8-ae18-53cd2c5e2ddb")
+		)
+		(fp_line
+			(start 3.302 2.413)
+			(end 3.429 4.445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4d76ffd7-4730-4ac7-9ea1-74a36dd42db7")
+		)
+		(fp_line
+			(start 3.048 4.191)
+			(end 2.159 4.191)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1c87ecef-aee6-401a-87e9-a2ace319b1a9")
+		)
+		(fp_line
+			(start 2.159 4.191)
+			(end 2.159 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "37c86ad1-a668-4dfb-a370-13eadf8b71c0")
+		)
+		(fp_line
+			(start 2.286 4.445)
+			(end 2.921 4.445)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "abe175d4-63eb-4c3e-a45f-b6d3d50a03d0")
+		)
+		(fp_line
+			(start 3.81 4.572)
+			(end 3.81 5.08)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9b849a6f-7d10-4079-859f-47d7af1786dc")
+		)
+		(fp_line
+			(start 3.556 4.572)
+			(end 3.556 4.953)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "19938a1e-8900-4230-b683-6f12522427b5")
+		)
+		(fp_line
+			(start 3.429 4.572)
+			(end 3.81 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "63952aba-e317-476d-b5d3-ae42848e1b60")
+		)
+		(fp_line
+			(start 3.048 4.572)
+			(end 3.048 4.191)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ac62629b-3f4f-4b3a-bd36-817e441ad123")
+		)
+		(fp_line
+			(start 2.159 4.572)
+			(end 3.048 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "31fbe4af-8146-4618-acdd-14c700e1e4be")
+		)
+		(fp_line
+			(start 3.683 4.953)
+			(end 3.683 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "db77199c-da3c-4e7e-b498-2f904c426056")
+		)
+		(fp_line
+			(start 3.556 4.953)
+			(end 3.556 4.826)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4147d352-3a1d-4916-84b8-bbd8ff4feb24")
+		)
+		(fp_line
+			(start 3.556 4.953)
+			(end 3.556 4.826)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d74bec66-733a-4bd0-a131-82bbe45cc860")
+		)
+		(fp_line
+			(start 3.556 4.953)
+			(end 3.683 4.953)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "364bc577-3160-448a-b54b-2908f8175fa4")
+		)
+		(fp_line
+			(start 3.556 5.08)
+			(end 3.683 4.699)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f7d39122-fbfa-451c-a65c-f3de104ec7b5")
+		)
+		(fp_line
+			(start 3.429 5.08)
+			(end 3.429 4.572)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "cfb5f6ed-7f32-42a9-a98e-564708830f70")
+		)
+		(fp_line
+			(start 0.889 5.08)
+			(end 3.81 5.08)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a1e6e454-f246-422a-a919-36afb5c15ce8")
+		)
+		(fp_line
+			(start 1.397 5.207)
+			(end 1.397 5.715)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "64091c10-8f5b-4e2f-8557-813aa98d4495")
+		)
+		(fp_line
+			(start 0.254 5.588)
+			(end 4.445 1.397)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "38ef1034-ae58-4456-92e0-258f1ab01929")
+		)
+		(fp_line
+			(start 1.524 5.715)
+			(end 1.524 5.207)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4a762539-7c06-42b2-9e7c-5133172ffd3a")
+		)
+		(fp_line
+			(start 1.397 5.715)
+			(end 1.524 5.715)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0a8b67f5-eca2-44e6-98e0-93d08b42615f")
+		)
+		(fp_line
+			(start 2.54 5.842)
+			(end 2.54 5.969)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6c66aa99-7a32-4dea-b015-42731a214107")
+		)
+		(fp_line
+			(start 2.159 5.842)
+			(end 2.54 5.842)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "06bf3182-dcb3-4ed2-a269-01f65357ba44")
+		)
+		(fp_line
+			(start 2.54 5.969)
+			(end 2.159 5.969)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "606103b9-ec7c-4be7-af04-0f5a64217076")
+		)
+		(fp_line
+			(start 2.159 5.969)
+			(end 2.159 5.842)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2f8533de-5944-40ce-85e9-f5b77b90f26f")
+		)
+		(fp_arc
+			(start 3.429 5.207)
+			(mid 2.286 5.680446)
+			(end 1.143 5.207)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "023b007e-821a-43a5-aac3-723f2cebc903")
+		)
+		(fp_circle
+			(center 3.302 1.905)
+			(end 3.429 1.905)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "02ddb86a-aec8-4afb-b69a-c321b2b8072c")
+		)
+		(fp_circle
+			(center 3.302 1.905)
+			(end 3.683 2.032)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "fbc17b2f-379d-4983-8ce0-e1aa23f184e2")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "OLIMEX_LOGOs-FP:LOGO_PBFREE"
+		(locked yes)
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005d8c51dd")
+		(at 129.875000 98.250000)
+		(property "Reference" ""
+			(at -0.2794 3.52552 0)
+			(layer "B.SilkS")
+			(uuid "55da5eac-77e6-4e57-bd60-548c9cc732be")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" ""
+			(at 0.05588 -3.15214 0)
+			(layer "B.Fab")
+			(uuid "c86019ce-deb4-4f07-85e8-4ab10d4290a5")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "301a4d4d-73ea-4fb7-9f59-67693b31b3cd")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cef0db74-b8ad-4b02-a043-e207da7a8ff3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.36398 1.47828)
+			(end 1.06934 -0.94234)
+			(stroke
+				(width 0.2)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "082d5993-4bad-4f93-b62c-f027763ec073")
+		)
+		(fp_circle
+			(center -0.2032 0.31496)
+			(end 0.90678 1.73482)
+			(stroke
+				(width 0.254)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "7c5ef266-0f27-4ed6-9ec9-4d7005304d7a")
+		)
+		(fp_text user "Pb"
+			(at -0.08636 0.33528 0)
+			(layer "B.SilkS")
+			(uuid "d2946751-8ae6-4e6e-b955-1eb81f8bbe09")
+			(effects
+				(font
+					(size 1.7 1.5)
+					(thickness 0.254)
+				)
+				(justify mirror)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(footprint "OLIMEX_LOGOs-FP:OLIMEX_LOGO_TB"
+		(locked yes)
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005e7dd057")
+		(at 129.875000 98.250000)
+		(property "Reference" ""
+			(at -2.4003 3.0607 180)
+			(layer "B.SilkS")
+			(hide yes)
+			(uuid "399d0cef-b3bf-41a9-92f0-fae906f3fada")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" ""
+			(at -1.6637 -3.7084 180)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "5a9754fc-e6ca-425f-b11e-ef9379c56dec")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cd0e1d64-4d73-47da-9a70-d0cdcb15b890")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7860c809-15e2-4b52-af9a-037006db9555")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 7.2644 1.3081)
+			(end 6.4008 0.4144)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7308d41f-5e8b-4541-ac16-38446872acc7")
+		)
+		(fp_line
+			(start 7.2136 -1.3716)
+			(end 6.3754 -0.5588)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ab4d15c6-d809-4979-bd31-7911f42eb225")
+		)
+		(fp_line
+			(start 5.8674 -0.4572)
+			(end 6.4008 -0.4572)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "bf2a81b1-ff11-4c63-a285-f09390059607")
+		)
+		(fp_line
+			(start 5.842 0.3175)
+			(end 6.4008 0.3175)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7fa9ae2e-04e0-46d6-ac9a-bab4a3741ac8")
+		)
+		(fp_line
+			(start 4.8387 1.8288)
+			(end 6.096 0.5842)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "79eadff5-aef5-41de-843d-0efb243000bb")
+		)
+		(fp_line
+			(start 4.7879 1.8288)
+			(end 4.8387 1.8288)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7e63c563-5040-4021-9bf8-69b4816347f6")
+		)
+		(fp_line
+			(start 4.7244 1.4986)
+			(end 5.8166 0.4318)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "fbffb3ab-cb62-4103-a139-39680ebcb461")
+		)
+		(fp_line
+			(start 4.7244 -1.6764)
+			(end 5.8674 -0.5588)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5368f0d4-e2b6-4a6f-ab77-74213bfccd0a")
+		)
+		(fp_line
+			(start 4.191 -0.0762)
+			(end 2.9718 -0.0762)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0db95411-a72f-43bf-add2-d0f38c28b1ef")
+		)
+		(fp_line
+			(start 3.5025 1.4986)
+			(end 4.7244 1.4986)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "11ad56c4-c0ec-42a7-8f24-8b0704d47297")
+		)
+		(fp_line
+			(start 3.4163 1.8288)
+			(end 4.7879 1.8288)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a7ba5318-4d83-439e-ae1b-00e09ed372c2")
+		)
+		(fp_line
+			(start 3.4036 -1.6764)
+			(end 4.7244 -1.6764)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2006bd8d-1b84-4af1-84e6-7e847894503b")
+		)
+		(fp_line
+			(start 2.9718 1.016)
+			(end 3.4544 1.524)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "dad99415-6907-4e8d-945a-3138d6701da1")
+		)
+		(fp_line
+			(start 2.9718 0.9906)
+			(end 2.9718 -1.2446)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "495592f8-620d-410c-a67d-01b8a26348fa")
+		)
+		(fp_line
+			(start 2.9718 -1.2446)
+			(end 3.4036 -1.6764)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "243a1c9a-55c7-4a02-a7df-c78438416b62")
+		)
+		(fp_line
+			(start 2.0447 1.7907)
+			(end 0.7493 1.7907)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0bbd95a3-72d3-498c-8f86-3b5668c8471c")
+		)
+		(fp_line
+			(start 2.0447 1.778)
+			(end 2.0447 1.7907)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9e308bb5-dcbf-4130-90cd-888a87e2f18c")
+		)
+		(fp_line
+			(start 2.0447 -1.2319)
+			(end 2.0447 1.778)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4985d1e2-20c7-48c5-853f-c27e8d0a6fbf")
+		)
+		(fp_line
+			(start 1.8923 1.7145)
+			(end 1.9939 1.7145)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "bf3d020f-0e07-4960-a5eb-1f5d1de17776")
+		)
+		(fp_line
+			(start 1.7145 1.4859)
+			(end 1.7145 -1.1176)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "28409c7b-5c96-463d-a9e6-4cbd0f2d66f9")
+		)
+		(fp_line
+			(start 0.8128 1.4732)
+			(end 1.7018 1.4732)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "30f53825-af9d-439b-aea6-aec4efe42522")
+		)
+		(fp_line
+			(start 0.7493 1.7907)
+			(end 0.7239 1.7907)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b40f334e-9ddb-41ff-aac2-fc22fd496a73")
+		)
+		(fp_line
+			(start 0.7239 1.7907)
+			(end 0.1016 1.2954)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "8bbd251d-593f-4d2e-b867-3c947d3360a1")
+		)
+		(fp_line
+			(start 0.1778 0.9652)
+			(end 0.8128 1.4732)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0bcc8587-fa28-436a-89b0-2609724d2d3f")
+		)
+		(fp_line
+			(start 0.1016 0.1778)
+			(end 0.1016 0.889)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5c5b3092-e670-4250-99d6-191ed3149198")
+		)
+		(fp_line
+			(start -0.5207 1.7907)
+			(end 0.0635 1.3081)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f2281f64-1def-4e76-91ac-cd01bbab5b11")
+		)
+		(fp_line
+			(start -0.6096 1.4732)
+			(end 0 0.9652)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4b599bfe-9525-4940-8894-e2212a1e6a80")
+		)
+		(fp_line
+			(start -1.4478 1.4732)
+			(end -0.6096 1.4732)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "44a8d006-6c3f-4c0e-b79d-45dea3a10784")
+		)
+		(fp_line
+			(start -1.4478 -1.1176)
+			(end -1.4478 1.4732)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f7236fc0-7037-41d2-b032-1a7d009c8983")
+		)
+		(fp_line
+			(start -1.6129 1.7272)
+			(end -1.6891 1.7272)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "3f9da128-984c-4e48-993b-bcd59d315ed7")
+		)
+		(fp_line
+			(start -1.7653 1.7907)
+			(end -0.5207 1.7907)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6e56ee92-0a45-4413-be02-3ff1092ffb5b")
+		)
+		(fp_line
+			(start -1.7653 -1.2065)
+			(end -1.7653 1.778)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6c147495-10a1-4351-8fe7-81cffd9fad56")
+		)
+		(fp_line
+			(start -2.3495 -0.8636)
+			(end -2.3495 1.1557)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9a4dde35-a763-49c4-a8dd-7a25af6febd7")
+		)
+		(fp_line
+			(start -2.3749 -0.8636)
+			(end -2.3495 -0.8636)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b96ddc50-abd4-4d38-bbf2-fe31587e6b5c")
+		)
+		(fp_line
+			(start -2.5019 -0.8001)
+			(end -2.413 -0.8001)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ff7cc0c2-f489-41e4-870e-434dc5bbe659")
+		)
+		(fp_line
+			(start -2.667 1.0414)
+			(end -2.667 -0.5588)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "177ab1fa-d633-4bc2-ac17-a8fc5580fb61")
+		)
+		(fp_line
+			(start -2.8448 -0.8001)
+			(end -2.9083 -0.8001)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "92832d70-509e-46f8-a1ff-35801806468f")
+		)
+		(fp_line
+			(start -2.9845 1.1557)
+			(end -2.9845 -0.8636)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2019161b-7938-4a3b-b97f-712c6bf196a2")
+		)
+		(fp_line
+			(start -2.9845 -0.8636)
+			(end -2.3749 -0.8636)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6f0a261f-15ea-4c5a-aea1-8777333806b4")
+		)
+		(fp_line
+			(start -3.1798 -1.6764)
+			(end -4.1656 -1.6764)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "cd9986b4-d7b8-49d6-ad15-0df447dc76b2")
+		)
+		(fp_line
+			(start -4.1656 -1.6764)
+			(end -4.6228 -1.2192)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a693fe77-aa42-4629-91da-e891d35be80e")
+		)
+		(fp_line
+			(start -4.3053 1.8415)
+			(end -4.3053 -1.1938)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f723620b-68d7-4a21-98a7-1dd100b5986b")
+		)
+		(fp_line
+			(start -4.4831 1.7653)
+			(end -4.3688 1.7653)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "072d03c8-be7e-4595-8ad1-4fd1baa225f4")
+		)
+		(fp_line
+			(start -4.6101 1.8415)
+			(end -4.3053 1.8415)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b9d88d32-c489-4465-aaf7-b4d944d91d1d")
+		)
+		(fp_line
+			(start -4.6228 1.8415)
+			(end -4.9022 1.8415)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "003fd888-0473-413e-adb0-ec76b41d23cd")
+		)
+		(fp_line
+			(start -4.6228 -1.2319)
+			(end -4.6228 1.4986)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "3ccd6512-6f74-44a4-ab18-4e0850f4ef19")
+		)
+		(fp_line
+			(start -4.7879 1.7526)
+			(end -4.8514 1.7653)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "825dc198-b5f4-45ef-bce2-e04fceb0da40")
+		)
+		(fp_line
+			(start -4.9022 1.8415)
+			(end -4.9149 1.8415)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6997c5ff-73c0-4e68-a7ca-05908c330633")
+		)
+		(fp_line
+			(start -4.9149 1.8415)
+			(end -4.9276 1.8415)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "68d2fb7e-a28e-4a6b-b177-f5a33383d8a1")
+		)
+		(fp_line
+			(start -4.9276 1.8415)
+			(end -4.9276 -1.3081)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "bb8ab64c-487e-41ac-a573-8361ed4ae914")
+		)
+		(fp_line
+			(start -5.7785 0.889)
+			(end -5.7785 -1.0414)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "6cc2353c-69b8-4cb5-8925-086943a3a4db")
+		)
+		(fp_line
+			(start -5.7912 -1.0795)
+			(end -6.35 -1.6637)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "764e59f0-faf5-4c37-b990-bc276e17cc39")
+		)
+		(fp_line
+			(start -6.4008 1.4986)
+			(end -7.4041 1.4986)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e2dff08a-2d85-44a7-943d-f94c8cf5a2ce")
+		)
+		(fp_line
+			(start -6.4008 1.4859)
+			(end -5.7658 0.8763)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0d753950-3996-428e-81ec-66314582c494")
+		)
+		(fp_line
+			(start -7.4295 -1.6891)
+			(end -6.3881 -1.6891)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f5033879-b547-4084-8f4e-acd91627aa12")
+		)
+		(fp_line
+			(start -7.9883 -1.1303)
+			(end -7.9883 -0.3683)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9395f758-3041-4bf6-84aa-6337782c0ffb")
+		)
+		(fp_line
+			(start -8.001 0.9017)
+			(end -7.493 1.4097)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7e9d2c26-0243-45d9-af68-6c93ef6d7611")
+		)
+		(fp_line
+			(start -8.001 0.8509)
+			(end -8.001 0.6096)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a9d3cb7a-69e6-46b9-ac38-56b5505b7b98")
+		)
+		(fp_line
+			(start -8.001 -1.1176)
+			(end -7.4168 -1.6891)
+			(stroke
+				(width 0.7)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7cf3b0f5-b8e4-4286-b8e3-76e0f3dca45a")
+		)
+		(fp_circle
+			(center 7.6327 1.6637)
+			(end 7.9375 1.8542)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "d0264f73-a328-4455-b0be-4f7bc426f55e")
+		)
+		(fp_circle
+			(center 7.5438 -1.7272)
+			(end 7.8359 -1.5748)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "d767a115-1994-4ee4-8439-2ec82c4ba899")
+		)
+		(fp_circle
+			(center 4.699 -0.0762)
+			(end 4.9657 0.1651)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "45116d00-6592-447c-b577-427ad201fbf5")
+		)
+		(fp_circle
+			(center 1.7145 -1.6383)
+			(end 1.9304 -1.3462)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "33d2b6ff-d344-47b5-9917-aca2749f42e0")
+		)
+		(fp_circle
+			(center 0.1016 -0.3556)
+			(end 0.3302 -0.0635)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "17205aa1-2969-4cc9-840c-620cc306a641")
+		)
+		(fp_circle
+			(center -1.4351 -1.6256)
+			(end -1.1938 -1.3589)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "4570dae9-6c63-46d4-a24f-74028d866a95")
+		)
+		(fp_circle
+			(center -2.6543 1.5748)
+			(end -2.54 1.9304)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "127a5504-a5f9-4ce1-a0c2-aeb10dd0b07d")
+		)
+		(fp_circle
+			(center -2.667 -1.651)
+			(end -2.4638 -1.3462)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "608b5b14-5718-4e71-9517-71a024a265e8")
+		)
+		(fp_circle
+			(center -7.9883 0.127)
+			(end -7.6708 0.2413)
+			(stroke
+				(width 0.4)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "910ec872-6da5-44fd-a998-cb3af4919baf")
+		)
+		(embedded_fonts no)
+	)
+	(gr_line
+		(start 114 91)
+		(end 145.75 91)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "c98b8739-5517-49c0-94ff-7449c2e1f124")
+	)
+	(gr_line
+		(start 114 105.5)
+		(end 114 91)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "9fd60985-4559-4d03-995f-538746ddb926")
+	)
+	(gr_line
+		(start 145.75 91)
+		(end 145.75 105.5)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "958a9bf3-dbc9-40cf-9a79-578932c7906e")
+	)
+	(gr_line
+		(start 145.75 105.5)
+		(end 114 105.5)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "608edb87-fa2c-450e-b965-d0fd974fd824")
+	)
+	(embedded_fonts no)
+)

--- a/tests/fixtures/run25/esp_prog_placed.kicad_pro
+++ b/tests/fixtures/run25/esp_prog_placed.kicad_pro
@@ -1,0 +1,61 @@
+{
+  "board": {
+    "design_settings": {
+      "rules": {
+        "min_clearance": 0.15,
+        "min_hole_clearance": 0.15,
+        "min_hole_to_hole": 0.25,
+        "min_copper_edge_clearance": 0.3,
+        "min_track_width": 0.15,
+        "min_via_diameter": 0.45,
+        "min_through_hole_diameter": 0.25,
+        "min_via_drill": 0.25
+      },
+      "rule_severities": {}
+    }
+  },
+  "meta": {
+    "filename": "board.kicad_pro",
+    "version": 1
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12,
+        "clearance": 0.15,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": 0.2,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.2,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "priority": 2147483647,
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.15,
+        "via_diameter": 0.45,
+        "via_drill": 0.25,
+        "wire_width": 6
+      }
+    ],
+    "meta": {
+      "version": 0
+    }
+  },
+  "kicad_routing_tools": {
+    "floor_provenance": {
+      "authored_by": "run25 orchestrator, before any placement/routing tool ran (brief step 1, #441)",
+      "floors": {
+        "clearance": 0.15,
+        "track_width": 0.15,
+        "via_diameter": 0.45,
+        "via_drill": 0.25,
+        "hole_to_hole": 0.25,
+        "copper_edge": 0.3
+      },
+      "note": "fix_kicad_drc_settings capped min_clearance and the Default class at the 0.0508 mm pad override found on C1/C3/Q1/Q2/U2; both hand-raised to the declared 0.15 floor (KiCad floors a pad override at rules.min_clearance, so 0.15 is what every checker grades). Class draw defaults set to the declared sizes.",
+      "escalation": "board"
+    }
+  }
+}

--- a/tests/mutate_711.py
+++ b/tests/mutate_711.py
@@ -98,13 +98,13 @@ ROWS = [
      "        if not f0 < f1:",
      "        if False:",
      (TSCH, T712, T711), KILLED),
-    # RE-ANCHORED for #837, which took READER_VERSION 2 -> 3. The mutation is
-    # restated rather than transliterated: it must move the version BELOW the
-    # one #712's fields need, and `3 -> 2` would now be a bump that is merely
-    # smaller rather than absent -- a row that could survive for the wrong
-    # reason. `3 -> 1` is the same claim the row has always made.
+    # RE-ANCHORED for #837 (2 -> 3) and again for #902 (3 -> 4). The mutation
+    # is restated rather than transliterated each time: it must move the
+    # version BELOW the one #712's fields need, so `4 -> 3` would be a bump
+    # merely smaller rather than absent -- a row that could survive for the
+    # wrong reason. `4 -> 1` is the same claim the row has always made.
     ('reader-version-not-bumped', 'fp',
-     "READER_VERSION = 3",
+     "READER_VERSION = 4",
      "READER_VERSION = 1",
      (TSCH, T712), KILLED),
 

--- a/tests/mutate_837.py
+++ b/tests/mutate_837.py
@@ -229,9 +229,13 @@ ROWS = [
      "'both',\n",
      (CEN,), 'KILLED'),
 
+    # RE-ANCHORED for #902, which took READER_VERSION 3 -> 4. The MUTATION is
+    # unchanged in kind -- fail to move the reader when a declarable field
+    # arrives -- so it reverts 4 to the version before this key, exactly as it
+    # used to revert 3 to the version before `assembly.sides`.
     ('the-reader-version-does-not-move', 'fp',
+     "READER_VERSION = 4\n",
      "READER_VERSION = 3\n",
-     "READER_VERSION = 2\n",
      (CEN,), 'KILLED'),
 
     # ------------------------------------------------------- the arithmetic

--- a/tests/mutate_902.py
+++ b/tests/mutate_902.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Mutation battery for #902 / #895.
+
+Green tests are not evidence of coverage. Every row below breaks one thing the
+test files CLAIM to hold down; a row that survives is a hole in the tests, and
+a row recorded as an expected survivor is a finding rather than a convenience.
+
+    python3 tests/mutate_902.py            # every row
+    python3 tests/mutate_902.py --list
+    python3 tests/mutate_902.py --row min-becomes-max
+
+A row is KILLED by a FAILURE or an ERROR. An anchor that does not match EXACTLY
+ONCE is reported BROKEN, never skipped: a mutation that silently edited nothing
+would be recorded as a surviving row, which is the opposite of what it means.
+
+Refuses to start on a dirty target tree, because it restores the ORIGINAL text
+from disk and would write committed text over uncommitted work.
+
+THE MEASURED TABLE GOES IN THE HEADER OF THE TEST FILE IT DEFENDS, FROM THE
+RUN -- never predicted here and never edited afterwards to match.
+
+Every row here has a scar. Nine of them are branches that ALREADY survived a
+battery once: five found by the verifier of the rule (the `min` that is the
+stated invariant, both abstentions, the partial-pad miss, the courtyard-vs-body
+read) and four by the verifier of the close-out gate (the bool check, longest-
+match resolution, the `+ ':'` suffix guard, the whole DRIFTED arm). They are
+recorded here so the next change has to get past them rather than past a
+memory.
+"""
+import argparse
+import os
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+KILLED, SURVIVED, BROKEN = 'KILLED', 'SURVIVED', 'BROKEN'
+
+TARGETS = {
+    'fp': os.path.join(REPO, 'py_placer', 'placement', 'floorplan.py'),
+    'db': os.path.join(REPO, 'py_placer', 'placement', 'design_brief.py'),
+    'cf': os.path.join(REPO, 'py_tools', 'check_floorplan.py'),
+    'bc': os.path.join(REPO, 'py_tools', 'board_context.py'),
+}
+
+T902 = 'tests/test_902_proximity.py'
+T895 = 'tests/test_895_boundary_criteria.py'
+T891 = 'tests/test_891_board_context.py'
+TSCH = 'tests/test_549_floorplan_schema.py'
+
+#: (name, target, old, new, tests that must notice, expectation)
+ROWS = [
+    # ---- the rule's own arithmetic -----------------------------------------
+    # THE INVARIANT. Every declared case gives a subject pad exactly one
+    # candidate partner, so min and max were indistinguishable until a case
+    # gave one pad six partners on one net.
+    ('min-becomes-max', 'fp',
+     "        if best is None or g < best[0]:",
+     "        if best is None or g > best[0]:",
+     (T902,), KILLED),
+    # The narrowing that makes a claim about the RAIL leg rather than the
+    # nearest pad. Dropping it reports a number about a different pin.
+    ('net-narrowing-dropped', 'fp',
+     "    same = ([q for q in partners if q.net_id == pad.net_id and pad.net_id > 0]\n"
+     "            if net_match else [])",
+     "    same = []",
+     (T902,), KILLED),
+    # A pad NUMBER is not unique: a crystal has two ground tabs both named
+    # `3`. First-hit makes the answer depend on file order.
+    ('pads-named-takes-the-first', 'fp',
+     "    return [p for p in (fp_obj.pads or ()) if p.pad_number in want]",
+     "    got = [p for p in (fp_obj.pads or ()) if p.pad_number in want]\n"
+     "    return got[:1]",
+     (T902,), KILLED),
+    # A partially-wrong pad list graded CLEAN on the survivors: the guard
+    # fired only when EVERY name missed.
+    ('partial-pad-miss-ignored', 'fp',
+     "            missing = [n for n in names if n not in have]",
+     "            missing = [] if have else [n for n in names if n not in have]",
+     (T902,), KILLED),
+    # Both abstentions could be deleted with the whole suite green, and a
+    # claim naming a padless part then yielded NOTHING while `proximity`
+    # stayed in `rules_run` -- the vacuous pass `_ARM` was dropped on.
+    ('pads-abstention-deleted', 'fp',
+     "            ctx.abstain(\n                f\"{akey}.pads\",",
+     "            _unused = (\n                f\"{akey}.pads\",",
+     (T902,), KILLED),
+    ('body-abstention-deleted', 'fp',
+     "                ctx.abstain(f\"{akey}.basis\", why)\n                continue",
+     "                continue",
+     (T902,), KILLED),
+    # `body_local` is COURTYARD-first, and #896 says a courtyard is not a
+    # body. Reading it under-states every gap by the assembly margin.
+    ('body-reads-the-courtyard', 'fp',
+     "        rect_local = None if geom is None else (geom.drawn_local\n"
+     "                                                or geom.body_local)",
+     "        rect_local = None if geom is None else geom.body_local",
+     (T902,), KILLED),
+    # A missing ref must be a FINDING, not silence: a typo would grade clean,
+    # which is `block_unresolved`'s failure one level over.
+    ('missing-ref-is-silent', 'fp',
+     "        missing = [r for r, f in ((ref, a_fp), (near, b_fp)) if f is None]",
+     "        missing = []",
+     (T902,), KILLED),
+    # `_wants` ends in a bare `return True`, so a rule with no branch runs on
+    # every board and lands in `rules_run` having measured nothing.
+    ('wants-branch-deleted', 'fp',
+     "    if rule == 'proximity':\n        return bool(intent.proximity)",
+     "    if rule == 'proximity':\n        return True",
+     (T902,), KILLED),
+
+    # ---- the loaders --------------------------------------------------------
+    # inf and nan pass both `_number(lo=)` and a `<= 0` guard, and json.load
+    # accepts the literals: a declared limit nothing can ever violate.
+    ('brief-finite-check-deleted', 'db',
+     "            if not math.isfinite(float(limit)):",
+     "            if False:",
+     (T902,), KILLED),
+    ('intent-finite-check-deleted', 'fp',
+     "        if not math.isfinite(limit) or limit <= 0.0:",
+     "        if limit <= 0.0:",
+     (T902,), KILLED),
+    # Three spellings of "unpadded" defeated the reverse guard, so a brief
+    # could declare 5mm one way and 9mm the other.
+    ('reverse-guard-keys-on-none', 'db',
+     "            if isinstance(pads, dict) and pads.get(ref_one):\n                continue",
+     "            if pads is not None:\n                continue",
+     (T902,), KILLED),
+    ('intent-reverse-guard-deleted', 'fp',
+     "        if not (p.get('pads') or {}).get(ref) and (near, ref) in seen:",
+     "        if False:",
+     (T902,), KILLED),
+    # A reference may contain `~`, so a bare `ref~near` id collides and one of
+    # two declared unknowns disappears into a set union.
+    ('claim-id-drops-the-row', 'db',
+     "    return f\"proximity[{row}:{ref}~{near}]\"",
+     "    return f\"proximity[{ref}~{near}]\"",
+     (T902,), KILLED),
+    # An integer pad number matches nothing, measures nothing, grades clean.
+    ('pad-number-type-check-gone', 'db',
+     "            if not isinstance(n, str):",
+     "            if False:",
+     (T902,), KILLED),
+
+    # ---- clause coverage ----------------------------------------------------
+    ('coverage-uncovered-reads-graded', 'db',
+     "        return ('uncovered', f\"`{rule}` did not run on this grade\", rule)",
+     "        return ('graded', '', rule)",
+     (T902,), KILLED),
+    ('coverage-abstention-ignored', 'db',
+     "        if _abstention_is_about(akey, kind, ref, near, intent_doc):",
+     "        if False:",
+     (T902,), KILLED),
+    # Trusting the row index alone charged an abstention to whatever claim sat
+    # at that row -- a finding about an innocent clause.
+    ('abstention-matches-on-index-only', 'db',
+     "    if not akey.startswith(f\"proximity[{row}:{ref}~{near}]\"):\n        return False",
+     "    if False:\n        return False",
+     (T902,), KILLED),
+    # `not_claimed` and `carried` must never block, or declaring honestly is
+    # punished and people stop declaring.
+    ('unknown-clauses-block', 'db',
+     "    out['complete'] = (counts['uncovered'] == 0 and counts['abstained'] == 0\n"
+     "                       and counts['drifted'] == 0)",
+     "    out['complete'] = (counts['uncovered'] == 0 and counts['abstained'] == 0\n"
+     "                       and counts['drifted'] == 0\n"
+     "                       and counts['not_claimed'] == 0)",
+     (T902,), KILLED),
+    # The absence message must name what is actually absent, not fabricate a
+    # brief that was never found.
+    ('absence-reason-keys-on-coverage', 'cf',
+     "                  + (_brief_absence_reason(args, brief) if not brief_fragment",
+     "                  + (_brief_absence_reason(args, brief) if not coverage",
+     (T902,), KILLED),
+
+    # ---- #895's instrument --------------------------------------------------
+    # The span is the WORST shared-net pad distance: a bus is as long as its
+    # longest member, and the nearest pair says nothing about whether it fits.
+    ('span-takes-the-nearest', 'bc',
+     "        if worst is None or near > worst:",
+     "        if worst is None or near < worst:",
+     (T891, T895), KILLED),
+]
+
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
+
+def _dirty():
+    r = subprocess.run(['git', 'status', '--porcelain'] +
+                       sorted(set(TARGETS.values())),
+                       cwd=REPO, capture_output=True, text=True)
+    return [ln for ln in r.stdout.splitlines() if ln.strip()]
+
+
+def run_row(row, keep=False):
+    name, target, old, new, tests, _expect = row
+    path = TARGETS[target]
+    with open(path, encoding='utf-8') as fh:
+        original = fh.read()
+    if original.count(old) != 1:
+        return BROKEN, f'anchor matched {original.count(old)} time(s)'
+    try:
+        with open(path, 'w', encoding='utf-8', newline='\n') as fh:
+            fh.write(original.replace(old, new, 1))
+        for t in tests:
+            r = subprocess.run([sys.executable, os.path.join(REPO, t)],
+                               cwd=REPO, capture_output=True, text=True)
+            if r.returncode != 0:
+                return KILLED, f'{t} exit {r.returncode}'
+        return SURVIVED, ''
+    finally:
+        if not keep:
+            with open(path, 'w', encoding='utf-8', newline='\n') as fh:
+                fh.write(original)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--list', action='store_true')
+    ap.add_argument('--row', action='append', default=[])
+    a = ap.parse_args()
+
+    if a.list:
+        for name, target, _o, _n, tests, expect in ROWS:
+            print(f"  {name:38} {target:3} {expect:8} {' '.join(tests)}")
+        return 0
+
+    dirty = _dirty()
+    if dirty:
+        print('REFUSING: the target tree is dirty. This restores the ORIGINAL '
+              'text from disk and would write committed text over uncommitted '
+              'work.')
+        for ln in dirty:
+            print(f'  {ln}')
+        return 2
+
+    rows = [r for r in ROWS if not a.row or r[0] in a.row]
+    if a.row and not rows:
+        print(f'no row matches {a.row}')
+        return 2
+    counts = {KILLED: 0, SURVIVED: 0, BROKEN: 0}
+    disagreed = 0
+    for row in rows:
+        got, detail = run_row(row)
+        counts[got] += 1
+        flag = 'ok  ' if got == row[5] else 'DISAGREES'
+        if got != row[5]:
+            disagreed += 1
+        print(f'  {row[0]:38} {got:9} {flag} {detail}')
+    print(f"\n{len(rows)} rows: {counts[KILLED]} killed, "
+          f"{counts[SURVIVED]} survived, {counts[BROKEN]} broken, "
+          f"{disagreed} disagreeing with expectation")
+    return 1 if (counts[BROKEN] or disagreed) else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutate_902.py
+++ b/tests/mutate_902.py
@@ -19,13 +19,18 @@ from disk and would write committed text over uncommitted work.
 THE MEASURED TABLE GOES IN THE HEADER OF THE TEST FILE IT DEFENDS, FROM THE
 RUN -- never predicted here and never edited afterwards to match.
 
-Every row here has a scar. Nine of them are branches that ALREADY survived a
-battery once: five found by the verifier of the rule (the `min` that is the
-stated invariant, both abstentions, the partial-pad miss, the courtyard-vs-body
-read) and four by the verifier of the close-out gate (the bool check, longest-
-match resolution, the `+ ':'` suffix guard, the whole DRIFTED arm). They are
-recorded here so the next change has to get past them rather than past a
-memory.
+Every row here has a scar. FIVE of these rows are branches that ALREADY
+survived a battery once, all found by the verifier of the rule: the `min` that
+is the stated invariant, both abstentions, the partial-pad miss and the
+courtyard-vs-body read.
+
+Four MORE such branches exist and are deliberately NOT rows here -- the bool
+check, longest-match waiver resolution, the `+ ':'` suffix guard and the whole
+DRIFTED arm all live in `.claude/skills/plan-pcb-placement/scripts/
+placement_driver.py`, which this battery does not target, and they are killed
+by that driver's own `--self-test`. Saying "nine rows" would have credited this
+file with four kills it does not perform, which is the kind of arithmetic a
+reader has no way to check without opening TARGETS.
 """
 import argparse
 import os

--- a/tests/test_549_floorplan_cli.py
+++ b/tests/test_549_floorplan_cli.py
@@ -236,8 +236,8 @@ def test_the_summary_reports_what_did_not_run():
     # would make this arm agree with whatever the module currently says
     # and stop being a change detector. 9 before #794 added
     # `decap_ungraded` and #705 added `decap_pin_distance`; 11 before #837
-    # added `assembly_side`.
-    assert s['rules_skipped'] == 12, s['rules_skipped']
+    # added `assembly_side`; 12 before #902 added `proximity`.
+    assert s['rules_skipped'] == 13, s['rules_skipped']
     print(f"  PASS: an empty intent passes with rules_run=0, "
           f"rules_skipped={s['rules_skipped']} -- visibly vacuous")
 

--- a/tests/test_549_floorplan_schema.py
+++ b/tests/test_549_floorplan_schema.py
@@ -126,7 +126,7 @@ KEY_SETS = {
         'schema', 'kind', 'board', 'units', 'min_reader', 'envelope',
         'defaults', 'blocks', 'keepouts', 'edge_connectors', 'decaps',
         'must_lock', 'legality_budget', 'health', 'severity', 'context',
-        'overlap_waivers', 'assembly'},
+        'overlap_waivers', 'assembly', 'proximity'},
     '_ENVELOPE_KEYS': {'rect', 'tolerance_mm'},
     '_DEFAULTS_KEYS': {'zone_tolerance_mm'},
     '_BLOCK_KEYS': {'name', 'group', 'refs', 'zone', 'side', 'exclusive',
@@ -156,6 +156,11 @@ KEY_SETS = {
     # records how it was reached, and `emit_intent` fills it with the
     # observation rather than a reason nobody gave.
     '_ASSEMBLY_KEYS': {'sides', 'why', 'context'},
+    # #902: one declared claim -- these two named parts, no further apart
+    # than `max_mm`. `ref` is a single ref here; the brief's list form is
+    # sugar that `compile_brief` expands before it reaches this schema.
+    '_PROXIMITY_KEYS': {'ref', 'near', 'max_mm', 'basis', 'pads', 'note',
+                        'source', 'context'},
 }
 
 
@@ -205,6 +210,7 @@ def test_the_key_sets_are_exactly_what_is_documented():
         '_OVERHANG_KEYS': 'edge_connectors[].overhang_mm',
         '_EDGE_CONNECTOR_KEYS': 'edge_connectors[]',
         '_ASSEMBLY_KEYS': 'assembly',
+        '_PROXIMITY_KEYS': 'proximity[]',
     }
     checked = 0
     for name, row in sorted(TABLE_ROWS.items()):
@@ -274,6 +280,12 @@ def test_an_intent_using_every_known_key_loads():
                              'context': {'why': 'w'}}],
         'assembly': {'sides': 'F', 'why': 'one reflow pass',
                      'context': {'quoted': 'the fab'}},
+        # #902. `source` is compiler-written, `note` and `context` are the
+        # prose slots, and `pads` names only refs this claim mentions.
+        'proximity': [{'ref': 'Y1', 'near': 'U1', 'max_mm': 2.0,
+                       'basis': 'body', 'pads': {'Y1': ['1']},
+                       'note': 'n', 'source': 'brief',
+                       'context': {'why': 'w'}}],
     }
     # Every key of every set must appear above, or this proves less than it
     # claims -- the point is coverage of the vocabulary, not of a sample.
@@ -290,6 +302,7 @@ def test_an_intent_using_every_known_key_loads():
     seen |= set(raw['health']['bus_corridors'][0])
     seen |= set(raw['overlap_waivers'][0])
     seen |= set(raw['assembly'])
+    seen |= set(raw['proximity'][0])
     for k in raw['keepouts']:
         seen |= set(k)
     missing = sorted({k for keys in KEY_SETS.values() for k in keys} - seen)
@@ -555,7 +568,8 @@ def test_severity_keys_are_checked_against_the_rule_names():
                                         'intent_zone_in_keepout',
                                         'keepout_allow_unresolved',
                                         'decap_pin_distance_inferred',
-                                        'decap_pin_uncovered'}
+                                        'decap_pin_uncovered',
+                                        'proximity_unresolved'}
     assert _SEVERITY_KEYS == expected, sorted(_SEVERITY_KEYS ^ expected)
     for name in sorted(expected):
         i = intent_from_dict(_base(severity={name: WARN}))

--- a/tests/test_712_edge_centering.py
+++ b/tests/test_712_edge_centering.py
@@ -414,12 +414,15 @@ def test_the_loader_refuses_every_malformed_along_edge_claim():
     # need a reader that knows them. The second is the change detector: a
     # hand-stated literal that fires when the vocabulary grows, so the bump is
     # re-stated deliberately rather than absorbed. It was 2 before #837 added
-    # `assembly.sides`.
+    # `assembly.sides`, and 3 before #902 added `proximity[]` -- "these two
+    # named parts, this far apart", the one class of constraint the netlist
+    # implies and no instrument here could read.
     assert fp.READER_VERSION >= 2, (
         f"{fp.READER_VERSION}: #712's fields need a reader that knows them")
-    assert fp.READER_VERSION == 3, (
+    assert fp.READER_VERSION == 4, (
         f"{fp.READER_VERSION}: the field vocabulary grew. Re-state this "
-        f"literal and say which field arrived, the way #712 and #837 did")
+        f"literal and say which field arrived, the way #712, #837 and #902 "
+        f"did")
     # What this pair checks is the GATE -- a document may demand at most what
     # this build can serve. Written against `READER_VERSION` rather than a
     # literal 2/3, because the change-detector duty is already carried by the

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -129,6 +129,13 @@ _ROOT_JOIN_ARGV_OK = {
         'ALREADY qualified by directory ("py_router/route.py") straight out '
         'of the skill text and filters them through os.path.isfile -- so the '
         'join is over a relative path, not a bare basename.',
+    'mutate_902.py':
+        'its `tests` values are the module-level T902/T895/T891/TSCH '
+        'constants, every one a directory-qualified literal '
+        '("tests/test_902_proximity.py"), so the join is over a relative path '
+        'and not a bare basename. `run_utils.tool()` is the wrong resolver '
+        'here: these are TEST files rather than shipped CLIs, and it looks '
+        'only in the four tool directories #522 created.',
 }
 
 
@@ -946,7 +953,8 @@ _UNRESOLVABLE = {}
 #: Every `tests/mutate_*.py` in the tree, pinned. A resolver that quietly stops
 #: finding batteries would otherwise report a clean sweep over nothing -- the
 #: exact shape of the defect #877 is about, reproduced in its own gate.
-_BATTERY_COUNT = 42
+#: 42 before #902 added `mutate_902.py`.
+_BATTERY_COUNT = 43
 
 #: A floor well under today's 831, not a target. Same purpose as
 #: `test_the_scanners_still_match_something`: prove the corpus is populated.

--- a/tests/test_837_assembly_sides.py
+++ b/tests/test_837_assembly_sides.py
@@ -505,8 +505,14 @@ def main():
               for s in ('F', 'B', 'both')))
     check("loader: an intent with no assembly key defaults to both",
           fp.intent_from_dict(base).assembly_sides() == 'both')
+    # 3 when #837 added `assembly.sides`; 4 since #902 added `proximity[]`.
+    # Re-stated rather than loosened to `>= 3`: the literal IS the detector,
+    # and this is the fourth one that bump had to move -- the others live in
+    # test_712_edge_centering, mutate_711 and mutate_837. It is also the only
+    # one `run_all.py --fast` cannot see, because this file is classified
+    # integration, so a red here reads as a green suite.
     check("reader version names the field it learned",
-          fp.READER_VERSION == 3, fp.READER_VERSION)
+          fp.READER_VERSION == 4, fp.READER_VERSION)
 
     check("graded every fixture", graded == len(EXPECT), f"{graded}")
     print(f"\n{'FAIL' if FAILURES else 'PASS'}: #837 census over {graded} "

--- a/tests/test_891_board_context.py
+++ b/tests/test_891_board_context.py
@@ -244,6 +244,66 @@ def test_panels_are_written_and_referenced():
                    if not os.path.isfile(p['panel'])][:3]))
 
 
+def test_the_span_column_is_the_length_the_pair_is_forced_to_run():
+    """#895's criterion 1 had NO instrument.
+
+    `pair_metrics` computes inversions and discards the distance,
+    `render_placement --json-out` gives a board-total `hpwl`, and
+    `net_affinity` needs declared zoned blocks -- so "how long is this pair
+    forced to run" could not be read off anything, and a reviewer asked to
+    judge it had to estimate.
+
+    Re-derived here from pad coordinates rather than trusted: the sheet's
+    number must be the WORST shared-net pad distance, because a bus is as long
+    as its longest member and a mean hides the one that will not fit.
+    """
+    import math
+    import sys as _sys
+    _sys.path.insert(0, os.path.join(ROOT, 'py_router'))
+    from kicad_parser import parse_kicad_pcb
+
+    doc = json.loads(_run(LAP5, '--json').stdout)
+    rows = {(r['a'], r['b'], r['scope']): r for r in doc['pin_order']['rows']}
+    pcb = parse_kicad_pcb(LAP5)
+
+    def _worst(a, b, only=None):
+        fa, fb = pcb.footprints[a], pcb.footprints[b]
+        by = {}
+        for pad in fa.pads or ():
+            nid = pad.net_id or 0
+            if nid > 0 and (only is None or pad.net_name in only):
+                by.setdefault(nid, []).append(pad)
+        worst = None
+        for pad in fb.pads or ():
+            nid = pad.net_id or 0
+            if nid <= 0 or nid not in by:
+                continue
+            near = min(math.dist((q.global_x, q.global_y),
+                                 (pad.global_x, pad.global_y))
+                       for q in by[nid])
+            worst = near if worst is None else max(worst, near)
+        return worst
+
+    pair = rows.get(('U1', 'USB1', 'pair /D_P//D_N'))
+    check('the pair row carries a span', pair is not None
+          and pair.get('span_mm') is not None, sorted(rows))
+    if pair:
+        mine = _worst('U1', 'USB1', only={'/D_P', '/D_N'})
+        check('the pair span is the worst shared-net pad distance',
+              abs(pair['span_mm'] - mine) < 1e-3,
+              f"sheet {pair['span_mm']} vs {mine}")
+        # The INTERFACE row blends more nets, so it cannot be smaller than the
+        # pair-scoped one -- if it were, the scope column would be meaningless.
+        iface = rows.get(('U1', 'USB1', 'interface'))
+        check('the interface span is at least the pair span',
+              iface and iface['span_mm'] >= pair['span_mm'],
+              f"{iface and iface['span_mm']} vs {pair['span_mm']}")
+    md = _run(LAP5, '--md').stdout
+    check('the md table has the span column', '| span mm |' in md)
+    check('the md says the threshold is a judgement',
+          'a judgement' in md and '1.5' in md)
+
+
 def test_md_is_a_sheet_a_reader_can_use():
     r = _run(TRACKED, '--md')
     check('--md exits 0', r.returncode == 0, r.stderr[-300:])
@@ -260,6 +320,7 @@ TESTS = [test_json_is_parseable_from_char_zero,
          test_every_derived_fact_names_its_source,
          test_the_body_column_is_the_896_model,
          test_panels_are_written_and_referenced,
+         test_the_span_column_is_the_length_the_pair_is_forced_to_run,
          test_md_is_a_sheet_a_reader_can_use]
 
 

--- a/tests/test_895_boundary_criteria.py
+++ b/tests/test_895_boundary_criteria.py
@@ -41,6 +41,9 @@ REFERENCE = os.path.join(ROOT, '.claude', 'skills',
 #: The board the example is drawn from. Named HERE and never in the reference.
 FIXTURE = os.path.join(ROOT, 'tests', 'fixtures', 'run25',
                        'esp_prog_lap5.kicad_pcb')
+#: The declared clauses criterion 3 is worked from.
+BRIEF = os.path.join(ROOT, 'tests', 'fixtures', '902',
+                     'esp_prog_proximity.design-brief.json')
 
 FAILURES = []
 
@@ -157,6 +160,118 @@ def test_criterion_6_is_what_the_instrument_reports():
           'COURTYARD AREA' in ref)
 
 
+def test_criterion_3_is_what_the_grader_reports():
+    """Every distance criterion 3 quotes, re-derived through the real grader.
+
+    This gate exists because the reference first shipped the crystal leg as
+    3.14mm -- the right number for a DIFFERENT fixture of the same board, one
+    lap earlier. The file claimed every figure was pinned by a test; criterion
+    3's were not, so the one figure measured on the wrong board was the one
+    nothing caught.
+
+    The PASSING distances matter as much as the failing one, so the brief is
+    re-read with every `max_mm` tightened to 0.001: that makes each declared
+    row report its measured gap instead of only the row that exceeds its own
+    limit. It is the same rule measuring either way -- a limit decides what is
+    REPORTED, never what is measured.
+    """
+    import tempfile
+
+    from kicad_parser import parse_kicad_pcb
+    from placement import groups
+
+    with open(BRIEF, encoding='utf-8') as fh:
+        brief = json.load(fh)
+    for row in brief['proximity']:
+        row['max_mm'] = 0.001
+    ref = _text(REFERENCE)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tight = os.path.join(tmp, 'tight.json')
+        intent = os.path.join(tmp, 'intent.json')
+        graded = os.path.join(tmp, 'graded.json')
+        with open(tight, 'w', encoding='utf-8') as fh:
+            json.dump(brief, fh)
+        cf = os.path.join(ROOT, 'py_tools', 'check_floorplan.py')
+        emit = subprocess.run([sys.executable, '-X', 'utf8', cf, FIXTURE,
+                               '--brief', tight, '--emit-intent', intent],
+                              capture_output=True, text=True)
+        check('check_floorplan emitted an intent', os.path.isfile(intent),
+              emit.stderr[-300:])
+        if not os.path.isfile(intent):
+            return
+        subprocess.run([sys.executable, '-X', 'utf8', cf, FIXTURE,
+                        '--brief', tight, '--intent', intent,
+                        '--json', graded], capture_output=True, text=True)
+        check('check_floorplan wrote a graded document',
+              os.path.isfile(graded))
+        if not os.path.isfile(graded):
+            return
+        with open(graded, encoding='utf-8') as fh:
+            doc = json.load(fh)
+
+    # Key on the PAIR, not on the number. Two of the measured gaps round to
+    # the same two decimals (the second bulk cap at 0.292 and the transistor
+    # pair at 0.295), so a bare `f'{gap:.2f}' in ref` sweep passes for a row
+    # the reference never quotes, satisfied by a different row's digits.
+    gaps = {}
+    for v in doc['violations']:
+        m = v.get('measured') or {}
+        if v.get('rule') == 'proximity' and 'gap_mm' in m:
+            gaps[(v.get('ref'), m.get('near'), m.get('pad'))] = m['gap_mm']
+    check('the rule measured every declared row', len(gaps) >= 5, sorted(gaps))
+    #: The distances criterion 3 states, and the subject pad each belongs to.
+    quoted = (('Y1', 'U1', '1'), ('Y1', 'U1', '2'),
+              ('C1', 'U2', '1'), ('C3', 'U2', '1'))
+    for key in quoted:
+        gap = gaps.get(key)
+        check(f'{key[0]} pad {key[2]} -> {key[1]} was measured', gap is not None,
+              sorted(gaps))
+        if gap is None:
+            continue
+        check(f'the reference quotes it as {gap:.2f}mm', f'{gap:.2f}' in ref,
+              f'measured {gap}')
+    # The transistor pair is measured on the body basis and deliberately NOT
+    # quoted -- criterion 3's text is about the regulator and the crystal. It
+    # is asserted absent-by-pair rather than by digits, which C3 also carries.
+    check('the body-basis pair was measured too',
+          ('Q1', 'Q2', None) in gaps, sorted(gaps))
+
+    # The two tether distances the same section cites as the WRONG partners.
+    # They are the argument for the rule existing, so they are pinned too.
+    tethers = groups.decap_tethers(parse_kicad_pcb(FIXTURE))
+    wrong = sorted(mm for rows in (tethers or {}).values() for _, mm in rows)
+    check('the reference quotes the wrong-partner distances it cites',
+          all(f'{mm:.2f}' in ref for mm in wrong[-2:]),
+          [f'{mm:.2f}' for mm in wrong])
+
+
+def test_criterion_1_quotes_the_bodies_it_compares_against():
+    """The denominator, not only the span.
+
+    Criterion 1 is a RATIO, and the reference used to state its two bodies as
+    round numbers nobody could source -- one of them out by 2mm. A span with an
+    invented denominator is a criterion measuring nothing.
+    """
+    r = subprocess.run([sys.executable, os.path.join(ROOT, 'py_tools',
+                                                     'board_context.py'),
+                        FIXTURE, '--json'],
+                       capture_output=True, text=True)
+    check('board_context exits 0', r.returncode == 0, r.stderr[-300:])
+    parts = {p['ref']: p for p in json.loads(r.stdout).get('parts', [])}
+    ref = _text(REFERENCE)
+    for who in ('U1', 'USB1'):
+        body = (parts.get(who) or {}).get('body_mm')
+        check(f'{who} reports a body', bool(body), sorted(parts))
+        if not body:
+            continue
+        for mm in body:
+            check(f'the reference quotes the {mm:.2f}mm body extent',
+                  f'{mm:.2f}' in ref, f'measured {body}')
+        src = parts[who].get('body_source')
+        check(f'...and names the rung it came from ({src})', str(src) in ref)
+
+
 def test_the_reference_says_which_journal_numbers_did_not_reproduce():
     """The example's own warning about prose.
 
@@ -175,6 +290,8 @@ def test_the_reference_says_which_journal_numbers_did_not_reproduce():
 TESTS = [test_the_seven_criteria_are_named_and_the_ordering_is_stated,
          test_the_reference_names_no_board_and_no_work_directory,
          test_criterion_1_and_2_are_what_the_instrument_reports,
+         test_criterion_1_quotes_the_bodies_it_compares_against,
+         test_criterion_3_is_what_the_grader_reports,
          test_criterion_5_is_what_the_instrument_reports,
          test_criterion_6_is_what_the_instrument_reports,
          test_the_reference_says_which_journal_numbers_did_not_reproduce]

--- a/tests/test_895_boundary_criteria.py
+++ b/tests/test_895_boundary_criteria.py
@@ -160,6 +160,73 @@ def test_criterion_6_is_what_the_instrument_reports():
           'COURTYARD AREA' in ref)
 
 
+def test_the_criteria_name_keys_the_instruments_actually_emit():
+    """A criterion keyed on a field that does not exist measures nothing.
+
+    Criterion 6 shipped reading `hot[].ratio`. `hot` is a LOCAL inside
+    check_pockets; the emitted key is `windows[].ratio`, already sorted by
+    descending ratio. A reviewer following it finds no such field and either
+    guesses or skips -- and the criterion is mandatory, so skipping it blocks
+    the close for a reason that is the document's fault.
+
+    Every dotted path the seven criteria quote is resolved here against the
+    real output of the instrument named beside it.
+    """
+    s = _text(SKILL)
+    ctx = subprocess.run([sys.executable, os.path.join(ROOT, 'py_tools',
+                                                       'board_context.py'),
+                          FIXTURE, '--json'], capture_output=True, text=True)
+    ctx_doc = json.loads(ctx.stdout)
+    check('board_context exits 0', ctx.returncode == 0, ctx.stderr[-200:])
+
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        pk_path = os.path.join(tmp, 'pockets.json')
+        subprocess.run([sys.executable, '-X', 'utf8',
+                        os.path.join(ROOT, 'py_tools', 'check_pockets.py'),
+                        FIXTURE, '--bin', '5', '--json', pk_path],
+                       capture_output=True, text=True)
+        check('check_pockets wrote a document', os.path.isfile(pk_path))
+        if not os.path.isfile(pk_path):
+            return
+        with open(pk_path, encoding='utf-8') as fh:
+            pk_doc = json.load(fh)
+
+    #: (the path as the criteria spell it, the document, a resolver)
+    paths = (
+        ('pin_order.rows[].span_mm', ctx_doc,
+         lambda d: d['pin_order']['rows'][0]['span_mm']),
+        ('pin_order.rows[].verdict', ctx_doc,
+         lambda d: d['pin_order']['rows'][0]['verdict']),
+        ('parts[].body_mm', ctx_doc, lambda d: d['parts'][0]['body_mm']),
+        ('parts[].pads_by_face', ctx_doc,
+         lambda d: d['parts'][0]['pads_by_face']),
+        ('parts[].partners', ctx_doc, lambda d: d['parts'][0]['partners']),
+        ('cold_regions[0].area_mm2', pk_doc,
+         lambda d: d['cold_regions'][0]['area_mm2']),
+        ('windows[0].ratio', pk_doc, lambda d: d['windows'][0]['ratio']),
+        ('arrangement.sides[<layer>].offset_mm', pk_doc,
+         lambda d: next(iter(d['arrangement']['sides'].values()))['offset_mm']),
+    )
+    for path, doc, resolve in paths:
+        check(f'the criteria quote `{path}`', path in s)
+        try:
+            resolve(doc)
+            check(f'...and the instrument emits it', True)
+        except (KeyError, IndexError, TypeError, StopIteration) as exc:
+            check(f'...and the instrument emits it', False,
+                  f'{type(exc).__name__}: {exc}')
+
+    # The seam comes from render_placement, which is too slow to run here; its
+    # key is asserted at the emit site instead of by re-rendering the board.
+    rp = _text(os.path.join(ROOT, 'py_tools', 'render_placement.py'))
+    check('the criteria quote `checklist.b_body_seam`',
+          'checklist.b_body_seam' in s)
+    check("...and render_placement emits 'b_body_seam'", "'b_body_seam':" in rp)
+
+    check('`hot[` is gone -- it was never an emitted key', 'hot[' not in s)
+
+
 def test_criterion_3_is_what_the_grader_reports():
     """Every distance criterion 3 quotes, re-derived through the real grader.
 
@@ -288,6 +355,7 @@ def test_the_reference_says_which_journal_numbers_did_not_reproduce():
 
 
 TESTS = [test_the_seven_criteria_are_named_and_the_ordering_is_stated,
+         test_the_criteria_name_keys_the_instruments_actually_emit,
          test_the_reference_names_no_board_and_no_work_directory,
          test_criterion_1_and_2_are_what_the_instrument_reports,
          test_criterion_1_quotes_the_bodies_it_compares_against,

--- a/tests/test_895_boundary_criteria.py
+++ b/tests/test_895_boundary_criteria.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""#895: the boundary criteria, and the numbers the worked example quotes.
+
+The mandate this ships beside was followed to the letter on run 25 and passed a
+layout a human rejects at a glance. The criteria are the fix; this file is what
+stops the WORKED EXAMPLE becoming the thing it warns about.
+
+Two of the numbers in that reference started life as journal figures -- a seam
+of 0.183mm and a pair of 9.3mm -- and re-measuring them with the shipped
+instruments gives -0.133mm and 8.10mm. Neither journal figure was wrong when it
+was written; neither could be reproduced from what was written down. So every
+figure the reference quotes is re-derived here from a TRACKED fixture and
+compared against the file's own text: a number that stops being true fails the
+suite instead of ageing quietly.
+
+The reference names no board and no work directory -- `test_run8_skills_generic`
+bans both in every skill file, and rightly: a skill that names a corpus board
+teaches the next reader to reach for it. That is exactly why the numbers need a
+gate HERE, where the fixture may be named.
+
+    python3 tests/test_895_boundary_criteria.py
+"""
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+for _d in ('py_router', 'py_placer', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _d))
+sys.path.insert(0, ROOT)
+
+RUN_ALL_TIMEOUT = 600
+
+SKILL = os.path.join(ROOT, '.claude', 'skills',
+                     'plan-pcb-placement-and-routing', 'SKILL.md')
+REFERENCE = os.path.join(ROOT, '.claude', 'skills',
+                         'plan-pcb-placement-and-routing', 'references',
+                         'boundary-criteria.md')
+#: The board the example is drawn from. Named HERE and never in the reference.
+FIXTURE = os.path.join(ROOT, 'tests', 'fixtures', 'run25',
+                       'esp_prog_lap5.kicad_pcb')
+
+FAILURES = []
+
+
+def check(name, cond, detail=''):
+    if cond:
+        print(f"  PASS: {name}")
+    else:
+        FAILURES.append(f"{name} -- {detail}")
+        print(f"  FAIL: {name} -- {detail}")
+
+
+def _text(path):
+    with open(path, encoding='utf-8') as fh:
+        return fh.read()
+
+
+def test_the_seven_criteria_are_named_and_the_ordering_is_stated():
+    """A criterion that is not written down is one nobody has to answer."""
+    s = _text(SKILL)
+    for want in ('Pair and bus length', 'Pin-order agreement',
+                 'Cluster distance', 'Facing', 'Seams',
+                 'Density and balance', 'The human question'):
+        check(f'the boundary section names {want!r}', want in s)
+    check('...and says an unanswered criterion blocks the close',
+          'unanswered criterion blocks the close' in s)
+    # The sharpened ordering rule: BEFORE ANY VERDICT, not merely before any
+    # checklist key. The letter of the old rule was satisfied by a run that
+    # read three checker verdicts 16 seconds before its sheet existed.
+    check('the ordering rule is before any VERDICT, not just any key',
+          'before any VERDICT' in s and '16 seconds' in s)
+    check('the reference is linked from the section',
+          'references/boundary-criteria.md' in s)
+
+
+def test_the_reference_names_no_board_and_no_work_directory():
+    """The prose gate bans both; this says WHY rather than leaving the next
+    author to discover it from a failing test."""
+    import re
+    s = _text(REFERENCE)
+    check('no corpus board name', 'esp_prog' not in s)
+    check('no work directory', re.search(r'wk/run\d+', s) is None)
+    check('the subject is described by part class instead',
+          'USB debug adapter' in s)
+
+
+def test_criterion_1_and_2_are_what_the_instrument_reports():
+    """`span_mm` and `verdict`, re-derived from the tracked fixture."""
+    r = subprocess.run([sys.executable, os.path.join(ROOT, 'py_tools',
+                                                     'board_context.py'),
+                        FIXTURE, '--json'],
+                       capture_output=True, text=True)
+    check('board_context exits 0', r.returncode == 0, r.stderr[-300:])
+    doc = json.loads(r.stdout)
+    rows = {(x['a'], x['b'], x['scope']): x for x in doc['pin_order']['rows']}
+    pair = rows.get(('U1', 'USB1', 'pair /D_P//D_N'))
+    iface = rows.get(('U1', 'USB1', 'interface'))
+    check('the pair row exists', pair is not None, sorted(rows))
+    ref = _text(REFERENCE)
+    if pair:
+        check('the reference quotes the pair span',
+              f"{pair['span_mm']:.2f}" in ref,
+              f"measured {pair['span_mm']}")
+        check('...and the pair reads CROSSED, as the reference says',
+              pair['verdict'] == 'CROSSED' and 'CROSSED' in ref,
+              pair['verdict'])
+        check('...with the one inversion the reference cites',
+              pair['inversions'] == 1 and 'one inversion' in ref,
+              pair['inversions'])
+    if iface:
+        check('the reference quotes the interface span',
+              f"{iface['span_mm']:.2f}" in ref, f"measured {iface['span_mm']}")
+
+
+def test_criterion_5_is_what_the_instrument_reports():
+    """The tightest body seam, signed, with its sources."""
+    from kicad_parser import parse_kicad_pcb
+    from placement import legality
+    pcb = parse_kicad_pcb(FIXTURE)
+    found = legality.grade_body_overlap(pcb, 0.15, (), FIXTURE)
+    seam = found.get('body_seam') or {}
+    ref = _text(REFERENCE)
+    check('a seam was measured', bool(seam), found.keys())
+    if seam:
+        check('the reference quotes the seam',
+              f"{seam['mm']}" in ref, f"measured {seam['mm']}")
+        check('...and names both source rungs',
+              seam['source_a'] in ref and seam['source_b'] in ref,
+              f"{seam['source_a']}/{seam['source_b']}")
+        check('the seam is an OVERLAP, which the reference says outright',
+              seam['mm'] < 0 and 'Negative is an overlap' in ref, seam['mm'])
+
+
+def test_criterion_6_is_what_the_instrument_reports():
+    """And that the reference calls the centroid what it is."""
+    r = subprocess.run([sys.executable, os.path.join(ROOT, 'py_tools',
+                                                     'check_pockets.py'),
+                        FIXTURE, '--bin', '5'],
+                       capture_output=True, text=True)
+    line = [x for x in r.stdout.splitlines() if x.startswith('JSON_SUMMARY:')]
+    check('check_pockets emitted a summary', bool(line), r.stderr[-200:])
+    if not line:
+        return
+    s = json.loads(line[0].split('JSON_SUMMARY: ', 1)[1])
+    ref = _text(REFERENCE)
+    check('the reference quotes the emptiest region',
+          f"{s['cold_top_area_mm2']}" in ref, s['cold_top_area_mm2'])
+    check('the reference quotes the centroid offset',
+          f"{round(s['centroid_offset_frac'] * 100, 1)}" in ref,
+          s['centroid_offset_frac'])
+    # The weight is COURTYARD AREA and the tool says so; a reference that
+    # called it "the centroid" would be quoting a different number.
+    check('the reference says the weight is courtyard area',
+          'COURTYARD AREA' in ref)
+
+
+def test_the_reference_says_which_journal_numbers_did_not_reproduce():
+    """The example's own warning about prose.
+
+    A worked example that quietly used the reproducible numbers, and said
+    nothing about the two that did not reproduce, would be the more flattering
+    document and the less useful one.
+    """
+    ref = _text(REFERENCE)
+    check('it names the journal seam that did not reproduce', '0.183' in ref)
+    check('it names the journal pair length that did not reproduce',
+          '9.3' in ref)
+    check('...and says why neither was wrong when written',
+          'measured differently' in ref)
+
+
+TESTS = [test_the_seven_criteria_are_named_and_the_ordering_is_stated,
+         test_the_reference_names_no_board_and_no_work_directory,
+         test_criterion_1_and_2_are_what_the_instrument_reports,
+         test_criterion_5_is_what_the_instrument_reports,
+         test_criterion_6_is_what_the_instrument_reports,
+         test_the_reference_says_which_journal_numbers_did_not_reproduce]
+
+
+def main():
+    for t in TESTS:
+        print(f'--- {t.__name__}')
+        try:
+            t()
+        except Exception as exc:                             # noqa: BLE001
+            check(f'{t.__name__} ran to completion', False,
+                  f'{type(exc).__name__}: {exc}')
+    print(f"\n{'FAIL' if FAILURES else 'PASS'}: #895 boundary criteria, "
+          f"{len(FAILURES)} failure(s)")
+    for f in FAILURES:
+        print(f'  - {f}')
+    return 1 if FAILURES else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_902_proximity.py
+++ b/tests/test_902_proximity.py
@@ -38,6 +38,7 @@ sys.path.insert(0, ROOT)
 
 from placement import design_brief as db          # noqa: E402
 from placement import floorplan as fp             # noqa: E402
+from placement import legality                    # noqa: E402
 
 RUN_ALL_FAST_OK = True
 
@@ -414,6 +415,236 @@ def test_the_fixture_brief_compiles_to_the_claims_the_issue_names():
           f"3 pad_edge and 1 body")
 
 
+# --------------------------------------------------------------------------
+# the RULE: what the compiled claims measure, on tracked boards
+# --------------------------------------------------------------------------
+
+#: The two boards, and what the SAME brief measures on each. The placed board
+#: is run 25's result; the tracked one is where that run started. The rule is
+#: what makes the difference between them visible at all -- and it needs no
+#: fixture manipulation, because the improvement is real.
+PLACED = os.path.join(ROOT, 'tests', 'fixtures', 'run25',
+                      'esp_prog_placed.kicad_pcb')
+UNPLACED = os.path.join(ROOT, 'kicad_files', 'esp_prog.kicad_pcb')
+
+FIXTURE_BRIEF = os.path.join(ROOT, 'tests', 'fixtures', '902',
+                             'esp_prog_proximity.design-brief.json')
+
+
+def _graded(board, rows=None):
+    from kicad_parser import parse_kicad_pcb
+    if rows is None:
+        with open(FIXTURE_BRIEF, encoding='utf-8') as fh:
+            frag, _rep = db.compile_brief(db.brief_from_dict(json.load(fh)))
+        rows = frag['proximity']
+    intent = fp.intent_from_dict({'schema': fp.SCHEMA_VERSION, 'kind': fp.KIND,
+                                  'units': 'mm', 'proximity': rows})
+    return fp.grade(intent, parse_kicad_pcb(board), board)
+
+
+def _by_pad(result):
+    return {(v.ref, v.measured.get('pad')): v for v in result.violations
+            if v.rule == 'proximity'}
+
+
+def test_the_acceptance_numbers_the_issue_names():
+    """#902's own measurement, off the pad geometry rather than off prose.
+
+    Asserted on `measured`, never on the message: a message assertion passes
+    when the sentence is right and the number is wrong.
+    """
+    r = _graded(PLACED)
+    assert 'proximity' in r.rules_run, r.rules_run
+    got = _by_pad(r)
+    assert len(got) == 1, sorted(got)
+    v = got[('Y1', '1')]
+    m = v.measured
+    assert m['gap_mm'] == 3.1425, m
+    assert (m['near'], m['near_pad']) == ('U1', '9'), m
+    assert m['paired_by'] == 'net' and m['pads_basis'] == 'declared', m
+    assert m['basis'] == 'pad_edge' and v.expected == {'max_mm': 2.0}, v
+    assert v.severity == fp.ERROR, v.severity
+    print(f"  PASS: one violation on the placed board -- {v.message}")
+
+
+def test_the_same_brief_measures_the_board_the_run_started_from():
+    """The rule is what makes run 25's improvement measurable.
+
+    Three of the claims fail on the board the run started from and one fails
+    on what it shipped. A single-board assertion could not tell "the rule
+    works" from "the rule always fires".
+    """
+    placed, unplaced = _by_pad(_graded(PLACED)), _by_pad(_graded(UNPLACED))
+    assert len(unplaced) == 3, sorted(unplaced)
+    assert unplaced[('Y1', '1')].measured['gap_mm'] == 4.7425
+    assert unplaced[('Y1', '2')].measured['gap_mm'] == 2.522
+    assert unplaced[('C1', '1')].measured['gap_mm'] == 4.4111
+    assert set(placed) < set(unplaced), (sorted(placed), sorted(unplaced))
+    # The pad both boards flag got CLOSER, and that direction is the point.
+    assert (placed[('Y1', '1')].measured['gap_mm']
+            < unplaced[('Y1', '1')].measured['gap_mm'])
+    print("  PASS: 3 violations where the run started, 1 where it ended, and "
+          "the shared pad moved 4.7425 -> 3.1425mm")
+
+
+def test_a_claim_the_board_satisfies_is_a_measured_clean_not_a_skip():
+    """The negative control, and both halves are load-bearing.
+
+    "No violations" and "the rule never ran" must not look the same -- this
+    file's own subject, one level down. So the assertion is that `proximity`
+    IS in `rules_run` AND produced nothing.
+    """
+    r = _graded(PLACED, rows=[{'ref': 'C3', 'near': 'U2', 'max_mm': 2.0,
+                               'pads': {'C3': ['1'], 'U2': ['2', '3']}}])
+    assert 'proximity' in r.rules_run, r.rules_run
+    assert [v for v in r.violations if v.rule == 'proximity'] == []
+    assert 'proximity' not in r.rules_skipped, r.rules_skipped
+    print("  PASS: C3 at 0.29mm against a 2.0mm limit -- graded, and clean")
+
+
+def test_an_intent_declaring_none_does_not_run_the_rule():
+    """The `_wants` trap.
+
+    That function ends in a bare `return True`, so a rule registered without
+    an explicit branch runs on EVERY board and lands in `rules_run` having
+    measured nothing -- the vacuous pass `--require-rules` exists to catch,
+    arriving through the mechanism that implements it.
+    """
+    r = _graded(PLACED, rows=[])
+    assert 'proximity' not in r.rules_run, r.rules_run
+    why = r.rules_skipped['proximity']
+    assert why == 'the intent declares no proximity claims', why
+    print(f"  PASS: not declared -> not run, and the skip says why: {why!r}")
+
+
+def test_both_bases_measure_the_same_pair_differently():
+    """Which is why `basis` has no silent default.
+
+    The same two parts are 3.14mm apart pad to pad and 0.32mm apart body to
+    body. A default would have graded whichever one the tool preferred.
+    """
+    pad_edge = _graded(PLACED, rows=[
+        {'ref': 'Y1', 'near': 'U1', 'max_mm': 0.1,
+         'pads': {'Y1': ['1'], 'U1': ['9']}}])
+    body = _graded(PLACED, rows=[
+        {'ref': 'Y1', 'near': 'U1', 'max_mm': 0.1, 'basis': 'body'}])
+    a = pad_edge.violations[0].measured
+    b = body.violations[0].measured
+    assert a['gap_mm'] == 3.1425 and a['basis'] == 'pad_edge', a
+    assert b['gap_mm'] == 0.32 and b['basis'] == 'body', b
+    # The rung that answered is on the wire, which is the whole reason the
+    # basis is spelled `body` and `courtyard` is refused BY NAME: this board
+    # draws no courtyard at all, so a number under that name would rest on fab
+    # and silk without saying so.
+    assert (b['basis_source'], b['near_basis_source']) == ('fab', 'silk'), b
+    print(f"  PASS: same pair, {a['gap_mm']}mm pad-edge vs {b['gap_mm']}mm "
+          f"body (from {b['basis_source']}/{b['near_basis_source']})")
+
+
+def test_a_body_claim_for_parts_that_share_no_net_is_what_pad_edge_cannot_do():
+    """Q1 and Q2 share no net, so there is no pad pair to measure at all."""
+    from kicad_parser import parse_kicad_pcb
+    pcb = parse_kicad_pcb(PLACED)
+    nets = [{p.net_id for p in pcb.footprints[r].pads if p.net_id > 0}
+            for r in ('Q1', 'Q2')]
+    assert not (nets[0] & nets[1]), nets
+    r = _graded(PLACED, rows=[{'ref': 'Q1', 'near': 'Q2', 'max_mm': 0.1,
+                               'basis': 'body'}])
+    assert r.violations[0].measured['gap_mm'] == 0.295, r.violations[0].measured
+    print("  PASS: a pair sharing no net is measurable only body to body "
+          "(0.295mm) -- the reason the second basis exists")
+
+
+def test_a_name_the_board_does_not_have_is_a_finding_not_silence():
+    """A typo must not grade clean -- `block_unresolved`'s failure one level
+    over. Both spellings: a missing REF, and a pad number a real part lacks.
+    """
+    r = _graded(PLACED, rows=[{'ref': 'U99', 'near': 'U1', 'max_mm': 2.0}])
+    v = [x for x in r.violations if x.rule == 'proximity_unresolved']
+    assert len(v) == 1 and 'U99' in v[0].message, r.violations
+    assert v[0].severity == fp.ERROR, v[0].severity
+
+    # `Y1` has pads 1, 2, 3, 3 -- there is no pad 7.
+    r = _graded(PLACED, rows=[{'ref': 'Y1', 'near': 'U1', 'max_mm': 2.0,
+                               'pads': {'Y1': ['7']}}])
+    v = [x for x in r.violations if x.rule == 'proximity_unresolved']
+    assert len(v) == 1 and "'7'" in v[0].message, r.violations
+    assert v[0].measured['unresolved_ref'] == 'Y1', v[0].measured
+    # ...and it does NOT also emit a distance measured from no pads at all.
+    assert not [x for x in r.violations if x.rule == 'proximity']
+    print("  PASS: a missing ref and a missing pad number are each one named "
+          "finding, and neither produces a distance measured from nothing")
+
+
+def test_a_duplicated_pad_number_is_minimised_over_not_first_hit():
+    """`Y1` carries TWO pads numbered `3` -- a crystal's ground tabs.
+
+    A first-hit lookup would answer from whichever the parser saw first, so
+    the number would depend on file order. Taking every match and minimising
+    cannot.
+    """
+    from kicad_parser import parse_kicad_pcb
+    pcb = parse_kicad_pcb(PLACED)
+    threes = [p for p in pcb.footprints['Y1'].pads if p.pad_number == '3']
+    assert len(threes) == 2, threes
+    u1_8 = [q for q in pcb.footprints['U1'].pads if q.pad_number == '8'][0]
+    gaps = sorted(legality.rect_gap(legality.pad_rect(p),
+                                    legality.pad_rect(u1_8)) for p in threes)
+    assert gaps[0] != gaps[1], gaps
+    r = _graded(PLACED, rows=[{'ref': 'Y1', 'near': 'U1', 'max_mm': 0.01,
+                               'pads': {'Y1': ['3'], 'U1': ['8']}}])
+    got = r.violations[0].measured['gap_mm']
+    assert abs(got - gaps[0]) < 1e-6, (got, gaps)
+    print(f"  PASS: two pads named '3' at {gaps[0]:.3f} and {gaps[1]:.3f}mm -- "
+          f"the rule reports the minimum, not the first")
+
+
+def test_the_rule_is_total_over_its_claims():
+    """Every claim yields a pass, a violation, an unresolved, or an abstention.
+
+    This is the promise `_ARM` was dropped on: a branch falling through
+    without one of the four would put `proximity` in `rules_run` having graded
+    a claim it never measured.
+    """
+    rows = [
+        {'ref': 'Y1', 'near': 'U1', 'max_mm': 99.0},               # pass
+        {'ref': 'C1', 'near': 'U2', 'max_mm': 0.01},               # violation
+        {'ref': 'U99', 'near': 'U1', 'max_mm': 2.0},               # unresolved
+        # A DIFFERENT pair for the second unresolved case: the loader refuses
+        # two claims about one relation, and the first draft of this row
+        # reused Y1~U1 and was refused -- the duplicate guard doing its job on
+        # its own test.
+        {'ref': 'C3', 'near': 'U2', 'max_mm': 2.0,
+         'pads': {'C3': ['9']}},                                   # unresolved
+    ]
+    r = _graded(PLACED, rows=rows)
+    kinds = {v.rule for v in r.violations}
+    assert kinds == {'proximity', 'proximity_unresolved'}, kinds
+    assert len([v for v in r.violations if v.rule == 'proximity']) == 1
+    assert len([v for v in r.violations
+                if v.rule == 'proximity_unresolved']) == 2
+    print("  PASS: 4 claims -> 1 pass, 1 violation, 2 unresolved, "
+          "0 unaccounted for")
+
+
+def test_severity_is_settable_per_name():
+    """A DNP-variant board must be able to demote the RESOLUTION finding
+    without demoting the distance one -- which is why there are two names.
+    """
+    from kicad_parser import parse_kicad_pcb
+    intent = fp.intent_from_dict({
+        'schema': fp.SCHEMA_VERSION, 'kind': fp.KIND, 'units': 'mm',
+        'severity': {'proximity_unresolved': fp.WARN},
+        'proximity': [{'ref': 'U99', 'near': 'U1', 'max_mm': 2.0},
+                      {'ref': 'C1', 'near': 'U2', 'max_mm': 0.01}]})
+    r = fp.grade(intent, parse_kicad_pcb(PLACED), PLACED)
+    by = {v.rule: v.severity for v in r.violations}
+    assert by['proximity_unresolved'] == fp.WARN, by
+    assert by['proximity'] == fp.ERROR, by
+    print("  PASS: proximity_unresolved demoted to warn while proximity stays "
+          "an error")
+
+
 TESTS = [
     test_every_malformed_shape_is_refused_by_its_reason,
     test_a_whole_key_unknown_is_refused_naming_the_key_not_a_character,
@@ -429,6 +660,16 @@ TESTS = [
     test_drift_compares_at_the_effective_value_not_at_key_presence,
     test_the_basis_vocabulary_matches_the_intent_loader_or_says_it_cannot_yet,
     test_the_fixture_brief_compiles_to_the_claims_the_issue_names,
+    test_the_acceptance_numbers_the_issue_names,
+    test_the_same_brief_measures_the_board_the_run_started_from,
+    test_a_claim_the_board_satisfies_is_a_measured_clean_not_a_skip,
+    test_an_intent_declaring_none_does_not_run_the_rule,
+    test_both_bases_measure_the_same_pair_differently,
+    test_a_body_claim_for_parts_that_share_no_net_is_what_pad_edge_cannot_do,
+    test_a_name_the_board_does_not_have_is_a_finding_not_silence,
+    test_a_duplicated_pad_number_is_minimised_over_not_first_hit,
+    test_the_rule_is_total_over_its_claims,
+    test_severity_is_settable_per_name,
 ]
 
 

--- a/tests/test_902_proximity.py
+++ b/tests/test_902_proximity.py
@@ -725,13 +725,25 @@ def test_an_abstention_is_its_own_state_not_a_pass_and_not_an_absence():
     over; folding it into `uncovered` makes it unclearable when the board
     genuinely cannot answer. It gets its own state and carries the reason.
     """
-    _frag, _rep, cov = _cov(
-        abstained={'proximity[Q1~Q2].basis': 'Q1 draws no body'})
+    frag, _rep, _c = _cov()
+    # The key format the RULE writes, derived from the intent row rather than
+    # hardcoded: it carries the row INDEX because a reference may contain `~`,
+    # so a coverage consumer resolves the index against the intent instead of
+    # matching `ref~near` as a string.
+    row_i = next(i for i, p in enumerate(frag['proximity'])
+                 if p['ref'] == 'Q1')
+    akey = f"proximity[{row_i}:Q1~Q2].basis"
+    _f, _r, cov = _cov(abstained={akey: 'Q1 draws no body'})
     assert cov['abstained'] == 1 and cov['graded'] == 3, cov
     row = next(c for c in cov['clauses'] if c['state'] == 'abstained')
     assert row['why'] == 'Q1 draws no body', row
+    assert row['ref'] == 'Q1', row
     assert cov['complete'] is False
-    print(f"  PASS: {row['id']} abstained, carrying its reason verbatim")
+    # A key naming a row that is not this clause must NOT be attributed to it.
+    _f, _r, other = _cov(abstained={'proximity[0:Q1~Q2].basis': 'x'})
+    assert other['abstained'] == 0, other
+    print(f"  PASS: {row['id']} abstained carrying its reason verbatim, and a "
+          f"key naming another row is not attributed to it")
 
 
 def test_a_graded_clause_can_still_be_DRIFTED():
@@ -814,6 +826,204 @@ def test_a_board_with_no_brief_is_untouched():
     print("  PASS: a board with no brief prints no coverage line and carries "
           "no coverage key")
 
+# --------------------------------------------------------------------------
+# the holes a second verifier found: branches nothing reached
+# --------------------------------------------------------------------------
+
+#: A board that DRAWS courtyards, which the esp_prog fixture does not (0 of
+#: 21). Without it nothing here could see the difference between a courtyard
+#: and a drawn body, which is a whole basis' worth of meaning.
+COURTYARD_BOARD = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
+
+
+def test_the_body_basis_measures_the_DRAWN_body_not_the_courtyard():
+    """#896 stores two ladders and says why: "a courtyard is not a body -- it
+    is a body plus an assembly margin plus any shell overhang".
+
+    `body_local` is courtyard-FIRST, so reading it made `basis: "body"`
+    silently measure courtyards on every board that draws them, under-stating
+    each gap by the assembly margin and PASSING claims that should fail --
+    while `basis: "courtyard"` is refused by name on the grounds that boards
+    do not draw them. The esp_prog fixture draws none, so no test on it could
+    ever have seen this; it took a board that does.
+    """
+    from kicad_parser import parse_kicad_pcb
+    from placement import body as body_mod
+    pcb = parse_kicad_pcb(COURTYARD_BOARD)
+    bodies = body_mod.board_bodies(pcb, COURTYARD_BOARD)
+    pair = ('U1', 'Y1')
+    assert all(bodies[r].source == 'courtyard' for r in pair), \
+        {r: bodies[r].source for r in pair}
+    assert all(bodies[r].drawn_source == 'fab' for r in pair), \
+        {r: bodies[r].drawn_source for r in pair}
+
+    def _rect(ref, local):
+        fp_obj = pcb.footprints[ref]
+        x0, y0, x1, y1 = legality.rotate_local_bounds(
+            *local, fp_obj.rotation or 0.0)
+        return (fp_obj.x + x0, fp_obj.y + y0, fp_obj.x + x1, fp_obj.y + y1)
+
+    courtyard_gap = legality.rect_gap(
+        _rect(pair[0], bodies[pair[0]].body_local),
+        _rect(pair[1], bodies[pair[1]].body_local))
+    drawn_gap = legality.rect_gap(
+        _rect(pair[0], bodies[pair[0]].drawn_local),
+        _rect(pair[1], bodies[pair[1]].drawn_local))
+    assert drawn_gap > courtyard_gap + 0.5, (courtyard_gap, drawn_gap)
+
+    intent = fp.intent_from_dict({
+        'schema': fp.SCHEMA_VERSION, 'kind': fp.KIND, 'units': 'mm',
+        'proximity': [{'ref': pair[0], 'near': pair[1], 'max_mm': 2.0,
+                       'basis': 'body'}]})
+    r = fp.grade(intent, pcb, COURTYARD_BOARD)
+    got = r.violations[0].measured
+    assert abs(got['gap_mm'] - drawn_gap) < 1e-6, (got, drawn_gap)
+    assert got['basis_source'] == 'fab', got
+    # ...and the courtyard reading would have PASSED this very claim.
+    assert courtyard_gap <= 2.0 < drawn_gap, (courtyard_gap, drawn_gap)
+    print(f"  PASS: courtyard-first reads {courtyard_gap:.3f}mm and would "
+          f"PASS a 2.0mm claim; the drawn bodies are {drawn_gap:.3f}mm apart "
+          f"and the rule reports that, sourced 'fab'")
+
+
+def test_a_partially_wrong_pad_list_is_not_graded_on_the_survivors():
+    """`pads: {'Y1': ['2', '7']}` used to grade CLEAN on pad 2 while '7'
+    vanished.
+
+    The claim then measured a strictly smaller subject set than it declared --
+    the exact failure the loader cites when it refuses an integer pad number
+    ("would match no pad, measure nothing, and grade clean"), and a
+    falsification of this rule's own invariant, which is quantified over the
+    pads the claim DECLARES.
+    """
+    r = _graded(PLACED, rows=[{'ref': 'Y1', 'near': 'U1', 'max_mm': 2.0,
+                               'pads': {'Y1': ['2', '7']}}])
+    unres = [v for v in r.violations if v.rule == 'proximity_unresolved']
+    assert len(unres) == 1, r.violations
+    assert unres[0].measured['pads'] == ['7'], unres[0].measured
+    assert unres[0].measured['resolved_pads'] == 1, unres[0].measured
+    # ...and NO distance was reported from the pad that did resolve.
+    assert not [v for v in r.violations if v.rule == 'proximity'], r.violations
+
+    # The partner side too.
+    r = _graded(PLACED, rows=[{'ref': 'Y1', 'near': 'U1', 'max_mm': 0.01,
+                               'pads': {'Y1': ['1'], 'U1': ['9', '99']}}])
+    unres = [v for v in r.violations if v.rule == 'proximity_unresolved']
+    assert len(unres) == 1 and unres[0].measured['unresolved_ref'] == 'U1'
+    assert not [v for v in r.violations if v.rule == 'proximity'], r.violations
+    print("  PASS: one bad name in a pad list stops the claim on either side, "
+          "naming the pad that missed and how many resolved")
+
+
+def test_the_minimum_over_partners_is_a_minimum():
+    """The rule's stated INVARIANT, and nothing reached it.
+
+    Every earlier case gave a subject pad exactly ONE candidate partner (net
+    matching reduces the declared arity to one), so `min` and `max` were
+    indistinguishable -- flipping the comparison survived every test. This
+    gives one subject pad SEVERAL partners on the same net and pins the
+    smallest.
+    """
+    from kicad_parser import parse_kicad_pcb
+    pcb = parse_kicad_pcb(PLACED)
+    # USB1 carries six pads numbered '0', all on GND -- six real candidates
+    # for one subject pad, at six different distances.
+    zeros = [p for p in pcb.footprints['USB1'].pads if p.pad_number == '0']
+    assert len(zeros) == 6, len(zeros)
+    u1_8 = [q for q in pcb.footprints['U1'].pads if q.pad_number == '8'][0]
+    gaps = sorted(legality.rect_gap(legality.pad_rect(u1_8),
+                                    legality.pad_rect(p)) for p in zeros)
+    assert gaps[0] < gaps[-1] - 1.0, gaps
+
+    r = _graded(PLACED, rows=[{'ref': 'U1', 'near': 'USB1', 'max_mm': 0.01,
+                               'pads': {'U1': ['8'], 'USB1': ['0']}}])
+    got = [v for v in r.violations if v.rule == 'proximity']
+    assert len(got) == 1, got
+    # Against the ROUNDED minimum: `measured['gap_mm']` is 4dp on the wire,
+    # and comparing it to a raw float at 1e-6 fails for a reason that has
+    # nothing to do with which end of the range the rule took.
+    assert got[0].measured['gap_mm'] == round(gaps[0], 4), \
+        (got[0].measured['gap_mm'], gaps)
+    # ...and NOT the maximum, which is what the flipped comparison produces.
+    assert got[0].measured['gap_mm'] != round(gaps[-1], 4), gaps
+    assert got[0].measured['near_pads'] == 6, got[0].measured
+    print(f"  PASS: one subject pad against six partners {gaps[0]:.3f}.."
+          f"{gaps[-1]:.3f}mm -- the rule reports {gaps[0]:.3f}, the minimum")
+
+
+def test_a_padless_part_abstains_rather_than_passing_silently():
+    """The abstention branches, which nothing reached.
+
+    Both could be deleted with the whole suite green, and a claim naming a
+    padless part then yielded NOTHING while `proximity` stayed in
+    `rules_run` -- the vacuous pass `_ARM` was dropped on.
+    """
+    from kicad_parser import parse_kicad_pcb
+    pcb = parse_kicad_pcb(PLACED)
+    padless = sorted(r for r, f in pcb.footprints.items() if not f.pads)
+    assert padless, 'the fixture has no padless footprint to test with'
+    ref = padless[0]
+
+    r = _graded(PLACED, rows=[{'ref': ref, 'near': 'U1', 'max_mm': 2.0}])
+    assert not r.violations, r.violations
+    assert 'proximity' in r.rules_run, r.rules_run
+    keys = [k for k in r.budget_abstained if k.startswith('proximity[')]
+    assert len(keys) == 1, r.budget_abstained
+    assert 'no pads at all' in r.budget_abstained[keys[0]], r.budget_abstained
+    # An abstention makes the grade INCOMPLETE, which is what stops it being
+    # read as a clean board.
+    assert r.complete is False and r.passed is False
+    print(f"  PASS: a claim naming padless {ref} abstains -- "
+          f"{r.budget_abstained[keys[0]][:60]}...")
+
+
+def test_a_body_claim_for_a_part_with_no_geometry_abstains():
+    """The other abstention branch, on the body basis."""
+    from kicad_parser import parse_kicad_pcb
+    from placement import body as body_mod
+    pcb = parse_kicad_pcb(PLACED)
+    bodies = body_mod.board_bodies(pcb, PLACED)
+    nogeom = sorted(r for r, g in bodies.items()
+                    if g.drawn_local is None and g.body_local is None)
+    if not nogeom:
+        print("  PASS (VACUOUS): every part on this fixture has geometry; the "
+              "source='none' branch has no subject here and is covered by the "
+              "padless case above")
+        return
+    r = _graded(PLACED, rows=[{'ref': nogeom[0], 'near': 'U1', 'max_mm': 2.0,
+                               'basis': 'body'}])
+    keys = [k for k in r.budget_abstained if k.startswith('proximity[')]
+    assert len(keys) == 1, r.budget_abstained
+    assert 'draws no body' in r.budget_abstained[keys[0]]
+    print(f"  PASS: a body claim naming {nogeom[0]} abstains rather than "
+          f"passing")
+
+
+def test_the_intent_loader_refuses_the_reversed_pair_the_brief_refuses():
+    """The hand-written intent is the path the brief compiler never sees.
+
+    Without this the two documents disagreed about the same rows: the brief
+    refused them and the loader accepted them, and the grade then charged one
+    symmetric measurement twice, reporting an identical number under two
+    claims.
+    """
+    base = {'schema': fp.SCHEMA_VERSION, 'kind': fp.KIND, 'units': 'mm'}
+    try:
+        fp.intent_from_dict(dict(base, proximity=[
+            {'ref': 'Y1', 'near': 'U1', 'max_mm': 0.1},
+            {'ref': 'U1', 'near': 'Y1', 'max_mm': 0.1}]))
+        raise AssertionError('NOT REFUSED')
+    except fp.IntentError as exc:
+        assert 'same symmetric measurement' in str(exc), str(exc)
+    # ...and the asymmetric form, with a subject pad list on each side, is
+    # KEPT -- a guard that refuses everything is not a guard.
+    i = fp.intent_from_dict(dict(base, proximity=[
+        {'ref': 'Y1', 'near': 'U1', 'max_mm': 0.1, 'pads': {'Y1': ['1']}},
+        {'ref': 'U1', 'near': 'Y1', 'max_mm': 0.1, 'pads': {'U1': ['9']}}]))
+    assert len(i.proximity) == 2, i.proximity
+    print("  PASS: the loader refuses the symmetric reversed pair and keeps "
+          "the asymmetric one, exactly as the brief does")
+
 TESTS = [
     test_every_malformed_shape_is_refused_by_its_reason,
     test_a_whole_key_unknown_is_refused_naming_the_key_not_a_character,
@@ -847,6 +1057,12 @@ TESTS = [
     test_unknown_and_carried_clauses_never_block,
     test_the_cli_refuses_and_names_every_uncovered_clause,
     test_a_board_with_no_brief_is_untouched,
+    test_the_body_basis_measures_the_DRAWN_body_not_the_courtyard,
+    test_a_partially_wrong_pad_list_is_not_graded_on_the_survivors,
+    test_the_minimum_over_partners_is_a_minimum,
+    test_a_padless_part_abstains_rather_than_passing_silently,
+    test_a_body_claim_for_a_part_with_no_geometry_abstains,
+    test_the_intent_loader_refuses_the_reversed_pair_the_brief_refuses,
 ]
 
 

--- a/tests/test_902_proximity.py
+++ b/tests/test_902_proximity.py
@@ -7,13 +7,22 @@ ungradable -- and run 25 shipped a board whose brief said exactly that, with
 `rules_run: 6` and every declared clause ungraded.
 
 This file holds the BRIEF half: the vocabulary, its refusals, and the
-three-state contract. The rule that grades the compiled rows is
-`rule_proximity`, and its measurements are tested beside it.
+three-state contract. Grading the compiled rows is the intent half's job, and
+`test_the_basis_vocabulary_matches_the_intent_loader_or_says_it_cannot_yet`
+reports which of the two states this tree is in rather than passing either
+way.
 
-Most of these rows exist because an adversarial verifier found the defect they
-pin. Every one of the shapes under `_REFUSALS` LOADED CLEAN at some point in
-this feature's history, so they are change detectors with a scar, not a
-catalogue of things that were never going to happen.
+FIVE of the twenty-six shapes under `_REFUSALS` actually LOADED CLEAN in this
+feature's first commit -- rows 3, 4 (`inf` and `NaN` limits), 20 (`pads: {}`)
+and 24, 25 (the two spellings of a reversed pair). They are marked `# WAS
+CLEAN` below. The other twenty-one were refused from the start.
+
+That sentence began life as "every one of them loaded clean", which was a
+claim in the feature's own favour that nobody had measured. The number is
+measurable -- run each shape against `git show 7c682f89:...design_brief.py` --
+and measuring it turned 26 into 5. It is written out here because the marked
+rows are the ones with a scar, and a reader deciding which of these to trust
+should not have to take the docstring's word for it.
 
     python3 tests/test_902_proximity.py
 """
@@ -66,11 +75,13 @@ def _rejects(rows, why, **over):
 _REFUSALS = [
     ([{'ref': 'Y1', 'near': 'U1'}], 'needs `max_mm`'),
     ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 0}], 'expected a positive'),
-    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': -1}], 'expected'),
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': -1}], 'expected a positive'),
     # inf and nan pass BOTH `_number(lo=0.0)` and a `<= 0.0` guard, and
     # json.load accepts the literals, so this was reachable from a file.
+    # WAS CLEAN at 7c682f89.
     ([{'ref': 'Y1', 'near': 'U1', 'max_mm': float('inf')}],
      'not a finite distance'),
+    # WAS CLEAN at 7c682f89.
     ([{'ref': 'Y1', 'near': 'U1', 'max_mm': float('nan')}],
      'not a finite distance'),
     ([{'ref': 'Y1', 'near': 'Y1', 'max_mm': 2}], '0mm from itself'),
@@ -101,11 +112,14 @@ _REFUSALS = [
      'non-empty list'),
     # An empty dict was a THIRD spelling of "unpadded" the reverse guard did
     # not recognise.
+    # WAS CLEAN at 7c682f89.
     ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2, 'pads': {}}], 'empty pad spec'),
-    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2, 'pads': 7}], 'expected'),
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2, 'pads': 7}],
+     "expected {'REF': ['1', '2']}"),
     # Two limits on one relation, in both spellings of "the same relation".
     ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2},
       {'ref': 'Y1', 'near': 'U1', 'max_mm': 3}], 'duplicate proximity'),
+    # WAS CLEAN at 7c682f89 (both of the next two).
     ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 5},
       {'ref': 'U1', 'near': 'Y1', 'max_mm': 9}], 'same symmetric measurement'),
     ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 5, 'pads': 'unknown'},
@@ -309,6 +323,27 @@ def test_an_absent_partner_is_named_once_not_once_per_member():
     print("  PASS: an absent partner named once, not once per list member")
 
 
+def test_an_absent_partner_is_named_even_when_the_limit_is_unknown():
+    """A typo does not become invisible because the limit was not stated.
+
+    The first fix for the "declared unknown was swallowed" defect moved the
+    PADS report above the `continue` and left the UNMATCHED report below it --
+    so a misspelled partner on an "as short as possible" row was reported by
+    nothing at all. The same defect, one line further down, is why this row
+    exists rather than an extra assert on the one above.
+    """
+    for limit in (2.0, 'unknown'):
+        _frag, rep = _compile([{'ref': 'Y1', 'near': 'ZZ9', 'max_mm': limit}],
+                              refs=('Y1', 'U1'))
+        assert rep['unmatched'] == ['ZZ9'], (limit, rep['unmatched'])
+    # And the control: a ref the board HAS is never reported.
+    _frag, rep = _compile([{'ref': 'Y1', 'near': 'U1', 'max_mm': 'unknown'}],
+                          refs=('Y1', 'U1'))
+    assert rep['unmatched'] == [], rep['unmatched']
+    print("  PASS: an absent partner is named with a limit and with an "
+          "unknown one; a present partner is never named")
+
+
 def test_drift_compares_at_the_effective_value_not_at_key_presence():
     """A brief meaning the DEFAULT versus an intent declaring otherwise.
 
@@ -390,6 +425,7 @@ TESTS = [
     test_the_counts_disclose_an_expansion_and_a_drop_that_cancel,
     test_a_brief_with_no_proximity_reports_exactly_what_it_did_before,
     test_an_absent_partner_is_named_once_not_once_per_member,
+    test_an_absent_partner_is_named_even_when_the_limit_is_unknown,
     test_drift_compares_at_the_effective_value_not_at_key_presence,
     test_the_basis_vocabulary_matches_the_intent_loader_or_says_it_cannot_yet,
     test_the_fixture_brief_compiles_to_the_claims_the_issue_names,

--- a/tests/test_902_proximity.py
+++ b/tests/test_902_proximity.py
@@ -40,7 +40,6 @@ from placement import design_brief as db          # noqa: E402
 from placement import floorplan as fp             # noqa: E402
 from placement import legality                    # noqa: E402
 
-RUN_ALL_FAST_OK = True
 
 BASE = {'schema': 1, 'kind': 'design-brief', 'units': 'mm'}
 REFS = ('Y1', 'U1', 'U2', 'C1', 'C3', 'Q1', 'Q2')
@@ -645,6 +644,176 @@ def test_severity_is_settable_per_name():
           "an error")
 
 
+# --------------------------------------------------------------------------
+# clause coverage: did a rule reach a verdict on every DECLARED clause?
+# --------------------------------------------------------------------------
+
+
+def _cov(rows=None, intent=None, **kw):
+    """Compile the fixture brief and cover it against `intent`."""
+    with open(FIXTURE_BRIEF, encoding='utf-8') as fh:
+        raw = json.load(fh)
+    if rows is not None:
+        raw = dict(raw, proximity=rows)
+    frag, rep = db.compile_brief(db.brief_from_dict(raw, 'e.design-brief.json'))
+    if intent is None:
+        # `.get`, because a brief whose every limit is "unknown"
+        # compiles to NO proximity key at all -- which is the state
+        # `test_unknown_and_carried_clauses_never_block` is about.
+        intent = {'proximity': frag.get('proximity', [])}
+    kw.setdefault('rules_run', ('proximity',))
+    kw.setdefault('drifted_ids', db.drifted_clause_ids(intent, frag))
+    return frag, rep, db.clause_coverage(rep, intent, **kw)
+
+
+def test_every_clause_id_the_compiler_emits_parses_back():
+    """ONE parser for a format built in seventeen places.
+
+    A second implementation of a string format is how two halves drift, so
+    this round-trips every id `compile_brief` produces. An id that stops
+    parsing becomes a test failure rather than a clause that silently vanishes
+    from the coverage report.
+    """
+    _frag, rep, _c = _cov()
+    ids = list(rep['declared']) + list(rep['unknown']) + list(rep['not_graded'])
+    assert ids, ids
+    for cid in ids:
+        rec = db.parse_clause_id(cid)
+        assert rec is not None, cid
+        assert rec['kind'] in ('interfaces', 'keepouts', 'proximity',
+                               'product'), (cid, rec)
+        if rec['kind'] == 'proximity':
+            assert rec['near'] and rec['row'] is not None, (cid, rec)
+            assert db.proximity_claim_id(rec['row'], rec['ref'],
+                                         rec['near']) in cid, (cid, rec)
+    # ...and a free-text `unknown[]` entry is NOT a clause and must not be
+    # counted as one.
+    assert db.parse_clause_id('mounting_datum') is None
+    print(f"  PASS: {len(ids)} clause id(s) all parse back to their parts, and "
+          f"a free-text unknown is not mistaken for one")
+
+
+def test_a_declared_clause_the_intent_does_not_carry_is_UNCOVERED():
+    """The run-25 shape, and the whole point of the key.
+
+    Six rules ran, the grade passed, and not one clause the brief declared was
+    measured -- because `rules_run` counts RULES and the count was satisfied
+    by rules nobody had declared anything for.
+    """
+    _frag, _rep, cov = _cov(intent={})
+    assert cov['uncovered'] == 4 and cov['graded'] == 0, cov
+    assert cov['complete'] is False
+    for row in cov['clauses']:
+        if row['kind'] == 'proximity':
+            assert row['state'] == 'uncovered', row
+            assert 'no proximity claim' in row['why'], row
+    print(f"  PASS: 4 declared clauses, 0 graded, complete=False")
+
+
+def test_a_rule_that_did_not_run_leaves_its_clauses_uncovered():
+    _frag, _rep, cov = _cov(rules_run=())
+    assert cov['uncovered'] == 4, cov
+    assert all('did not run' in c['why'] for c in cov['clauses']
+               if c['kind'] == 'proximity'), cov['clauses']
+    print("  PASS: the clause names the rule that did not run")
+
+
+def test_an_abstention_is_its_own_state_not_a_pass_and_not_an_absence():
+    """Three outcomes, not two.
+
+    Folding an abstention into `graded` rebuilds the vacuous pass one key
+    over; folding it into `uncovered` makes it unclearable when the board
+    genuinely cannot answer. It gets its own state and carries the reason.
+    """
+    _frag, _rep, cov = _cov(
+        abstained={'proximity[Q1~Q2].basis': 'Q1 draws no body'})
+    assert cov['abstained'] == 1 and cov['graded'] == 3, cov
+    row = next(c for c in cov['clauses'] if c['state'] == 'abstained')
+    assert row['why'] == 'Q1 draws no body', row
+    assert cov['complete'] is False
+    print(f"  PASS: {row['id']} abstained, carrying its reason verbatim")
+
+
+def test_a_graded_clause_can_still_be_DRIFTED():
+    """Coverage answers "did a rule look at this"; drift answers "was the
+    thing graded the thing declared". A brief saying 2mm against an intent
+    saying 9mm is fully graded -- against the wrong requirement.
+    """
+    with open(FIXTURE_BRIEF, encoding='utf-8') as fh:
+        frag, rep = db.compile_brief(db.brief_from_dict(json.load(fh)))
+    intent = {'proximity': [dict(p, max_mm=9.0) if p['ref'] == 'Y1' else p
+                            for p in frag['proximity']]}
+    cov = db.clause_coverage(rep, intent, rules_run=('proximity',),
+                             drifted_ids=db.drifted_clause_ids(intent, frag))
+    row = next(c for c in cov['clauses'] if c['ref'] == 'Y1')
+    assert row['state'] == 'graded' and row['drifted'] is True, row
+    assert cov['complete'] is False, cov
+    print("  PASS: Y1's clause is graded AND drifted -- measured, against the "
+          "wrong number")
+
+
+def test_unknown_and_carried_clauses_never_block():
+    """Declaring honestly must not be punished, or the channel teaches people
+    to stop declaring. `mount_mode` is ungraded by design; a `"unknown"` limit
+    is an author saying so.
+    """
+    _frag, _rep, cov = _cov(rows=[{'ref': 'Y1', 'near': 'U1',
+                                   'max_mm': 'unknown'}])
+    assert cov['not_claimed'] >= 1, cov
+    assert cov['uncovered'] == 0 and cov['abstained'] == 0, cov
+    assert cov['complete'] is True, cov
+    assert cov['carried'] >= 1, cov
+    print(f"  PASS: {cov['not_claimed']} unknown + {cov['carried']} carried "
+          f"clause(s), complete=True -- the gate is clearable")
+
+
+def test_the_cli_refuses_and_names_every_uncovered_clause():
+    """The acceptance #902 asks for, through the real CLI."""
+    import subprocess
+    board = PLACED
+    intent = os.path.join(ROOT, 'wk', 'cov_test_intent.json')
+    os.makedirs(os.path.dirname(intent), exist_ok=True)
+    tool = os.path.join(ROOT, 'py_tools', 'check_floorplan.py')
+    emit = subprocess.run([sys.executable, '-X', 'utf8', tool, board,
+                           '--no-brief', '--emit-intent', intent, '-q'],
+                          capture_output=True, text=True)
+    assert emit.returncode == 0, emit.stderr[-800:]
+    r = subprocess.run([sys.executable, '-X', 'utf8', tool, board,
+                        '--brief', FIXTURE_BRIEF, '--intent', intent,
+                        '--require-brief-coverage'],
+                       capture_output=True, text=True)
+    assert r.returncode == 4, (r.returncode, r.stdout[-500:], r.stderr[-500:])
+    assert 'require-brief-coverage' in r.stderr, r.stderr
+    for ref, near in (('Y1', 'U1'), ('C1', 'U2'), ('C3', 'U2'), ('Q1', 'Q2')):
+        assert f"{ref}~{near}" in r.stdout, (ref, near, r.stdout[-900:])
+    # NOT the rule-count refusal: the right gate has to fire, or this passes
+    # for a reason that has nothing to do with clauses.
+    assert 'require-rules' not in r.stderr, r.stderr
+    print("  PASS: the CLI exits 4 naming all four uncovered clauses, on the "
+          "coverage gate rather than the rule count")
+
+
+def test_a_board_with_no_brief_is_untouched():
+    """The control. `counts`, the report line and the JSON must be what they
+    were before this key existed, or every board on the corpus starts
+    reporting zero of a thing nobody mentioned.
+    """
+    import subprocess
+    tool = os.path.join(ROOT, 'py_tools', 'check_floorplan.py')
+    intent = os.path.join(ROOT, 'wk', 'cov_nobrief_intent.json')
+    os.makedirs(os.path.dirname(intent), exist_ok=True)
+    board = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
+    subprocess.run([sys.executable, '-X', 'utf8', tool, board, '--no-brief',
+                    '--emit-intent', intent, '-q'], capture_output=True,
+                   text=True, check=True)
+    r = subprocess.run([sys.executable, '-X', 'utf8', tool, board,
+                        '--no-brief', '--intent', intent],
+                       capture_output=True, text=True)
+    assert 'clause coverage' not in r.stdout, r.stdout[-500:]
+    assert 'brief_clauses' not in r.stdout, r.stdout[-500:]
+    print("  PASS: a board with no brief prints no coverage line and carries "
+          "no coverage key")
+
 TESTS = [
     test_every_malformed_shape_is_refused_by_its_reason,
     test_a_whole_key_unknown_is_refused_naming_the_key_not_a_character,
@@ -670,6 +839,14 @@ TESTS = [
     test_a_duplicated_pad_number_is_minimised_over_not_first_hit,
     test_the_rule_is_total_over_its_claims,
     test_severity_is_settable_per_name,
+    test_every_clause_id_the_compiler_emits_parses_back,
+    test_a_declared_clause_the_intent_does_not_carry_is_UNCOVERED,
+    test_a_rule_that_did_not_run_leaves_its_clauses_uncovered,
+    test_an_abstention_is_its_own_state_not_a_pass_and_not_an_absence,
+    test_a_graded_clause_can_still_be_DRIFTED,
+    test_unknown_and_carried_clauses_never_block,
+    test_the_cli_refuses_and_names_every_uncovered_clause,
+    test_a_board_with_no_brief_is_untouched,
 ]
 
 

--- a/tests/test_902_proximity.py
+++ b/tests/test_902_proximity.py
@@ -805,6 +805,48 @@ def test_the_cli_refuses_and_names_every_uncovered_clause():
           "coverage gate rather than the rule count")
 
 
+def test_the_absence_reason_names_what_is_actually_absent():
+    """`--require-brief-coverage` must not fabricate a brief.
+
+    The coverage block became UNCONDITIONAL on the `--intent` path, which
+    turned `if not coverage` into a dead branch -- so every absence started
+    printing "the brief that was found declares no gradable clause" about
+    boards that have no brief at all, and under `--no-brief` it blamed the
+    board for the caller's own flag. `_brief_absence_reason` keeps three cases
+    apart on purpose; the gate has to reach them.
+    """
+    import subprocess
+    tool = os.path.join(ROOT, 'py_tools', 'check_floorplan.py')
+    board = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
+    intent = os.path.join(ROOT, 'wk', 'abs_intent.json')
+    os.makedirs(os.path.dirname(intent), exist_ok=True)
+    subprocess.run([sys.executable, '-X', 'utf8', tool, board, '--no-brief',
+                    '--emit-intent', intent, '-q'],
+                   capture_output=True, text=True, check=True)
+
+    def _run(*extra):
+        return subprocess.run(
+            [sys.executable, '-X', 'utf8', tool, board, '--intent', intent,
+             '--require-brief-coverage', '-q'] + list(extra),
+            capture_output=True, text=True)
+
+    found = _run()
+    assert found.returncode == 4, found.returncode
+    assert 'no design brief was found' in found.stderr, found.stderr
+    assert 'brief that was found' not in found.stderr, found.stderr
+
+    flag = _run('--no-brief')
+    assert flag.returncode == 4, flag.returncode
+    assert '--no-brief was passed' in flag.stderr, flag.stderr
+    assert 'no design brief was found' not in flag.stderr, flag.stderr
+
+    # The two reasons are DIFFERENT, which is the whole point of keeping
+    # three cases: one blames the board, the other blames the flag.
+    assert found.stderr != flag.stderr
+    print("  PASS: an absent brief and a suppressed one give different "
+          "reasons, and neither claims a brief was found")
+
+
 def test_a_board_with_no_brief_is_untouched():
     """The control. `counts`, the report line and the JSON must be what they
     were before this key existed, or every board on the corpus starts
@@ -1057,6 +1099,7 @@ TESTS = [
     test_unknown_and_carried_clauses_never_block,
     test_the_cli_refuses_and_names_every_uncovered_clause,
     test_a_board_with_no_brief_is_untouched,
+    test_the_absence_reason_names_what_is_actually_absent,
     test_the_body_basis_measures_the_DRAWN_body_not_the_courtyard,
     test_a_partially_wrong_pad_list_is_not_graded_on_the_survivors,
     test_the_minimum_over_partners_is_a_minimum,

--- a/tests/test_902_proximity.py
+++ b/tests/test_902_proximity.py
@@ -25,11 +25,12 @@ rows are the ones with a scar, and a reader deciding which of these to trust
 should not have to take the docstring's word for it.
 
 MEASURED, from the run and not predicted: `tests/mutate_902.py` is 21 rows,
-21 killed, 0 survived, 0 broken. Nine of those rows are branches that ALREADY
+21 killed, 0 survived, 0 broken. FIVE of those rows are branches that ALREADY
 survived a battery once -- the `min` that is the rule's stated invariant, both
-abstentions, the partial-pad miss, the courtyard-vs-body read, the bool check,
-longest-match waiver resolution, the `+ ':'` suffix guard and the whole DRIFTED
-arm -- so they are recorded there rather than remembered here.
+abstentions, the partial-pad miss and the courtyard-vs-body read. Four more
+such branches (the bool check, longest-match waiver resolution, the `+ ':'`
+suffix guard and the whole DRIFTED arm) live in the placement driver, which
+that battery does not target; they are killed by its own `--self-test`.
 
 The battery also found a hole nothing else did: deleting the INTENT loader's
 finite check survived, because every non-finite case tested the BRIEF. An
@@ -42,6 +43,7 @@ import json
 import math
 import os
 import sys
+import tempfile
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 for _d in ('py_router', 'py_placer', 'py_tools'):
@@ -795,8 +797,11 @@ def test_the_cli_refuses_and_names_every_uncovered_clause():
     """The acceptance #902 asks for, through the real CLI."""
     import subprocess
     board = PLACED
-    intent = os.path.join(ROOT, 'wk', 'cov_test_intent.json')
-    os.makedirs(os.path.dirname(intent), exist_ok=True)
+    # A TEMP dir, not `wk/`: this file is an output of the test, and writing
+    # it under the gitignored work tree made `test_718_static_test_hygiene`
+    # read the whole file as depending on a board out of `wk/` -- which it
+    # does not. The dependency it flagged would have been a false declaration.
+    intent = os.path.join(tempfile.mkdtemp(), 'cov_test_intent.json')
     tool = os.path.join(ROOT, 'py_tools', 'check_floorplan.py')
     emit = subprocess.run([sys.executable, '-X', 'utf8', tool, board,
                            '--no-brief', '--emit-intent', intent, '-q'],
@@ -830,8 +835,11 @@ def test_the_absence_reason_names_what_is_actually_absent():
     import subprocess
     tool = os.path.join(ROOT, 'py_tools', 'check_floorplan.py')
     board = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
-    intent = os.path.join(ROOT, 'wk', 'abs_intent.json')
-    os.makedirs(os.path.dirname(intent), exist_ok=True)
+    # A TEMP dir, not `wk/`: this file is an output of the test, and writing
+    # it under the gitignored work tree made `test_718_static_test_hygiene`
+    # read the whole file as depending on a board out of `wk/` -- which it
+    # does not. The dependency it flagged would have been a false declaration.
+    intent = os.path.join(tempfile.mkdtemp(), 'abs_intent.json')
     subprocess.run([sys.executable, '-X', 'utf8', tool, board, '--no-brief',
                     '--emit-intent', intent, '-q'],
                    capture_output=True, text=True, check=True)
@@ -866,8 +874,11 @@ def test_a_board_with_no_brief_is_untouched():
     """
     import subprocess
     tool = os.path.join(ROOT, 'py_tools', 'check_floorplan.py')
-    intent = os.path.join(ROOT, 'wk', 'cov_nobrief_intent.json')
-    os.makedirs(os.path.dirname(intent), exist_ok=True)
+    # A TEMP dir, not `wk/`: this file is an output of the test, and writing
+    # it under the gitignored work tree made `test_718_static_test_hygiene`
+    # read the whole file as depending on a board out of `wk/` -- which it
+    # does not. The dependency it flagged would have been a false declaration.
+    intent = os.path.join(tempfile.mkdtemp(), 'cov_nobrief_intent.json')
     board = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
     subprocess.run([sys.executable, '-X', 'utf8', tool, board, '--no-brief',
                     '--emit-intent', intent, '-q'], capture_output=True,

--- a/tests/test_902_proximity.py
+++ b/tests/test_902_proximity.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""`proximity[]`: the constraint the netlist implies and nothing measured (#902).
+
+A 3mm crystal loop and a 30mm one have IDENTICAL connectivity. Every instrument
+in this toolchain reads the board, so "Y1 beside U1, as short as possible" was
+ungradable -- and run 25 shipped a board whose brief said exactly that, with
+`rules_run: 6` and every declared clause ungraded.
+
+This file holds the BRIEF half: the vocabulary, its refusals, and the
+three-state contract. The rule that grades the compiled rows is
+`rule_proximity`, and its measurements are tested beside it.
+
+Most of these rows exist because an adversarial verifier found the defect they
+pin. Every one of the shapes under `_REFUSALS` LOADED CLEAN at some point in
+this feature's history, so they are change detectors with a scar, not a
+catalogue of things that were never going to happen.
+
+    python3 tests/test_902_proximity.py
+"""
+import json
+import math
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _d in ('py_router', 'py_placer', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _d))
+sys.path.insert(0, ROOT)
+
+from placement import design_brief as db          # noqa: E402
+from placement import floorplan as fp             # noqa: E402
+
+RUN_ALL_FAST_OK = True
+
+BASE = {'schema': 1, 'kind': 'design-brief', 'units': 'mm'}
+REFS = ('Y1', 'U1', 'U2', 'C1', 'C3', 'Q1', 'Q2')
+
+
+def _brief(rows, **over):
+    raw = dict(BASE, **over)
+    raw['proximity'] = rows
+    return db.brief_from_dict(raw, 'b.design-brief.json')
+
+
+def _compile(rows, refs=REFS, **over):
+    return db.compile_brief(_brief(rows, **over), board_refs=list(refs))
+
+
+def _rejects(rows, why, **over):
+    """Assert the document is refused AND that the message carries the REASON.
+
+    A refusal is not evidence on its own: the first draft of several of these
+    cases "passed" against a message about a completely different key.
+    """
+    try:
+        b = _brief(rows, **over)
+        db.compile_brief(b, board_refs=list(REFS))
+    except db.BriefError as exc:
+        msg = str(exc)
+        assert why in msg, (why, msg)
+        return msg
+    raise AssertionError(f"NOT REFUSED, expected {why!r}: {rows!r}")
+
+
+#: (rows, the substring the refusal must carry). Each was reachable.
+_REFUSALS = [
+    ([{'ref': 'Y1', 'near': 'U1'}], 'needs `max_mm`'),
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 0}], 'expected a positive'),
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': -1}], 'expected'),
+    # inf and nan pass BOTH `_number(lo=0.0)` and a `<= 0.0` guard, and
+    # json.load accepts the literals, so this was reachable from a file.
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': float('inf')}],
+     'not a finite distance'),
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': float('nan')}],
+     'not a finite distance'),
+    ([{'ref': 'Y1', 'near': 'Y1', 'max_mm': 2}], '0mm from itself'),
+    ([{'ref': ['Y1', 'U1'], 'near': 'U1', 'max_mm': 2}], '0mm from itself'),
+    ([{'ref': ['Y1', 'Y1'], 'near': 'U1', 'max_mm': 2}], 'names a part twice'),
+    ([{'ref': 'unknown', 'near': 'U1', 'max_mm': 2}], 'is not a row'),
+    ([{'ref': 'Y1', 'near': 'unknown', 'max_mm': 2}], 'no partner measures'),
+    ([{'ref': 'Y1', 'max_mm': 2}], 'needs `near`'),
+    # `basis` is the ONE enum here with a default, so "unknown" would compile
+    # to that default while the report says nobody knows.
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2, 'basis': 'unknown'}],
+     'HAS a default'),
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2, 'basis': 'courtyard'}],
+     '0 of 21'),
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2, 'basis': 'silk'}],
+     'expected one of'),
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2, 'min_mm': 0.2}],
+     "clearance channel's claim"),
+    ([{'ref': 'Y1', 'near': 'U1', 'max_distance_mm': 2}],
+     'the `decaps` spelling'),
+    ([{'reff': 'Y1', 'near': 'U1', 'max_mm': 2}], 'unknown key(s) reff'),
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2, 'pads': {'Q9': ['1']}}],
+     'says nothing about'),
+    # A JSON int matches no pad, resolves an empty set and grades CLEAN.
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2, 'pads': {'Y1': [1]}}],
+     'would match no pad'),
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2, 'pads': {'Y1': []}}],
+     'non-empty list'),
+    # An empty dict was a THIRD spelling of "unpadded" the reverse guard did
+    # not recognise.
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2, 'pads': {}}], 'empty pad spec'),
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2, 'pads': 7}], 'expected'),
+    # Two limits on one relation, in both spellings of "the same relation".
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2},
+      {'ref': 'Y1', 'near': 'U1', 'max_mm': 3}], 'duplicate proximity'),
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 5},
+      {'ref': 'U1', 'near': 'Y1', 'max_mm': 9}], 'same symmetric measurement'),
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 5, 'pads': 'unknown'},
+      {'ref': 'U1', 'near': 'Y1', 'max_mm': 9, 'pads': 'unknown'}],
+     'same symmetric measurement'),
+    # A pad list naming only the PARTNER leaves both rows existential, so they
+    # are still the same measurement.
+    ([{'ref': 'Y1', 'near': 'U1', 'max_mm': 5, 'pads': {'U1': ['9']}},
+      {'ref': 'U1', 'near': 'Y1', 'max_mm': 9, 'pads': {'Y1': ['1']}}],
+     'same symmetric measurement'),
+]
+
+
+def test_every_malformed_shape_is_refused_by_its_reason():
+    for rows, why in _REFUSALS:
+        _rejects(rows, why)
+    print(f"  PASS: {len(_REFUSALS)} malformed shapes, each refused by its "
+          f"reason")
+
+
+def test_a_whole_key_unknown_is_refused_naming_the_key_not_a_character():
+    """`"proximity": "unknown"` used to be refused by ITERATING THE STRING.
+
+    The message then named `proximity[0]` -- the character `u` -- and sent the
+    author to a row that does not exist.
+    """
+    try:
+        db.brief_from_dict(dict(BASE, proximity='unknown'))
+        raise AssertionError('NOT REFUSED')
+    except db.BriefError as exc:
+        msg = str(exc)
+    assert 'expected a list of rows' in msg, msg
+    assert 'proximity[0]' not in msg, msg
+    print(f"  PASS: {msg.splitlines()[0][:88]}")
+
+
+def test_a_reversed_pair_with_real_subject_pads_is_KEPT():
+    """The negative control for the reverse guard.
+
+    A guard that refuses everything is not a guard. With a SUBJECT pad list on
+    each side the two rows are genuinely different claims -- "for each of MY
+    pads, some pad of yours is close enough" is not symmetric -- and both must
+    survive.
+    """
+    frag, _ = _compile([
+        {'ref': 'Y1', 'near': 'U1', 'max_mm': 5, 'pads': {'Y1': ['1']}},
+        {'ref': 'U1', 'near': 'Y1', 'max_mm': 9, 'pads': {'U1': ['9']}}])
+    assert len(frag['proximity']) == 2, frag['proximity']
+    print("  PASS: a reversed pair with subject pads on both sides is kept -- "
+          "the guard refuses the symmetric case only")
+
+
+def test_the_three_states_stay_apart():
+    """declared / declared-unknown / absent, at claim granularity.
+
+    `max_mm: "unknown"` is DECLARED -- "as short as possible" is a real thing
+    for a spec to say -- and compiles to NO row, because a limit nobody stated
+    cannot be graded and inventing one is the guess this channel refuses.
+    """
+    frag, rep = _compile([{'ref': 'Y1', 'near': 'U1', 'max_mm': 'unknown'}])
+    assert 'proximity' not in frag, frag
+    assert rep['unknown'] == ['proximity[0:Y1~U1].max_mm'], rep['unknown']
+    assert not [d for d in rep['declared'] if 'proximity' in d], rep['declared']
+
+    # `pads: "unknown"` is the other arity: the row still grades, part to part.
+    frag, rep = _compile([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2.0,
+                           'pads': 'unknown'}])
+    assert len(frag['proximity']) == 1
+    assert 'pads' not in frag['proximity'][0], frag['proximity'][0]
+    assert 'proximity[0:Y1~U1].pads' in rep['unknown'], rep['unknown']
+
+    # BOTH unknown must report BOTH. The `continue` used to fire first, so an
+    # author who wrote two "I do not know"s saw one.
+    _frag, rep = _compile([{'ref': 'Y1', 'near': 'U1', 'max_mm': 'unknown',
+                            'pads': 'unknown'}])
+    assert rep['unknown'] == ['proximity[0:Y1~U1].max_mm',
+                              'proximity[0:Y1~U1].pads'], rep['unknown']
+
+    # The two sets are disjoint, or they are not two states.
+    frag, rep = _compile([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2.0},
+                          {'ref': 'C1', 'near': 'U2', 'max_mm': 'unknown'}])
+    assert not (set(rep['declared']) & set(rep['unknown']))
+    print("  PASS: an unknown limit compiles to no row and is reported; an "
+          "unknown pads keeps the row; both together report both; disjoint")
+
+
+def test_a_claim_id_survives_a_reference_that_contains_a_tilde():
+    """`TP4~2` is a reference this toolchain PRODUCES.
+
+    `disambiguate_references` spells a duplicated refdes that way and esp_prog
+    itself parses `Ref*~2`. With a bare `ref~near` id, a row `A~B` near `C` and
+    a row `A` near `B~C` collide -- and since `unknown` is a set union, one of
+    two DECLARED "I do not know"s silently disappeared.
+    """
+    _frag, rep = _compile([{'ref': 'A~B', 'near': 'C', 'max_mm': 'unknown'},
+                           {'ref': 'A', 'near': 'B~C', 'max_mm': 'unknown'}],
+                          refs=('A~B', 'C', 'A', 'B~C'))
+    assert len(rep['unknown']) == 2, rep['unknown']
+    assert len(set(rep['unknown'])) == 2, rep['unknown']
+    # And the id is the one shared function's, not a local f-string.
+    assert db.proximity_claim_id(0, 'A~B', 'C') + '.max_mm' in rep['unknown']
+    print(f"  PASS: two tilde-bearing claims keep two ids: {rep['unknown']}")
+
+
+def test_a_list_ref_expands_and_the_intent_never_carries_the_sugar():
+    frag, rep = _compile([{'ref': ['C1', 'C3'], 'near': 'U2', 'max_mm': 2.0,
+                           'pads': {'C1': ['1'], 'C3': ['1'],
+                                    'U2': ['2', '3']}}])
+    rows = frag['proximity']
+    assert [r['ref'] for r in rows] == ['C1', 'C3'], rows
+    assert all(isinstance(r['ref'], str) for r in rows), rows
+    # Each member keeps ONLY its own pads plus the partner's.
+    assert rows[0]['pads'] == {'C1': ['1'], 'U2': ['2', '3']}, rows[0]
+    assert rows[1]['pads'] == {'C3': ['1'], 'U2': ['2', '3']}, rows[1]
+    # And each traces back to the line its author wrote.
+    assert all(r['context']['brief_row'] == 0 for r in rows), rows
+    assert rep['counts']['proximity'] == 1
+    assert rep['counts']['proximity_claims'] == 2
+    print("  PASS: one row with a list ref compiles to two single-ref claims, "
+          "each carrying its own pads and its source row")
+
+
+def test_min_reader_is_the_running_max_and_is_not_written_for_a_dropped_row():
+    """The field whose only job is to be true.
+
+    A brief carrying both an along-edge claim and a proximity row needs the
+    HIGHER reader; writing whichever branch ran last understates it.
+    """
+    frag, _ = _compile([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2.0}])
+    assert frag['min_reader'] == 4, frag
+
+    along = [{'ref': 'USB1', 'edge': 'east', 'along_edge': 'center',
+              'along_edge_tolerance_mm': 0.5}]
+    frag, _ = _compile([], interfaces=along)
+    assert frag['min_reader'] == 2, frag
+
+    frag, _ = _compile([{'ref': 'Y1', 'near': 'U1', 'max_mm': 2.0}],
+                       interfaces=along)
+    assert frag['min_reader'] == 4, frag
+
+    # A row that compiled to NOTHING must not claim a reader for a key the
+    # document does not carry.
+    frag, _ = _compile([{'ref': 'Y1', 'near': 'U1', 'max_mm': 'unknown'}])
+    assert 'min_reader' not in frag, frag
+
+    frag, _ = _compile([{'ref': 'Y1', 'near': 'U1', 'max_mm': 'unknown'}],
+                       interfaces=along)
+    assert frag['min_reader'] == 2, frag
+
+    # And the MERGE maxes too, one line below where the fragment does.
+    rep = {'contradictions': [], 'path': '', 'declared': [], 'unknown': [],
+           'absent': [], 'not_graded': [], 'unmatched': [],
+           'unmatched_checked': False, 'counts': {}, 'fixed': [], 'product': {}}
+    merged = db.merge_into_intent({'min_reader': 3}, {'min_reader': 2}, rep)
+    assert merged['min_reader'] == 3, merged['min_reader']
+    print("  PASS: min_reader 4 / 2 / 4, absent for a dropped row, and the "
+          "merge takes the max rather than the last writer")
+
+
+def test_the_counts_disclose_an_expansion_and_a_drop_that_cancel():
+    """Three rows, three claims -- and one of each event underneath.
+
+    The first version compared the two counts, which cancel exactly here, so
+    the line disclosed nothing on the very shape this feature was built for.
+    """
+    _frag, rep = _compile([
+        {'ref': 'Y1', 'near': 'U1', 'max_mm': 2.0},
+        {'ref': ['C1', 'C3'], 'near': 'U2', 'max_mm': 2.0},
+        {'ref': 'Q1', 'near': 'Q2', 'max_mm': 'unknown'}])
+    c = rep['counts']
+    assert c['proximity'] == 3 and c['proximity_claims'] == 3, c
+    assert c['proximity_expanded'] == 1 and c['proximity_dropped'] == 1, c
+    line = db.format_report(rep, path='b.design-brief.json')
+    assert '3 proximity row(s) -> 3 claim(s)' in line, line
+    print(f"  PASS: {line}")
+
+
+def test_a_brief_with_no_proximity_reports_exactly_what_it_did_before():
+    """`counts` is emitted verbatim as `design_brief.counts` by board_brief.
+
+    An unconditional key would make every board on the corpus start reporting
+    zero of a thing nobody mentioned.
+    """
+    _frag, rep = _compile([])
+    assert rep['counts'] == {'interfaces': 0, 'keepouts': 0, 'fixed': 0}, \
+        rep['counts']
+    assert 'proximity' not in db.format_report(rep, path='b.json')
+    print("  PASS: no proximity -> the counts dict and the report line are "
+          "the pre-#902 ones")
+
+
+def test_an_absent_partner_is_named_once_not_once_per_member():
+    """`unmatched` was not deduped, and a list `ref` appends `near` per member.
+
+    check_floorplan prints one line per entry, so one missing part was
+    reported twice.
+    """
+    _frag, rep = _compile([{'ref': ['C1', 'C3'], 'near': 'ZZ9',
+                            'max_mm': 2.0}], refs=('C1', 'C3', 'U2'))
+    assert rep['unmatched'] == ['ZZ9'], rep['unmatched']
+    print("  PASS: an absent partner named once, not once per list member")
+
+
+def test_drift_compares_at_the_effective_value_not_at_key_presence():
+    """A brief meaning the DEFAULT versus an intent declaring otherwise.
+
+    The compiler writes `basis` only when non-default, so `if field in p`
+    reported no drift while the grade would have measured bodies against a
+    clause written about pads.
+    """
+    frag, _ = _compile([{'ref': 'Y1', 'near': 'U1', 'max_mm': 3.0}])
+    lines = db.drift({'proximity': [{'ref': 'Y1', 'near': 'U1', 'max_mm': 3.0,
+                                     'basis': 'body',
+                                     'pads': {'Y1': ['9']}}]}, frag)
+    assert any('basis' in ln and 'pad_edge' in ln and 'body' in ln
+               for ln in lines), lines
+    assert any('pads' in ln for ln in lines), lines
+    # Identical documents drift by nothing -- the vacuity control.
+    assert db.drift({'proximity': [{'ref': 'Y1', 'near': 'U1',
+                                    'max_mm': 3.0}]}, frag) == []
+    # A claim the intent has no row for at all.
+    assert db.drift({'proximity': []}, frag)[0].startswith('Y1 near U1:')
+    print(f"  PASS: drift sees a default-vs-declared divergence "
+          f"({len(lines)} line(s)) and is silent on identical documents")
+
+
+def test_the_basis_vocabulary_matches_the_intent_loader_or_says_it_cannot_yet():
+    """The brief must not accept a spelling the intent loader then refuses.
+
+    An author would see their own compiled document rejected by the same
+    binary that wrote it. This assertion goes LIVE the moment `floorplan`
+    grows the tuple; until then it prints that it is vacuous rather than
+    passing silently, because a guard that cannot fire is not a guard.
+    """
+    theirs = getattr(fp, '_PROXIMITY_BASES', None)
+    if theirs is None:
+        print("  PASS (VACUOUS): floorplan has no _PROXIMITY_BASES yet -- the "
+              "intent half is a later phase; this row is a change detector "
+              "waiting to arm, not a check that ran")
+        return
+    assert tuple(theirs) == tuple(db._PROXIMITY_BASES), (theirs,
+                                                         db._PROXIMITY_BASES)
+    print(f"  PASS: the brief and the intent accept the same bases {theirs}")
+
+
+def test_the_fixture_brief_compiles_to_the_claims_the_issue_names():
+    """The acceptance shape, from the tracked fixture rather than from prose.
+
+    Three rows -- a crystal to its load pins, a regulator's two bulk caps, and
+    a transistor pair with no shared net -- compile to the four claims #902
+    says nothing could grade.
+    """
+    path = os.path.join(ROOT, 'tests', 'fixtures', '902',
+                        'esp_prog_proximity.design-brief.json')
+    assert os.path.isfile(path), path
+    with open(path, encoding='utf-8') as fh:
+        raw = json.load(fh)
+    brief = db.brief_from_dict(raw, path)
+    frag, rep = db.compile_brief(brief, board_refs=list(REFS) + ['USB1'])
+    got = [(r['ref'], r['near'], r['max_mm'], r.get('basis')) for r in
+           frag['proximity']]
+    assert got == [('Y1', 'U1', 2.0, 'pad_edge'),
+                   ('C1', 'U2', 2.0, 'pad_edge'),
+                   ('C3', 'U2', 2.0, 'pad_edge'),
+                   ('Q1', 'Q2', 3.0, 'body')], got
+    assert frag['min_reader'] == 4
+    assert rep['unmatched'] == [], rep['unmatched']
+    assert rep['counts']['proximity'] == 3
+    assert rep['counts']['proximity_claims'] == 4
+    print(f"  PASS: the fixture brief compiles to {len(got)} claims, "
+          f"3 pad_edge and 1 body")
+
+
+TESTS = [
+    test_every_malformed_shape_is_refused_by_its_reason,
+    test_a_whole_key_unknown_is_refused_naming_the_key_not_a_character,
+    test_a_reversed_pair_with_real_subject_pads_is_KEPT,
+    test_the_three_states_stay_apart,
+    test_a_claim_id_survives_a_reference_that_contains_a_tilde,
+    test_a_list_ref_expands_and_the_intent_never_carries_the_sugar,
+    test_min_reader_is_the_running_max_and_is_not_written_for_a_dropped_row,
+    test_the_counts_disclose_an_expansion_and_a_drop_that_cancel,
+    test_a_brief_with_no_proximity_reports_exactly_what_it_did_before,
+    test_an_absent_partner_is_named_once_not_once_per_member,
+    test_drift_compares_at_the_effective_value_not_at_key_presence,
+    test_the_basis_vocabulary_matches_the_intent_loader_or_says_it_cannot_yet,
+    test_the_fixture_brief_compiles_to_the_claims_the_issue_names,
+]
+
+
+if __name__ == '__main__':
+    for t in TESTS:
+        print(f"--- {t.__name__}")
+        t()
+    print('ALL PASS')

--- a/tests/test_902_proximity.py
+++ b/tests/test_902_proximity.py
@@ -24,6 +24,18 @@ and measuring it turned 26 into 5. It is written out here because the marked
 rows are the ones with a scar, and a reader deciding which of these to trust
 should not have to take the docstring's word for it.
 
+MEASURED, from the run and not predicted: `tests/mutate_902.py` is 21 rows,
+21 killed, 0 survived, 0 broken. Nine of those rows are branches that ALREADY
+survived a battery once -- the `min` that is the rule's stated invariant, both
+abstentions, the partial-pad miss, the courtyard-vs-body read, the bool check,
+longest-match waiver resolution, the `+ ':'` suffix guard and the whole DRIFTED
+arm -- so they are recorded there rather than remembered here.
+
+The battery also found a hole nothing else did: deleting the INTENT loader's
+finite check survived, because every non-finite case tested the BRIEF. An
+intent is a document a human may write directly, so each refusal has to exist
+on both sides or one path grades what the other refuses.
+
     python3 tests/test_902_proximity.py
 """
 import json
@@ -1041,6 +1053,49 @@ def test_a_body_claim_for_a_part_with_no_geometry_abstains():
           f"passing")
 
 
+def test_the_intent_loader_refuses_what_the_brief_loader_refuses():
+    """The hand-written intent never passes through the brief compiler.
+
+    Found by `tests/mutate_902.py`: deleting the INTENT loader's finite check
+    survived the whole suite, because every non-finite case tested the BRIEF.
+    An intent is a document a human may write directly -- `place_seed` and
+    `place_reconstruct` load one and never call `validate_intent` -- so each
+    refusal has to exist on both sides or one path grades what the other
+    refuses.
+    """
+    base = {'schema': fp.SCHEMA_VERSION, 'kind': fp.KIND, 'units': 'mm'}
+    cases = [
+        ({'ref': 'Y1', 'near': 'U1', 'max_mm': float('inf')},
+         'positive finite'),
+        ({'ref': 'Y1', 'near': 'U1', 'max_mm': float('nan')},
+         'positive finite'),
+        ({'ref': 'Y1', 'near': 'U1', 'max_mm': 0}, 'positive finite'),
+        ({'ref': 'Y1', 'near': 'U1', 'max_mm': -1}, 'positive finite'),
+        ({'ref': 'Y1', 'near': 'U1', 'max_mm': 2, 'pads': {'Y1': [1]}},
+         'match no pad'),
+        ({'ref': 'Y1', 'near': 'U1', 'max_mm': 2, 'basis': 'courtyard'},
+         'expected one of'),
+    ]
+    for row, why in cases:
+        try:
+            fp.intent_from_dict(dict(base, proximity=[row]))
+            raise AssertionError(f'NOT REFUSED: {row}')
+        except fp.IntentError as exc:
+            assert why in str(exc), (why, str(exc))
+    # And a real JSON document, since `json.load` accepts the literals that
+    # make this reachable from a file rather than only from the API.
+    doc = json.loads('{"schema": %d, "kind": "%s", "units": "mm", '
+                     '"proximity": [{"ref": "Y1", "near": "U1", '
+                     '"max_mm": Infinity}]}' % (fp.SCHEMA_VERSION, fp.KIND))
+    try:
+        fp.intent_from_dict(doc)
+        raise AssertionError('NOT REFUSED through real JSON')
+    except fp.IntentError as exc:
+        assert 'positive finite' in str(exc), str(exc)
+    print(f"  PASS: {len(cases)} shapes the brief refuses are refused by the "
+          f"intent loader too, including Infinity through real JSON")
+
+
 def test_the_intent_loader_refuses_the_reversed_pair_the_brief_refuses():
     """The hand-written intent is the path the brief compiler never sees.
 
@@ -1105,6 +1160,7 @@ TESTS = [
     test_the_minimum_over_partners_is_a_minimum,
     test_a_padless_part_abstains_rather_than_passing_silently,
     test_a_body_claim_for_a_part_with_no_geometry_abstains,
+    test_the_intent_loader_refuses_what_the_brief_loader_refuses,
     test_the_intent_loader_refuses_the_reversed_pair_the_brief_refuses,
 ]
 


### PR DESCRIPTION
Closes #902
Closes #895

## Builds on #915, which has since merged

This branched from `fix/896-891-body-model-and-context` (PR #915) rather than
from `main`, because the dependency is real: `basis: "body"` reads #896's body
model, and #895's criteria 2 and 5 read `board_context.py` and
`body.tightest_body_seam`. **#915 merged on 2026-09-07 while this was in
progress**, so that base is now in `main` and the 16 commits below are the only
ones this PR adds. (An earlier draft of this section asked for #915 to be
merged first — it already had been.)

## The problem

A brief can say *"Y1 beside U1, as short as possible"*, *"C1/C3 are U2's bulk
caps"*, *"Q1/Q2 together"*. Nothing graded any of it. One run closed with
`rules_run: 6`, passed every gate, and measured **not one clause its brief
declared**.

The existing rules cannot stand in, and this is structural rather than a gap
someone forgot to fill. `groups.is_decoupling_cap` is syntactic — a ref starting
with `C` bridging exactly two nets — and its IC partner must carry ≥ 4 copper
pads. Measured on the board in question, the tether election gives
`C1 → USB1 2.03 mm` and `C3 → U1 1.83 mm`: **a 3-pad SOT-89 regulator can never
be a tether target at any radius**, so its own bulk caps were graded against a
USB socket and a bridge IC. A crystal is never a subject at all.

And a 3 mm crystal loop and a 30 mm one have **identical connectivity**, so no
instrument that reads the board can tell them apart.

## What this adds

**A `proximity[]` brief key** — `{ref, near, max_mm, basis, pads}`, with `ref`
optionally a list — compiled into a new `proximity[]` intent key (a list `ref`
expands to one row per member, so the intent always names one part per side) and
graded by `rule_proximity`. On the run's own board:

```
[error] proximity: Y1 pad 1 is 3.14mm from U1 pad 9 on Net-(C4-Pad1),
        past the declared 2.00mm proximity limit
```

3.1425 mm is the number #902 names. The same brief on the board that run
*started from* reports **3** violations against **1** on what it shipped, so the
rule makes that run's improvement measurable — with no fixture manipulation.

**Clause coverage.** `--require-rules` counts RULES; that count was satisfied by
rules nobody had declared anything for. `brief_coverage` counts **clauses**, in
five states kept deliberately apart — `graded` / `abstained` / `uncovered` /
`not_claimed` / `carried` — because collapsing them rebuilds the same failure one
key over. `drifted` is a flag rather than a state: a clause can be fully graded
*against the wrong number*. New `--require-brief-coverage` makes it an exit code.

**P-close binds clauses**, in four arms, naming every uncovered clause with its
reason and a per-clause waiver that requires a reason.

**#895's seven criteria**, six of them naming the instrument that produces its
number (the seventh is the written human question),
plus the ordering rule sharpened to *before any verdict* — enforced by a new
`_guard_render` check and by reordering L5, which emitted three checker verdicts
before the render.

## Decisions worth reviewing

- **`basis: "courtyard"` is refused BY NAME**, with the measurement that decided
  it: `placement.body` is a ladder, and on the board this was written for **0 of
  21 footprints draw a courtyard** (10 fab, 4 silk, 4 pad-bbox, 3 nothing). The
  vocabulary is `pad_edge | body`, and the rung that answered is on the wire.
- **The rule is search-blind, stated as a decision** in the search-visibility
  table with its reason, and the follow-up named rather than left implicit.
- **`max_mm: "unknown"` is accepted** and compiles to no row; **`basis:
  "unknown"` is refused**, because `basis` has a default and declaring it
  unknown would compile to that default while the report says nobody knows.
- **The worked example is anonymised by part class.** `test_run8_skills_generic`
  bans a corpus board name and a `wk/run<N>` path in every skill file, so #895's
  acceptance ("on esp_prog's run-25 placement") is not something a skill file may
  say. The fixture is named in the test instead, where it may be.

## Two live defects fixed along the way

- **P-close's `rules_run <= 0` refusal was inert.** It tested
  `isinstance(_ran, int)` against the document its own `--intent-json` help text
  names — `check_floorplan --json`, which writes a **list**. Only the self-test
  fed it an int. It had never fired.
- **`test_837_assembly_sides.py` went red on this branch's own `READER_VERSION`
  bump, and `--fast` could not see it** — it is classified integration, so
  `run_all.py --fast` skips it. It was green at the base; the durable finding is
  the process one, and it is why the verification below is a FULL run. An
  earlier commit message of mine reported a green suite while this was red.

## Verification

- **`tests/run_all.py` — FULL, not `--fast`** (because `--fast` skips
  integration tests and has already hidden one red on this branch):
  **576 passed, 1 failed, 1 timed out, 2 self-skipped, in 3558 s**
  (`python3 tests/run_all.py`). Every non-pass is accounted for below; none is unexplained.
  - `test_run15_handback_contract.py` fails **identically at the base commit**
    `68fcacc2` (11 tests, 2 failures, both arms) — pre-existing, and #915's own
    notes record it.
  - `test_interf_u.py` hit the 600 s per-test budget under parallel load. Run
    alone it **completes on both the branch and the base**, so it is a load
    artifact rather than a defect — the harness says a timeout is not evidence
    and to re-run alone, which is what that is.
  - An earlier full run also failed `test_718_static_test_hygiene.py`, and it
    was right twice: my coverage tests wrote scratch files under `wk/` (they
    are outputs, so they moved to a temp dir — declaring a `wk/` dependency
    would have recorded something false), and the new battery tripped the
    `os.path.join(ROOT, <variable>)` rule from #522. Both fixed, plus the
    pinned `_BATTERY_COUNT` 42 → 43.
- `tests/mutate_902.py`: **21 rows, 21 killed, 0 survived, 0 broken**
  (`python3 tests/mutate_902.py`). **Five** of those rows are branches that
  survived a battery once already; four more such branches live in
  `placement_driver.py`, which this battery does not target — they are killed
  by its own `--self-test` instead.
- `tests/mutate_711.py` 35 rows / 34 killed / 0 broken; `mutation_anchors.py`
  990 anchors across 43 batteries, 0 stale.
- `placement_driver.py --self-test` OK; `--dump-all` exit 0.
- `run_doc_examples.py`: 32 run / 6 failed — **all six pre-existing**, with a
  byte-identical failing set at the base commit `68fcacc2`, and none in a file
  this PR touches.

`tests/713_abstention_census.json` is re-recorded: **22 insertions, every one the
identical line `"proximity",`, zero deletions.** `rules_run` moves on no board
and `boards_clean_but_ungraded` stays 0.

## Compatibility, and two shape changes

- **`READER_VERSION` 3 → 4.** `proximity[]` is declarable and changes the exit
  code, so the loader's own rule mandates the bump. It is the number
  `compile_brief` copies into `min_reader`: a brief-compiled intent carrying a
  proximity claim now declares `min_reader: 4`, and a build older than this
  change refuses that document rather than grading it without the claim.
- **`check_floorplan` emits `brief_coverage` on every `--intent` run**, including
  when it is empty. An absent block would be ambiguous between "this board
  declares nothing" and "an older build wrote this document", and a consumer
  cannot refuse the second without also refusing the first — which would reverse
  #711's contract that a brief-less board costs nothing. The `JSON_SUMMARY` keys
  stay conditional, so a brief-less board's summary line is byte-identical.
- **One new tracked fixture**, `tests/fixtures/run25/esp_prog_placed.kicad_pcb`
  (+ `.kicad_pro`, 5799 lines). It is the placed board the "3 violations vs 1"
  comparison rests on; `wk/` is gitignored, so the numbers had nowhere else to
  live.

## What the reviewers found

Four adversarial verifier passes; every one returned FAIL on its first run, and
the findings were real. Worth knowing when reading the diff:

- The first found **11 defects in the brief key**, including `max_mm: Infinity`
  and `NaN` passing both the bound and the guard (`inf < 0` and `nan <= 0` are
  both False, and `json.load` accepts the literals) — a declared limit nothing
  can ever violate, which is the bug this whole channel exists to prevent.
- The second found that **my fix for one of those created another**, and that a
  claim in my own test docstring was false: I wrote "every one of these 26 shapes
  loaded clean"; measured against the original commit it was **5**.
- The third found `basis: "body"` was measuring **courtyards** — on tigard,
  `U1~Y1` reads 1.600 mm courtyard-first and 2.300 mm drawn, so a 2.0 mm claim
  passed that the real bodies fail — and **five branches no test reached**,
  including both abstentions and the `min` that is the rule's stated invariant.
- The fourth found **a regression the previous commit had shipped**: making the
  coverage block unconditional killed the branch that reached
  `_brief_absence_reason`, so the gate began claiming a brief "was found" on
  boards that have none.

Two smaller things the tooling caught in my own work: the intent loader's
duplicate guard refused my own test data, and the static-hygiene gate caught
three `READER_VERSION` change detectors my bump had staled.

## Deliberately not in scope

The rule grades; no search gates on it. `reseat.clusters_from_tethers` is
already generic over (member, anchor, radius) and a declared pair is stationary,
so a per-move attraction term is constructible — but that function has **no
production caller today**, so wiring one would ship a new engine path with no
consumer under a grading fix. Named in the docs rather than left implicit.

Also not done: proximity to a net's centroid, to a board feature rather than a
part, and per-side qualifiers. Each needs an anchor the rule cannot resolve, and
they are listed in `docs/design-brief.md`'s deferred section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wa54dFaXWdK4aw3VsV8ay
