### PR TITLE
#893 + #916: a rotation a board can declare, and a body model the search was measured against

### DIFF
--- a/docs/floorplan-intent.md
+++ b/docs/floorplan-intent.md
@@ -136,7 +136,7 @@ source, suspect, suspect_reason
 | top level | `schema`, `kind`, `board`, `units`, `min_reader`, `envelope`, `defaults`, `blocks`, `keepouts`, `edge_connectors`, `decaps`, `must_lock`, `legality_budget`, `health`, `severity`, `overlap_waivers`, `assembly`, `proximity`, `context` |
 | `envelope` | `rect`, `tolerance_mm` |
 | `defaults` | `zone_tolerance_mm` |
-| `blocks[]` | `name`, `group`, `refs`, `zone`, `side`, `exclusive`, `tolerance_mm`, `note`, `context` |
+| `blocks[]` | `name`, `group`, `refs`, `zone`, `side`, `exclusive`, `tolerance_mm`, `rotation`, `rotation_candidates`, `note`, `context` |
 | `keepouts[]` | `name`, `rect`, `circle`, `sides`, `allow`, `note`, `context` |
 | `edge_connectors[]` | `ref`, `edge`, `overhang_mm`, `max_setback_mm`, `center_on_edge`, `along_edge_band`, `class`, `note`, `context`, and the emitter-written `source`, `suspect`, `suspect_reason`, `overhang_capped`, `observed_overhang_mm` |
 | `edge_connectors[].overhang_mm` | `min`, `max` |

--- a/docs/placement-optimization.md
+++ b/docs/placement-optimization.md
@@ -748,6 +748,28 @@ it in the engine, which keeps both properties at once:
 - Every candidate is then quenched by the ORDINARY engine — `quench.py` is
   not modified, and a default `place_optimize.py` run is bit-identical with
   the portfolio in the tree.
+
+### The same bound as an objective term (#893)
+
+`--facing-weight` puts `pair_order`'s inversion count into `quench.total_cost`
+directly, instead of using it only to prune seeds as `poses` does above. It is
+**0.0 by default**, and this document is why: everything below says a proxy
+added to this objective has repeatedly failed to translate. A lower bound is a
+better citizen than a correlational proxy — improving it cannot be gamed — but
+that is an argument for measuring, not a measurement.
+
+What it buys over `--orient-weight`, the other rotation-aware term: that one
+scores DIRECTION (pads pointing at a net's centroid) and is blind to ORDER. Two
+parts can point their pads straight at each other with every net crossed, which
+is exactly run 5's U3 — a 180° rotation took the same nets from 4/7 routed to
+7/7 while airwire lengths barely moved.
+
+What it buys over `place_portfolio --strategies poses`, which already explores
+rotations pruned by this bound: the portfolio prunes CANDIDATE SEEDS and then
+quenches each with an unmodified objective, so a rotation that would only pay
+off after the quench settles is never proposed; the weight makes the ordinary
+move loop able to turn a part mid-descent. They are complementary, and the
+portfolio remains the cheaper first thing to try.
 - Randomness is scoped, never ambient: candidate i draws from
   `random.Random(f"{seed}:{i}:{strategy}")`, so the portfolio is a pure
   function of (board, knobs, seed) and any single candidate replays alone

--- a/docs/placement-optimization.md
+++ b/docs/placement-optimization.md
@@ -749,6 +749,18 @@ it in the engine, which keeps both properties at once:
   not modified, and a default `place_optimize.py` run is bit-identical with
   the portfolio in the tree.
 
+- Randomness is scoped, never ambient: candidate i draws from
+  `random.Random(f"{seed}:{i}:{strategy}")`, so the portfolio is a pure
+  function of (board, knobs, seed) and any single candidate replays alone
+  via `--only i`. `tests/test_portfolio_determinism.py` pins this across
+  PYTHONHASHSEED values, test_457-style.
+- Ranking is a lexicographic tuple of numbers this document already
+  establishes as trustworthy — crossings, the inversion lower bound, hpwl,
+  the floorplan health signals, displacement — and the top candidates are
+  probe-ROUTED (`--route-top`, default 2), because proxies propose and the
+  router disposes applies to a slate exactly as it applies to a single
+  repair.
+
 ### The same bound as an objective term (#893)
 
 `--facing-weight` puts `pair_order`'s inversion count into `quench.total_cost`
@@ -770,18 +782,6 @@ quenches each with an unmodified objective, so a rotation that would only pay
 off after the quench settles is never proposed; the weight makes the ordinary
 move loop able to turn a part mid-descent. They are complementary, and the
 portfolio remains the cheaper first thing to try.
-- Randomness is scoped, never ambient: candidate i draws from
-  `random.Random(f"{seed}:{i}:{strategy}")`, so the portfolio is a pure
-  function of (board, knobs, seed) and any single candidate replays alone
-  via `--only i`. `tests/test_portfolio_determinism.py` pins this across
-  PYTHONHASHSEED values, test_457-style.
-- Ranking is a lexicographic tuple of numbers this document already
-  establishes as trustworthy — crossings, the inversion lower bound, hpwl,
-  the floorplan health signals, displacement — and the top candidates are
-  probe-ROUTED (`--route-top`, default 2), because proxies propose and the
-  router disposes applies to a slate exactly as it applies to a single
-  repair.
-
 The perturb-then-descend shape is classical basin hopping (Wales & Doye) —
 the "extend the scorer to evaluate a perturbation" note in the SA section
 above, finally built, with the acceptance step replaced by an explicit

--- a/py_placer/place_optimize.py
+++ b/py_placer/place_optimize.py
@@ -265,6 +265,7 @@ Examples:
         align_radius=args.align_radius,
         align_span=args.align_span,
         orient_weight=args.orient_weight,
+        facing_weight=args.facing_weight,
         metrics_out=ratsnest,
         groups=blocks,
         verbose=args.verbose,

--- a/py_placer/place_portfolio.py
+++ b/py_placer/place_portfolio.py
@@ -237,6 +237,7 @@ def _quench_kw(args, intent=None, intent_gate=None):
         lock_refs=args.lock, align_weight=args.align_weight,
         align_radius=args.align_radius, align_span=args.align_span,
         orient_weight=args.orient_weight,
+        facing_weight=args.facing_weight,
         corridor_weight=args.corridor_weight,
         corridor_specs=corridor_specs, intent_gate=intent_gate)
 

--- a/py_placer/place_route_loop.py
+++ b/py_placer/place_route_loop.py
@@ -1226,6 +1226,7 @@ def main():
             align_radius=args.align_radius,
             align_span=args.align_span,
             orient_weight=args.orient_weight,
+            facing_weight=args.facing_weight,
             metrics_out=ratsnest,
             groups=blocks,
             verbose=args.verbose,

--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -628,6 +628,17 @@ Examples:
     print(f"Seeded {len(result['placements'])} part(s); "
           f"{len(result['unseated'])} unseated; "
           f"{len(result['lock_refs'])} to lock")
+    # #893. A DECLARED rotation that could not be seated is a different fact
+    # from a part that merely found no pose, and it is the one the author can
+    # act on -- their claim is the reason. Without this the operator saw a
+    # generic "no legal pose within any cap" and had no way to know which
+    # declaration caused it.
+    _rot_unseated = result.get('rotation_unseated') or {}
+    if _rot_unseated:
+        print(f"  {len(_rot_unseated)} declared rotation(s) could not be "
+              f"seated -- the angle is the claim, not a fallback:")
+        for _r in sorted(_rot_unseated):
+            print(f"    {_r}: declared {_rot_unseated[_r]}")
 
     write_placed_output(args.input_file, args.output_file,
                         result['placements'])
@@ -803,6 +814,10 @@ Examples:
                # NAMES, not just a count. #629's complaint is that a verdict
                # you cannot act on is a dead end, and a count names nobody.
                'unseated_refs': list(result['unseated']),
+               # #893: WHICH declared angle was refused, by ref. A caller that
+               # sees only `unseated_refs` cannot tell a declaration it must
+               # revisit from a board that is simply full.
+               'rotation_unseated': result.get('rotation_unseated') or {},
                'no_pose_blockers': result.get('no_pose_blockers') or {},
                # WHY each of them has no pose, not just who is nearby (#699).
                # "nothing is near it" and "everything near it is locked" were

--- a/py_placer/placement/cli_gates.py
+++ b/py_placer/placement/cli_gates.py
@@ -275,3 +275,14 @@ def add_tidiness_args(parser) -> None:
                              "airwire cost already uses exact pad positions, "
                              "but a ~1mm pad offset is noise against a ~20mm "
                              "net, so the signal needs its own weight. Try 1")
+    parser.add_argument("--facing-weight", type=float, default=0.0,
+                        help="Price the pin ORDER a pose forces: for every "
+                             "part pair sharing 2+ nets, the count of net "
+                             "pairs whose pad order is crossed (a proven lower "
+                             "bound on the crossings any router must pay). "
+                             "0 = off (default). Distinct from "
+                             "--orient-weight, which scores DIRECTION and is "
+                             "blind to order: two parts can point straight at "
+                             "each other with every net crossed. Costly -- it "
+                             "is the most expensive term in the objective. "
+                             "Try 1")

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -120,7 +120,20 @@ EDGE_BAND_SANITY_MM = 5.0
 #: SAFETY. It is because `READER_VERSION` is the number `compile_brief` copies
 #: into `min_reader`, and at 3 a brief-compiled intent would claim a reader-3
 #: build acts on a claim it has never heard of.
-READER_VERSION = 4
+#: 5 (#893): `blocks[].rotation` and `blocks[].rotation_candidates` -- the
+#: ANGLE a part is to be placed at, and the set a search may choose from. The
+#: one placement decision the board file cannot hold as a decision: a
+#: footprint's `(at x y rot)` records the angle it HAS, and nothing
+#: distinguishes an angle somebody chose from a generator default, so
+#: `seeder._try_place` has always been free to turn a part whose rotation was
+#: load-bearing. Its docstring said so and told the author to lock the part
+#: instead, which freezes its POSITION too. Declarable, and it changes a
+#: verdict twice over -- the seeder honours it and REFUSES rather than falling
+#: back to the 90-degree lattice, and `rule_rotation` grades it -- so the rule
+#: above mandates the bump. Contrast `blocks[].side`, which is declarable and
+#: whose rule docs/floorplan-intent.md calls "vacuous, not conservative"
+#: because no search move carries a side: rotation is carried by every nudge.
+READER_VERSION = 5
 
 _TOP_LEVEL_KEYS = {
     'schema', 'kind', 'board', 'units', 'envelope', 'defaults', 'blocks',
@@ -129,7 +142,12 @@ _TOP_LEVEL_KEYS = {
     'assembly', 'proximity',
 }
 _BLOCK_KEYS = {'name', 'group', 'refs', 'zone', 'side', 'exclusive',
-               'tolerance_mm', 'note', 'context'}
+               'tolerance_mm', 'note', 'context',
+               # #893. `rotation` is a DECISION (honoured exactly, and the
+               # seeder refuses rather than silently turning the part);
+               # `rotation_candidates` is a SET a search may choose from.
+               # Declaring both on one block is refused -- see `_rotation`.
+               'rotation', 'rotation_candidates'}
 #: #837. The board-level assembly policy: which faces the fab will populate.
 #: `blocks[].side` is a claim about ONE subsystem; this is a claim about the
 #: whole board, and it is the thing `options.grow_board` needed and could not
@@ -285,6 +303,10 @@ class Zone:
     refs: Tuple[str, ...] = ()
     exclusive: bool = False
     tolerance_mm: Optional[float] = None
+    #: #893. The angle this block's members are to be placed at (a DECISION,
+    #: honoured exactly), and the set a search may choose from. Never both.
+    rotation: Optional[float] = None
+    rotation_candidates: Optional[Tuple[float, ...]] = None
     note: str = ''
     #: Free-form provenance, read by nothing (see `_BLOCK_KEYS`). Carried on
     #: the Zone rather than dropped: `keepouts`/`edge_connectors`/
@@ -418,6 +440,52 @@ def _rect(value, where: str) -> Tuple[float, float, float, float]:
                           f"numbers, got {value!r}")
     x0, y0, x1, y1 = (float(v) for v in value)
     return (min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1))
+
+
+def _rotation(raw, where: str) -> Optional[float]:
+    """One declared angle, normalised to [0, 360). Refuses anything else.
+
+    Normalised because KiCad writes -90 where this tool writes 270, and an
+    author copying an angle out of a board file must not get a claim that can
+    never be met. `bool` is refused explicitly: it is an int subclass, so
+    `rotation: true` would otherwise load as 1.0 degrees.
+    """
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raise IntentError(
+            f"{where}: rotation {raw!r}, expected a number of degrees")
+    return float(raw) % 360.0
+
+
+def _rotation_candidates(raw, where: str) -> Tuple[float, ...]:
+    """The declared candidate set, order PRESERVED.
+
+    Order is load-bearing, not cosmetic: the seeder keeps the FIRST pose that
+    fits, so a reordered list changes which rotation wins a tie. That is why
+    this returns a tuple in the author's order and never a set -- the same
+    warning `quench._candidate_rotations`' docstring carries.
+
+    An EMPTY list is refused rather than treated as "no constraint": an author
+    who writes `[]` has said something, and the something they said admits no
+    pose at all.
+    """
+    if isinstance(raw, (str, bytes)) or not isinstance(raw, (list, tuple)):
+        raise IntentError(
+            f"{where}: rotation_candidates {raw!r}, expected a list of "
+            f"degrees")
+    if not raw:
+        raise IntentError(
+            f"{where}: rotation_candidates is empty. An empty candidate set "
+            f"admits no pose at all; omit the key to leave the rotation free")
+    out = []
+    for i, v in enumerate(raw):
+        out.append(_rotation(v, f"{where}[{i}]"))
+    # Duplicates are refused rather than de-duplicated, for the same reason the
+    # empty list is: it is almost always a typo, and silently collapsing it
+    # would make the declared set differ from the graded one.
+    if len(set(out)) != len(out):
+        raise IntentError(
+            f"{where}: rotation_candidates has repeated angles {out!r}")
+    return tuple(out)
 
 
 def _reject_unknown(obj, allowed, where: str) -> None:
@@ -729,6 +797,21 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
         if side is not None and side not in ('F', 'B'):
             raise IntentError(
                 f"blocks[{i}] ({name}): side {side!r}, expected 'F' or 'B'")
+        # #893. A decision and a search set are contradictory: one says
+        # "this angle", the other "any of these". Refused rather than given a
+        # precedence rule nobody would remember.
+        if b.get('rotation') is not None and b.get('rotation_candidates') is not None:
+            raise IntentError(
+                f"blocks[{i}] ({name}): declares BOTH rotation and "
+                f"rotation_candidates. `rotation` is a decision the seeder "
+                f"honours exactly; `rotation_candidates` is a set it may "
+                f"choose from. Declare one")
+        rot = (None if b.get('rotation') is None
+               else _rotation(b['rotation'], f"blocks[{i}].rotation"))
+        rot_cands = (None if b.get('rotation_candidates') is None
+                     else _rotation_candidates(
+                         b['rotation_candidates'],
+                         f"blocks[{i}].rotation_candidates"))
         zone_rect = b.get('zone')
         blocks.append(Zone(
             name=name,
@@ -738,6 +821,8 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
             refs=_str_tuple(b.get('refs'), f"blocks[{i}].refs"),
             exclusive=bool(b.get('exclusive', False)),
             tolerance_mm=b.get('tolerance_mm'),
+            rotation=rot,
+            rotation_candidates=rot_cands,
             note=b.get('note', '') or '',
             context=b.get('context') or {},
         ))
@@ -1420,6 +1505,38 @@ def zone_covered_by_keepout(zone, keepouts, member_sides=None,
             if keepouts_for_ref((k,), ref, sides):
                 return str(k.get('name') or '<unnamed>')
     return None
+
+
+def rotations_for_ref(intent: Intent, blocks: Dict[str, List[str]]
+                      ) -> Dict[str, Tuple[Optional[float],
+                                           Optional[Tuple[float, ...]]]]:
+    """{ref: (declared rotation, declared candidates)} over ALREADY-RESOLVED blocks.
+
+    Iterates `intent.blocks`, not `zone_entries`: that one yields only blocks
+    carrying a `rect`, and a block may declare a rotation with no zone at all
+    ("U1 faces the USB socket" is not a coordinate claim).
+
+    A ref in two blocks that declare DIFFERENT angles is a contradiction the
+    author has to resolve, so it raises rather than picking one. Two blocks
+    declaring the SAME angle is not a contradiction and is allowed -- globs
+    overlap legitimately (`U*` and `U1`).
+    """
+    out: Dict[str, Tuple[Optional[float], Optional[Tuple[float, ...]]]] = {}
+    owner: Dict[str, str] = {}
+    for z in intent.blocks:
+        if z.rotation is None and z.rotation_candidates is None:
+            continue
+        claim = (z.rotation, z.rotation_candidates)
+        for ref in blocks.get(z.name, ()):
+            prev = out.get(ref)
+            if prev is not None and prev != claim:
+                raise IntentError(
+                    f"{ref} is claimed by blocks {owner[ref]!r} and {z.name!r} "
+                    f"with different rotations ({prev} vs {claim}). A part has "
+                    f"one angle; resolve the overlap")
+            out[ref] = claim
+            owner[ref] = z.name
+    return out
 
 
 def zone_entries(intent: Intent, blocks: Dict[str, List[str]]) -> Tuple[Dict, ...]:

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -128,9 +128,14 @@ EDGE_BAND_SANITY_MM = 5.0
 #: `seeder._try_place` has always been free to turn a part whose rotation was
 #: load-bearing. Its docstring said so and told the author to lock the part
 #: instead, which freezes its POSITION too. Declarable, and it changes a
-#: verdict twice over -- the seeder honours it and REFUSES rather than falling
-#: back to the 90-degree lattice, and `rule_rotation` grades it -- so the rule
-#: above mandates the bump. Contrast `blocks[].side`, which is declarable and
+#: verdict: the seeder honours it and REFUSES rather than falling back to the
+#: 90-degree lattice, and the quench's gate pins the part to it instead of
+#: offering the lattice -- so the rule above mandates the bump.
+#: There is deliberately NO `rule_rotation` in `RULES`: a declared rotation is
+#: ENFORCED (the seat search is given a one-angle ladder), so a grade rule
+#: would be checking an invariant the search cannot violate. An earlier draft
+#: of this comment claimed such a rule existed; it never did, and a
+#: justification naming a grader nobody wrote is worse than a shorter one. Contrast `blocks[].side`, which is declarable and
 #: whose rule docs/floorplan-intent.md calls "vacuous, not conservative"
 #: because no search move carries a side: rotation is carried by every nudge.
 READER_VERSION = 5
@@ -1608,7 +1613,14 @@ def resolve_intent_gate(intent: Intent, pcb_data,
         lock.update(fnmatch.filter(sorted(pcb_data.footprints), pat))
     lock.update(str(c['ref']) for c in intent.edge_claims()
                 if c.get('ref') in pcb_data.footprints)
-    return ({'zones': zones,
+    # #893. The declared ROTATION travels with the gate, so the quench can
+    # enforce what the seeder honoured. Without it the feature was strictly
+    # WEAKER than the advice it replaced: locking a part DID protect its angle
+    # from the quench (one boolean covers position and rotation), so
+    # `place_seed` -> `place_optimize` would have turned a declared part
+    # straight back -- against the very U3 case the seeder docstring cites.
+    return ({'rotations': rotations_for_ref(intent, blocks),
+             'zones': zones,
              'keepouts': tuple(intent.keepouts),
              'lock_refs': tuple(sorted(lock))}, problems)
 

--- a/py_placer/placement/pair_order.py
+++ b/py_placer/placement/pair_order.py
@@ -69,14 +69,38 @@ def _lis_length(seq: List[int]) -> int:
     return len(tails)
 
 
-def _escape_pads(part, nets, toward_xy, pose=None) -> Dict[int, Tuple[float, float]]:
+def part_pad_globals(part, pose=None):
+    """`part.pad_globals` at `pose` (or the live pose), as a LIST.
+
+    Hoisted out of `_escape_pads` because the transform does not depend on the
+    partner while the SELECTION does: `ref_inversions` asks about one part
+    against every partner it shares a net with, and the unhoisted version
+    re-transformed that part's whole pad list once per partner. Measured on
+    ulx3s (226 parts, ~150 partners for the FPGA after ignored nets), the two
+    hoists in this module together take `ref_inversions` from ~1430 us to the
+    low hundreds. The list is materialised because callers iterate it many
+    times; `pad_globals` may be a generator.
+    """
+    x, y, rot = pose if pose is not None else (part.x, part.y, part.rot)
+    return list(part.pad_globals(x, y, rot))
+
+
+def _escape_pads(part, nets, toward_xy, pose=None,
+                 pads=None) -> Dict[int, Tuple[float, float]]:
     """One representative pad per shared net: the pad nearest the partner
     (the one that would actually escape into the channel). Deterministic
-    tie-break by (x, y). `pose` overrides the part's live (x, y, rot)."""
-    x, y, rot = pose if pose is not None else (part.x, part.y, part.rot)
+    tie-break by (x, y). `pose` overrides the part's live (x, y, rot).
+
+    `pads` is `part_pad_globals(part, pose)` computed by the caller. It is an
+    optimisation ONLY: passing it must not change any number, which
+    `tests/test_893_pair_order_equivalence.py` asserts per ref rather than in
+    aggregate.
+    """
+    if pads is None:
+        pads = part_pad_globals(part, pose)
     tx, ty = toward_xy
     best: Dict[int, Tuple[float, float, float]] = {}
-    for gx, gy, nid in part.pad_globals(x, y, rot):
+    for gx, gy, nid in pads:
         if nid not in nets:
             continue
         d = (gx - tx) ** 2 + (gy - ty) ** 2
@@ -86,10 +110,47 @@ def _escape_pads(part, nets, toward_xy, pose=None) -> Dict[int, Tuple[float, flo
     return {nid: (gx, gy) for nid, (_, gx, gy) in best.items()}
 
 
+def _scoring_net_ids(state):
+    """`set(state.net_refs)`, cached on the state.
+
+    `pair_metrics` intersected against a freshly built `set(state.net_refs)` on
+    EVERY call -- the whole board's net-id set, rebuilt once per partner per
+    pose. It is pose-invariant: `net_refs` is assigned once in
+    `QuenchState.__init__` (quench.py:988) and never mutated afterwards, and
+    `part.nets` is filtered earlier in that same constructor (:825), so both are
+    frozen by the time anything here runs. Measured on ulx3s, that one
+    expression was 735 of 1782 us per `ref_inversions` call.
+    """
+    ids = getattr(state, '_pair_order_net_ids', None)
+    if ids is None:
+        ids = set(state.net_refs)
+        try:
+            state._pair_order_net_ids = ids
+        except AttributeError:        # a caller's stand-in state with __slots__
+            pass
+    return ids
+
+
+def _part_net_set(state, ref, part):
+    """`set(part.nets)` intersected with the scoring nets, cached per ref."""
+    cache = getattr(state, '_pair_order_part_nets', None)
+    if cache is None:
+        cache = {}
+        try:
+            state._pair_order_part_nets = cache
+        except AttributeError:
+            return set(part.nets) & _scoring_net_ids(state)
+    got = cache.get(ref)
+    if got is None:
+        got = set(part.nets) & _scoring_net_ids(state)
+        cache[ref] = got
+    return got
+
+
 def pair_metrics(state, ref_a: str, ref_b: str,
                  pose_a: Optional[Tuple[float, float, float]] = None,
                  pose_b: Optional[Tuple[float, float, float]] = None,
-                 only_nets=None) -> Optional[Dict]:
+                 only_nets=None, pads_a=None, pads_b=None) -> Optional[Dict]:
     """{'inversions', 'lis', 'nets'} for one part pair, or None when they share
     fewer than 2 scoring nets (one net cannot be out of order).
 
@@ -110,7 +171,8 @@ def pair_metrics(state, ref_a: str, ref_b: str,
     pa, pb = state.parts.get(ref_a), state.parts.get(ref_b)
     if pa is None or pb is None:
         return None
-    shared = sorted(set(pa.nets) & set(pb.nets) & set(state.net_refs))
+    shared = sorted(_part_net_set(state, ref_a, pa)
+                    & _part_net_set(state, ref_b, pb))
     if only_nets is not None:
         keep = set(only_nets)
         shared = [n for n in shared if n in keep]
@@ -124,8 +186,8 @@ def pair_metrics(state, ref_a: str, ref_b: str,
         return None                      # coincident parts: no channel axis
     # Cross-section axis of the channel between the parts.
     vx, vy = -uy / n, ux / n
-    ea = _escape_pads(pa, set(shared), (bx, by), pose_a)
-    eb = _escape_pads(pb, set(shared), (ax, ay), pose_b)
+    ea = _escape_pads(pa, set(shared), (bx, by), pose_a, pads=pads_a)
+    eb = _escape_pads(pb, set(shared), (ax, ay), pose_b, pads=pads_b)
     common = [nid for nid in shared if nid in ea and nid in eb]
     if len(common) < 2:
         return None
@@ -195,9 +257,28 @@ def ref_inversions(state, ref: str,
         partners.update(state.net_refs.get(nid, ()))
     partners.discard(ref)
     total = 0
+    # Transformed ONCE, then handed to whichever slot this ref occupies. The
+    # slot matters and is not cosmetic: `pair_metrics` builds `order_a` from
+    # the FIRST ref's escape pads and ranks the second against it, and the
+    # channel axis is `b - a`, so passing the pads to the wrong side changes
+    # the tie-break and the axis sign. A draft that always treated `ref` as A
+    # was 6.7x faster and reported ulx3s U2 as 358 inversions instead of 26.
+    pads = part_pad_globals(part, pose)
+    own_nets = _part_net_set(state, ref, part)
     for other in sorted(partners):
-        m = (pair_metrics(state, ref, other, pose_a=pose) if ref < other
-             else pair_metrics(state, other, ref, pose_b=pose))
+        # Early-out BEFORE the call. `pair_metrics` returns None for a pair
+        # sharing fewer than two scoring nets, and `ref_inversions` then skips
+        # it -- but only after paying the call plus two set intersections. On
+        # a board where one part has hundreds of partners and a handful of
+        # scoring pairs (ulx3s: 226 parts, 209 scoring pairs on tigard), that
+        # rejected majority IS the hot path. This cannot change a result: it
+        # reproduces `pair_metrics`' own `len(shared) < 2` test against the
+        # same cached sets it would build.
+        if len(own_nets & _part_net_set(state, other, state.parts[other])) < 2:
+            continue
+        m = (pair_metrics(state, ref, other, pose_a=pose, pads_a=pads)
+             if ref < other
+             else pair_metrics(state, other, ref, pose_b=pose, pads_b=pads))
         if m is not None:
             total += m['inversions']
     return total

--- a/py_placer/placement/pair_order.py
+++ b/py_placer/placement/pair_order.py
@@ -124,10 +124,12 @@ def _scoring_net_ids(state):
     `pair_metrics` intersected against a freshly built `set(state.net_refs)` on
     EVERY call -- the whole board's net-id set, rebuilt once per partner per
     pose. It is pose-invariant: `net_refs` is assigned once in
-    `QuenchState.__init__` (quench.py:988) and never mutated afterwards, and
-    `part.nets` is filtered earlier in that same constructor (:825), so both are
-    frozen by the time anything here runs. Measured on ulx3s, that one
-    expression was 735 of 1782 us per `ref_inversions` call.
+    `QuenchState.__init__` and never mutated afterwards, and `part.nets` is
+    filtered earlier in that same constructor, so both are frozen by the time
+    anything here runs. (Deliberately no line numbers: the first draft of this
+    docstring cited two, and this commit's own edits to `quench.py` moved both
+    before it was pushed.) Measured on ulx3s, that one expression was 735 of
+    1782 us per `ref_inversions` call.
     """
     ids = getattr(state, '_pair_order_net_ids', None)
     if ids is None:
@@ -282,7 +284,14 @@ def ref_inversions(state, ref: str,
         # rejected majority IS the hot path. This cannot change a result: it
         # reproduces `pair_metrics`' own `len(shared) < 2` test against the
         # same cached sets it would build.
-        if len(own_nets & _part_net_set(state, other, state.parts[other])) < 2:
+        other_part = state.parts.get(other)
+        if other_part is None:
+            # `pair_metrics` returns None for a ref outside `state.parts`, and
+            # the early-out must not turn that skip into a KeyError. Unreachable
+            # for a real QuenchState (`net_refs` is built FROM `parts`), but
+            # this function accepts any duck-typed state.
+            continue
+        if len(own_nets & _part_net_set(state, other, other_part)) < 2:
             continue
         m = (pair_metrics(state, ref, other, pose_a=pose, pads_a=pads)
              if ref < other

--- a/py_placer/placement/pair_order.py
+++ b/py_placer/placement/pair_order.py
@@ -27,10 +27,18 @@ off the two net orders, and count order inversions between them:
 
 These are lower bounds on what ANY router must pay, which is what makes them
 safe to rank poses by -- unlike a correlational proxy, improving them cannot be
-gamed by the optimizer, which is also why they deliberately do NOT join
-``quench.total_cost`` (docs/placement-optimization.md fact (a): proxies mislead
-optimizers). The consumers are pose ranking (pose_score components) and the
-operator reading a report.
+gamed by the optimizer.
+
+They join ``quench.total_cost`` ONLY under an explicit non-zero
+``facing_weight``, whose default is 0.0 (#893). Before that they joined it
+never, and the reason is still the operative one for the default:
+docs/placement-optimization.md is a file-length negative result about adding
+proxies to this objective. Being a lower bound rather than a correlational
+proxy is an argument for trying it, not a measurement that it helps -- so the
+weight exists to MEASURE the question and
+``tests/test_placement_ab.py`` exists to decide it. The consumers are pose
+ranking (pose_score components), the operator reading a report, and
+``QuenchState._facing_cost`` when it is armed.
 """
 from __future__ import annotations
 

--- a/py_placer/placement/pair_order.py
+++ b/py_placer/placement/pair_order.py
@@ -88,6 +88,16 @@ def part_pad_globals(part, pose=None):
     hoists in this module together take `ref_inversions` from ~1430 us to the
     low hundreds. The list is materialised because callers iterate it many
     times; `pad_globals` may be a generator.
+
+    ON THE SPEED-UP FIGURES, because they are machine-dependent and were nearly
+    reported as if they were not: measured here as 1.35x / 1.11x / 1.34x on
+    esp_prog / tigard / ulx3s, and independently on another box as 1.25x /
+    1.75x / 2.53x -- same direction, different magnitudes, and a different
+    per-board ORDER. What is NOT machine-dependent, and is what
+    `tests/test_893_pair_order_equivalence.py` actually pins, is that the
+    inversion counts are unchanged: 16 / 384 / 1138 on those three boards
+    before and after. Trust the equivalence; treat any single speed-up number
+    as an anecdote from one machine.
     """
     x, y, rot = pose if pose is not None else (part.x, part.y, part.rot)
     return list(part.pad_globals(x, y, rot))

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -776,7 +776,12 @@ class QuenchState:
                  # positional-binding reason as the #548 block above, and 0.0
                  # by default: see `_facing_cost` for why the default is a
                  # measurement question and not timidity.
-                 facing_weight: float = 0.0):
+                 facing_weight: float = 0.0,
+                 # --- #893 declared rotations, from the intent gate. APPENDED
+                 # for the same positional-binding reason as the #548 block
+                 # above, and empty by default so an undeclared board keeps the
+                 # full lattice and is bit-identical.
+                 declared_rotations: Optional[Dict] = None):
         bounds = pcb_data.board_info.board_bounds
         if bounds is None:
             raise ValueError("No board boundary (Edge.Cuts) found")
@@ -814,6 +819,11 @@ class QuenchState:
         # below yields None and `_Part` keeps its own ladder.
         self.body_model = bool(body_model)
         self.facing_weight = facing_weight
+        #: #893. {ref: (rotation, candidates)} from the intent gate. Empty when
+        #: nothing is declared, and every consumer falls back to the lattice --
+        #: so a board with no declaration is bit-identical.
+        self.declared_rotations: Dict[str, object] = dict(
+            declared_rotations or {})
         body_locals: Dict[str, object] = {}
         if self.body_model:
             from placement import body as _body
@@ -1203,7 +1213,8 @@ class QuenchState:
             d = self.align_radius
         return self.align_weight * d * d
 
-    def _facing_cost(self, ref, x=None, y=None, rot=None) -> float:
+    def _facing_cost(self, ref, x=None, y=None, rot=None,
+                     exclude: Optional[Set[str]] = None) -> float:
         """Price the pin-ORDER a pose forces (#893). Off at weight 0.0.
 
         `pair_order.ref_inversions` -- the SAME lower bound
@@ -1239,6 +1250,29 @@ class QuenchState:
         touching anything at weight 0, so a default run pays nothing.
         """
         if self.facing_weight <= 0.0:
+            return 0.0
+        if exclude:
+            # NUDGE ONLY, and this is a correctness bound rather than a
+            # simplification. Inversions are a PAIR quantity evaluated against
+            # the partner's LIVE pose, so the two multi-part evaluators cannot
+            # price it:
+            #
+            # * the SWAP passes `exclude={partner}` to each half and adds the
+            #   a-b halo and align pairs back at the candidate poses (see the
+            #   add-back below the swap loop). There is no such add-back for a
+            #   term that needs BOTH parts moved at once, and scoring `a` at
+            #   its candidate against `b` still at its PRE-swap pose is simply
+            #   the wrong geometry.
+            # * the GROUP translate passes `exclude=members - {r}` precisely
+            #   because intra-group geometry is invariant under a rigid move.
+            #   Facing is not: `r` would be displaced while its in-group
+            #   partners are not, turning an invariant into a bias on block
+            #   moves.
+            #
+            # `exclude` is non-empty only on those two paths, so returning 0.0
+            # here leaves the single-part nudge -- where `ref_inversions` IS
+            # the exact delta -- as the only consumer, and leaves the group and
+            # swap objectives bit-identical to their unarmed selves.
             return 0.0
         return self.facing_weight * ref_inversions(self, ref, x, y, rot)
 
@@ -1487,7 +1521,7 @@ class QuenchState:
         # nudge's own rotation loop then reverts every rotation the phase makes
         # (its candidate list always contains the current angle), so `moves`
         # never reaches 0 and `improved` sums two currencies.
-        pen += self._facing_cost(ref, x, y, rot)
+        pen += self._facing_cost(ref, x, y, rot, exclude)
         return pen
 
     def violation(self, ref, x=None, y=None, rot=None,
@@ -2650,7 +2684,8 @@ def _candidate_positions(part: _Part, max_disp: float, step: float,
     return out
 
 
-def _candidate_rotations(part: _Part, allow_rotations: bool) -> List[float]:
+def _candidate_rotations(part: _Part, allow_rotations: bool,
+                         declared=None) -> List[float]:
     """Rotation candidates for a nudge move.
 
     The 90-degree lattice through the part's CURRENT angle, plus the lattice
@@ -2670,6 +2705,18 @@ def _candidate_rotations(part: _Part, allow_rotations: bool) -> List[float]:
     """
     if not allow_rotations:
         return [part.rot]
+    if declared is not None:
+        # #893. A DECLARED rotation outranks the lattice. `[angle]` for a
+        # decision -- the move loop then has no rotation to choose and the
+        # part keeps the angle the seeder was told to give it -- and the
+        # author's SET, order preserved, for `rotation_candidates`. This is
+        # what makes the declaration survive `place_seed -> place_optimize`;
+        # without it the intent was honoured once and undone by the next step,
+        # which is weaker than the locking it replaced.
+        rot, cands = declared
+        if rot is not None:
+            return [rot % 360]
+        return [c % 360 for c in cands]
     bases = [part.rot % 90]
     if part.orig_rot % 90 != bases[0]:
         bases.append(part.orig_rot % 90)
@@ -2822,6 +2869,7 @@ def quench(pcb_data: PCBData, pcb_file: str,
                         corridor_specs=corridor_specs,
                         keepouts=(intent_gate or {}).get('keepouts'),
                         intent_zones=(intent_gate or {}).get('zones'),
+                        declared_rotations=(intent_gate or {}).get('rotations'),
                         body_model=body_model,
                         facing_weight=facing_weight)
     # #708: the lattice candidate OFFSETS are multiples of. The board's own
@@ -2975,7 +3023,8 @@ def quench(pcb_data: PCBData, pcb_file: str,
                 return net_cost + geo_cost
 
             current_cost = eval_at(part.x, part.y, part.rot)
-            rotations = _candidate_rotations(part, allow_rotations)
+            rotations = _candidate_rotations(
+                part, allow_rotations, state.declared_rotations.get(ref))
             for rot in rotations:
                 # A swap can hand a part an angle from ANOTHER seed's lattice,
                 # in a group holding two different non-orthogonal seeds. Add

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -581,7 +581,8 @@ class _Part:
                  'nets', 'halo', 'footprint_name', 'orig_rot',
                  'side', 'has_tht', 'sides', 'tht_by_rot')
 
-    def __init__(self, ref, fp, courtyard_sides, locked, halo_base, halo_coef):
+    def __init__(self, ref, fp, courtyard_sides, locked, halo_base, halo_coef,
+                 body_local=None):
         self.ref = ref
         self.footprint_name = fp.footprint_name
         self.pads_local = [(p.local_x, p.local_y, p.net_id)
@@ -592,9 +593,27 @@ class _Part:
         self.side = footprint_side(fp)
         self.has_tht = footprint_has_through_pads(fp)
         self.sides = sides_occupied(self.side, self.has_tht)
-        lb = courtyard_for_side(courtyard_sides.get(ref), self.side)
+        # #916. `body_local` is `placement.body`'s `occupancy_local` for this
+        # ref, supplied by QuenchState under `body_model=True`. None keeps the
+        # inlined ladder below, which is what every caller got before #916 and
+        # what the default still gets -- so the OFF arm of the A/B is this
+        # file unchanged, not a re-derivation that happens to agree.
+        #
+        # OCCUPANCY, not the bare body, and not the drawn body: this rect is
+        # what `pose_ok`/`candidate_valid` seat against, i.e. "what does this
+        # part occupy". `legality.part_local_bounds` already answers the same
+        # question with `occupancy_local` (legality.py:1213-1216), so before
+        # this the GRADER and the ENFORCER measured different rectangles for
+        # the same part -- the grader courtyard-union-pads, the search bare
+        # courtyard or a pad box. `QuenchState.fab_rect` deliberately does NOT
+        # move: containment is a different question with a fab-only
+        # calibration, and its own docstring calls a courtyard-based
+        # containment test a false-veto machine.
+        lb = body_local
         if lb is None:
-            lb = compute_footprint_bbox_local(fp)
+            lb = courtyard_for_side(courtyard_sides.get(ref), self.side)
+            if lb is None:
+                lb = compute_footprint_bbox_local(fp)
         self.bounds_by_rot = {r: _rotate_local_bounds(*lb, r) for r in ROTATIONS}
         tlb = through_pad_bounds_local(fp) if self.has_tht else None
         self.tht_by_rot = ({r: _rotate_local_bounds(*tlb, r) for r in ROTATIONS}
@@ -739,7 +758,19 @@ class QuenchState:
                  # same empty-by-default bit-identity, and the quench itself
                  # never passes it -- its zone_exclusive enforcement stays
                  # where #702 put it, in `intent_ok`.
-                 exclusive_zones: Optional[Sequence[Dict]] = None):
+                 exclusive_zones: Optional[Sequence[Dict]] = None,
+                 # --- #916. The SEARCH's body currency. APPENDED for the same
+                 # positional-binding reason as the #548 block above, and False
+                 # by default so this commit moves NO number: at False every
+                 # part takes the inlined courtyard-or-pad-box ladder it took
+                 # before, so the A/B's OFF arm is the old code rather than a
+                 # re-derivation that happens to agree. #896 wired every
+                 # GRADING consumer to `placement.body` and deliberately left
+                 # the search behind, because `pose_ok` reads these baked
+                 # bounds and so the change moves which BASIN the anneal lands
+                 # in -- an engine change owing its own A/B, which is what
+                 # flipping this default is gated on.
+                 body_model: bool = False):
         bounds = pcb_data.board_info.board_bounds
         if bounds is None:
             raise ValueError("No board boundary (Edge.Cuts) found")
@@ -771,6 +802,17 @@ class QuenchState:
         self._fab_cache = {}
 
         courtyards = extract_courtyard_sides(pcb_file)
+        # #916. One read for the whole board when armed, never per part:
+        # `board_bodies` makes three regex passes over the file, and the
+        # seeder builds states repeatedly. `{}` when off, so `.get(ref)`
+        # below yields None and `_Part` keeps its own ladder.
+        self.body_model = bool(body_model)
+        body_locals: Dict[str, object] = {}
+        if self.body_model:
+            from placement import body as _body
+            for _ref, _geom in _body.board_bodies(pcb_data, pcb_file).items():
+                if _geom.occupancy_local is not None:
+                    body_locals[_ref] = _geom.occupancy_local
         locked_refs = set(extract_locked_refs(pcb_file))
         if extra_locked_refs:
             locked_refs |= extra_locked_refs
@@ -788,7 +830,8 @@ class QuenchState:
                 # obstacles; without one there is no geometry to respect.
                 if ref in courtyards:
                     self.parts[ref] = _Part(ref, fp, courtyards, True,
-                                            halo_base, halo_coef)
+                                            halo_base, halo_coef,
+                                            body_locals.get(ref))
                 continue
             # #829: a footprint that draws part of the BOARD's own boundary is
             # never this tool's to move -- its pose transforms that Edge.Cuts
@@ -814,7 +857,8 @@ class QuenchState:
             if ref not in courtyards:
                 no_courtyard.append(ref)
             self.parts[ref] = _Part(ref, fp, courtyards, locked,
-                                    halo_base, halo_coef)
+                                    halo_base, halo_coef,
+                                    body_locals.get(ref))
             # A part with NO connected pins (mounting hole, NPTH, fiducial) is
             # invisible to the airwire cost -- only halo/edge decide where it
             # goes, which is how holes wander. Frozen by default; the caller
@@ -2602,7 +2646,11 @@ def quench(pcb_data: PCBData, pcb_file: str,
            corridor_specs: Optional[Sequence[Dict]] = None,
            intent_gate: Optional[Dict[str, object]] = None,
            cancel_check=None,
-           progress_callback=None) -> List[Dict]:
+           progress_callback=None,
+           # #916: the SEARCH's body currency. Appended, and False by default
+           # -- see QuenchState.__init__. Flipping it is an engine change
+           # gated on tests/test_placement_ab.py, not a tidy-up.
+           body_model: bool = False) -> List[Dict]:
     """Greedy quench: iterate over parts, accept only cost-reducing moves.
 
     align_weight / align_radius / align_span, orient_weight: the #548 tidiness
@@ -2706,7 +2754,8 @@ def quench(pcb_data: PCBData, pcb_file: str,
                         corridor_weight=corridor_weight,
                         corridor_specs=corridor_specs,
                         keepouts=(intent_gate or {}).get('keepouts'),
-                        intent_zones=(intent_gate or {}).get('zones'))
+                        intent_zones=(intent_gate or {}).get('zones'),
+                        body_model=body_model)
     # #708: the lattice candidate OFFSETS are multiples of. The board's own
     # pitch when one can be read off it, the `grid_step` raster otherwise.
     # There is deliberately no flag: the fallback IS the off state and the

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -45,6 +45,7 @@ from connectivity import compute_mst_edges
 from placement.parser import (courtyard_for_side, extract_courtyard_sides,
                               extract_locked_refs, warn_missing_courtyards)
 from placement.utility import compute_footprint_bbox_local, snap_to_grid
+from placement.pair_order import pair_inversions, ref_inversions
 from placement.board_grid import (describe as describe_lattice,
                                   resolve_snap_lattice)
 from placement import legality
@@ -770,7 +771,12 @@ class QuenchState:
                  # bounds and so the change moves which BASIN the anneal lands
                  # in -- an engine change owing its own A/B, which is what
                  # flipping this default is gated on.
-                 body_model: bool = False):
+                 body_model: bool = False,
+                 # --- #893 pin-order facing term. APPENDED for the same
+                 # positional-binding reason as the #548 block above, and 0.0
+                 # by default: see `_facing_cost` for why the default is a
+                 # measurement question and not timidity.
+                 facing_weight: float = 0.0):
         bounds = pcb_data.board_info.board_bounds
         if bounds is None:
             raise ValueError("No board boundary (Edge.Cuts) found")
@@ -807,6 +813,7 @@ class QuenchState:
         # seeder builds states repeatedly. `{}` when off, so `.get(ref)`
         # below yields None and `_Part` keeps its own ladder.
         self.body_model = bool(body_model)
+        self.facing_weight = facing_weight
         body_locals: Dict[str, object] = {}
         if self.body_model:
             from placement import body as _body
@@ -1196,6 +1203,45 @@ class QuenchState:
             d = self.align_radius
         return self.align_weight * d * d
 
+    def _facing_cost(self, ref, x=None, y=None, rot=None) -> float:
+        """Price the pin-ORDER a pose forces (#893). Off at weight 0.0.
+
+        `pair_order.ref_inversions` -- the SAME lower bound
+        `placement_score.pin_order_crossings` reports, called rather than
+        re-derived. For each partner sharing >= 2 scoring nets, project both
+        parts' escape pads onto the channel cross-section and count order
+        inversions: in a two-sided channel each inverted pair must cross at
+        least once, so this is a floor on the crossings any router must pay.
+
+        WHY THIS IS NOT `_orient_cost`, which already "rewards a pose whose
+        pads FACE the nets they serve": that term is a DIRECTION, summed per
+        pad against a net centroid, and it is blind to ORDER. Two parts can
+        point their pads straight at each other and still have every net
+        crossed -- which is exactly run 5's U3, where rotating 180 degrees took
+        the same nets from 4/7 routed to 7/7 while the airwire lengths barely
+        moved. `_orient_cost` cannot see that; this can. They are complementary
+        and both are off by default.
+
+        WHY IT IS OFF BY DEFAULT, and why that is not timidity:
+        `pair_order`'s own header records the standing decision that these
+        metrics "deliberately do NOT join quench.total_cost", and
+        `docs/placement-optimization.md` is a file-length negative result about
+        adding proxies to this objective -- "proxy-routability correlation is
+        weak", "proxies propose, the router disposes". A lower bound is a
+        better citizen than a correlational proxy (improving it cannot be
+        gamed), but "better citizen" is an argument, not a measurement. The
+        weight is the way to MEASURE it; `tests/test_placement_ab.py` is the
+        way to decide it.
+
+        Cost: `ref_inversions` is ~150-800 us/call depending on the board even
+        after the #893 hot-path work, so this is the most expensive term in
+        `part_geometry_cost` by an order of magnitude. It returns before
+        touching anything at weight 0, so a default run pays nothing.
+        """
+        if self.facing_weight <= 0.0:
+            return 0.0
+        return self.facing_weight * ref_inversions(self, ref, x, y, rot)
+
     def _align_cost(self, ref, rect, exclude: Optional[Set[str]] = None
                     ) -> float:
         if self.align_weight <= 0.0:
@@ -1434,6 +1480,14 @@ class QuenchState:
         # so a default run is bit-identical and pays nothing.
         pen += self._align_cost(ref, rect, exclude)
         pen += self._orient_cost(ref, x, y, rot)
+        # #893. Same hook, same contract: 0.0 before touching geometry when the
+        # weight is 0, so a default run is bit-identical. Deliberately NOT a
+        # separate move phase -- a phase minimising `nets+geo+facing` while the
+        # nudge minimises `nets+geo` gives the loop two objectives, and the
+        # nudge's own rotation loop then reverts every rotation the phase makes
+        # (its candidate list always contains the current angle), so `moves`
+        # never reaches 0 and `improved` sums two currencies.
+        pen += self._facing_cost(ref, x, y, rot)
         return pen
 
     def violation(self, ref, x=None, y=None, rot=None,
@@ -2173,12 +2227,23 @@ class QuenchState:
                     align += self._align_pair_penalty(pa, rect_a, pb, pb.rect())
         cut = (_corridor_cut_np(all_aw, self._corridor_boxes)
                if self._corridor_boxes else 0.0)
+        # #893. Counted over UNORDERED pairs, like `halo` and `align` above and
+        # for the same reason: `ref_inversions` sums a symmetric PAIR quantity
+        # from one part's side, so summing it over every ref would count each
+        # physical pair twice. `part_geometry_cost` does sum from one side --
+        # that is the factor of 2 the evaluators need, and it cancels between
+        # candidates -- but a REPORT must show each pair once.
+        facing = (self.facing_weight
+                  * sum(m['inversions']
+                        for m in pair_inversions(self).values())
+                  if self.facing_weight > 0.0 else 0.0)
         total = (self.length_weight * length
                  + self.crossing_penalty * w_crossings + halo + edge
-                 + align + orient + self.corridor_weight * cut)
+                 + align + orient + facing + self.corridor_weight * cut)
         return {'total': total, 'length': length, 'crossings': crossings,
                 'halo': halo, 'edge': edge, 'hpwl': self.hpwl(),
-                'align': align, 'orient': orient, 'corridor_cut': cut}
+                'align': align, 'orient': orient, 'facing': facing,
+                'corridor_cut': cut}
 
     def hpwl(self, nets=None):
         """Half-perimeter wirelength: sum over nets of the pad bbox's width plus
@@ -2650,7 +2715,9 @@ def quench(pcb_data: PCBData, pcb_file: str,
            # #916: the SEARCH's body currency. Appended, and False by default
            # -- see QuenchState.__init__. Flipping it is an engine change
            # gated on tests/test_placement_ab.py, not a tidy-up.
-           body_model: bool = False) -> List[Dict]:
+           body_model: bool = False,
+           # #893: the pin-order facing term. Appended, 0.0 by default.
+           facing_weight: float = 0.0) -> List[Dict]:
     """Greedy quench: iterate over parts, accept only cost-reducing moves.
 
     align_weight / align_radius / align_span, orient_weight: the #548 tidiness
@@ -2755,7 +2822,8 @@ def quench(pcb_data: PCBData, pcb_file: str,
                         corridor_specs=corridor_specs,
                         keepouts=(intent_gate or {}).get('keepouts'),
                         intent_zones=(intent_gate or {}).get('zones'),
-                        body_model=body_model)
+                        body_model=body_model,
+                        facing_weight=facing_weight)
     # #708: the lattice candidate OFFSETS are multiples of. The board's own
     # pitch when one can be read off it, the `grid_step` raster otherwise.
     # There is deliberately no flag: the fallback IS the off state and the

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -1043,9 +1043,15 @@ def _try_place(state, ref: str, tx: float, ty: float, exclude: Set[str],
     90-degree lattice: an unplaced pile's rotation is a generator default,
     not a decision, and a large part can have NO contained legal pose at it
     while fitting fine turned 90 (measured: the same LDO, 0 poses at rot 0
-    against 3 at rot 90 on a packed 51x21 board). A part whose rotation IS a
-    decision must be locked -- an unlocked "load-bearing rotation" was never
-    protected from the quench either (the U3 lesson). The caller can see a
+    against 3 at rot 90 on a packed 51x21 board).
+
+    `rotations` REPLACES that ladder with a declared one (#893) -- a single
+    angle for `blocks[].rotation`, the author's set for
+    `rotation_candidates` -- so a part whose rotation is a decision is seated
+    at it or not at all, and the quench's gate pins it there afterwards. This
+    paragraph used to end "a part whose rotation IS a decision must be locked";
+    that advice froze the part's POSITION as well, which is exactly what the
+    declaration exists to avoid. The caller can see a
     fallback fired by comparing the part's rot before and after.
 
     Returns the courtyard clearance the pose was found at, or None. The full
@@ -1080,9 +1086,29 @@ def _try_place(state, ref: str, tx: float, ty: float, exclude: Set[str],
             # because this search keeps the FIRST pose that fits and a
             # reordered ladder changes which angle wins. None keeps the
             # fallback ladder every caller had before #893, byte for byte.
-            for rot in (list(rotations) if rotations is not None
-                        else [part.rot] + [(part.rot + d) % 360
-                                           for d in (90.0, 180.0, 270.0)]):
+            _ladder_rots = (list(rotations) if rotations is not None
+                            else [part.rot] + [(part.rot + d) % 360
+                                               for d in (90.0, 180.0, 270.0)])
+            # #893. A DECLARED angle need not lie on the part's 90-degree
+            # lattice, and `_Part.rect` silently falls back to
+            # `bounds_by_rot[0.0]` for an angle it has no entry for -- so a
+            # declared 45 on a part seeded at 0 would be seated against the
+            # UNROTATED courtyard box and then written out at 45, with overlap,
+            # halo and edge containment all judged on the wrong rectangle. The
+            # quench's own nudge loop materialises the entry before using it
+            # for exactly this reason; the seat search must too. No-op for the
+            # fallback ladder, whose angles are always present by construction.
+            for _r in _ladder_rots:
+                if _r not in part.bounds_by_rot:
+                    from placement.legality import rotate_local_bounds
+                    part.bounds_by_rot[_r] = rotate_local_bounds(
+                        *part.bounds_by_rot[0.0], _r)
+                if (part.tht_by_rot is not None
+                        and _r not in part.tht_by_rot):
+                    from placement.legality import rotate_local_bounds
+                    part.tht_by_rot[_r] = rotate_local_bounds(
+                        *part.tht_by_rot[0.0], _r)
+            for rot in _ladder_rots:
                 xfine = max(0.05, getattr(state, 'grid_step', 0.1) or 0.1)
                 for radius, step in ((SEARCH_RADIUS_MM, SEARCH_STEP_MM),
                                      (SEARCH_FINE_RADIUS_MM,
@@ -1480,7 +1506,8 @@ def _already_on_its_edge(state, part) -> bool:
 
 
 def _seat_edge(state, ref: str, entry: Dict, must_lock: Set[str],
-               notes: List[str], target=None, exclude=None) -> bool:
+               notes: List[str], target=None, exclude=None,
+               rotations=None) -> bool:
     """Seat a DECLARED edge part on its edge band, minimal-move (run-4 B-6).
 
     Repair could never do this: `_try_place._ok` demands full containment,
@@ -1709,8 +1736,19 @@ def _seat_edge(state, ref: str, entry: Dict, must_lock: Set[str],
         # reading it afterwards reports the new angle as the old one and the
         # note says "at its own rotation 90deg; seated at 90deg".
         was_rot = part.rot
-        for rot in ((was_rot + 90) % 360, (was_rot + 180) % 360,
-                    (was_rot + 270) % 360):
+        # #893. A DECLARED rotation outranks this ladder: the whole argument
+        # for (3) above is that turning a connector "is only defensible where a
+        # human declared where it belongs". Where the human ALSO declared which
+        # way it points, that is the answer, and trying `+90k` past it would
+        # override the more specific claim with the less specific one. A
+        # declared angle already applied leaves this loop with nothing to try,
+        # which is correct: the seat either exists at the declared angle or the
+        # part is reported.
+        _decl_rots = ([r % 360 for r in rotations if r % 360 != was_rot % 360]
+                      if rotations is not None else None)
+        for rot in (_decl_rots if _decl_rots is not None
+                    else ((was_rot + 90) % 360, (was_rot + 180) % 360,
+                          (was_rot + 270) % 360)):
             seat = try_rot(rot)
             if seat is None:
                 continue
@@ -1777,7 +1815,8 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                      anchor_rounds: int = 1,
                      evict_depth: int = 0,
                      decap_owner_chips: bool = False,
-                     immovable_extra: Sequence[str] = ()) -> Dict:
+                     immovable_extra: Sequence[str] = (),
+                     body_model: bool = False) -> Dict:
     """Compute a full placement for an unplaced board from its intent.
 
     Returns {'placements': [...], 'lock_refs': [...], 'unseated': [...],
@@ -1832,7 +1871,10 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
         # nothing asked whether the region it was aiming at belonged to
         # somebody else.
         exclusive_zones=(floorplan.zone_entries(intent, blocks)
-                         if intent else ()))
+                         if intent else ()),
+        # #916. Reaches `pose_ok` through the state, which is the search
+        # this issue is actually about. False by default.
+        body_model=body_model)
     bounds = state.board
     refs_all = sorted(pcb_data.footprints)
     notes: List[str] = []
@@ -1982,6 +2024,30 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                     continue
                 f_lo, f_hi = _n_lo, _n_hi
             frac = min(f_hi, max(f_lo, frac))
+            # #893. An edge connector is the class whose rotation is most often
+            # a DECISION, and stage 1 never turns a part -- it seats at
+            # `part.rot`. So without this a declared angle was simply ignored
+            # here: not turned away silently, but seated at the INPUT angle,
+            # which is the same broken promise wearing a different face. Set it
+            # first, so `_edge_pose` and `_edge_correct` compute the overhang
+            # and the correction for the geometry that will actually be
+            # written. A candidate SET is not applied here (the edge ladder has
+            # no cost to choose by); the later stages resolve those.
+            _edge_decl = declared_rot.get(ref)
+            if _edge_decl is not None and _edge_decl[0] is not None:
+                _want = _edge_decl[0] % 360.0
+                if abs((part.rot % 360.0) - _want) > 1e-9:
+                    if _want not in part.bounds_by_rot:
+                        from placement.legality import rotate_local_bounds
+                        part.bounds_by_rot[_want] = rotate_local_bounds(
+                            *part.bounds_by_rot[0.0], _want)
+                        if part.tht_by_rot is not None:
+                            part.tht_by_rot[_want] = rotate_local_bounds(
+                                *part.tht_by_rot[0.0], _want)
+                    notes.append(
+                        f"edge connector {ref}: seated at the declared "
+                        f"rotation {_want:g}deg (input was {part.rot:g}deg)")
+                    state.apply_move(ref, part.x, part.y, _want)
             # #701: SLIDE along the edge when a declared keep-out refuses the
             # even-distribution position, using the same ladder `_seat_edge`
             # already uses. Without it, one keep-out over the middle of an
@@ -3329,7 +3395,8 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
             if zt is not None and zt.rect is not None:
                 tgt = ((zt.rect[0] + zt.rect[2]) / 2.0,
                        (zt.rect[1] + zt.rect[3]) / 2.0)
-            ok = _seat_edge(state, ref, ec, must_lock, notes, target=tgt)
+            ok = _seat_edge(state, ref, ec, must_lock, notes, target=tgt,
+                            rotations=_rot_ladder(ref))
             if ok:
                 d = math.hypot(part.x - part.seed_x, part.y - part.seed_y)
                 moves.append({'reference': ref, 'new_x': part.x,

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -2085,12 +2085,14 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
         tol = intent.zone_tolerance(z) if z is not None else 0.5
         info: Dict = {}
         clr = _try_place(state, ref, part.x, part.y, unplaced - {ref},
-                         constraint=rect, tol=tol, info=info)
+                         constraint=rect, tol=tol, info=info,
+                         rotations=_rot_ladder(ref))
         if clr is None and z is not None:
             zx = (z.rect[0] + z.rect[2]) / 2.0
             zy = (z.rect[1] + z.rect[3]) / 2.0
             clr = _try_place(state, ref, zx, zy, unplaced - {ref},
-                             constraint=rect, tol=tol, info=info)
+                             constraint=rect, tol=tol, info=info,
+                             rotations=_rot_ladder(ref))
         if clr is not None:
             placed.add(ref)
             unplaced.discard(ref)
@@ -2275,9 +2277,11 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
 
         def _seat(ref, tx, ty, owner, pn, constraint=None, tol=0.5):
             clr = _try_place(state, ref, tx, ty, unplaced - {ref},
-                             constraint=constraint, tol=tol)
+                             constraint=constraint, tol=tol,
+                             rotations=_rot_ladder(ref))
             if clr is None and constraint is not None:
-                clr = _try_place(state, ref, tx, ty, unplaced - {ref})
+                clr = _try_place(state, ref, tx, ty, unplaced - {ref},
+                                 rotations=_rot_ladder(ref))
             if clr is None:
                 return False
             avail.remove(ref)
@@ -2400,7 +2404,8 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
             clr = _try_place(state, ref, round((zx0 + zx1) / 2.0, 3),
                              round((zy0 + zy1) / 2.0, 3), unplaced - {ref},
                              constraint=z.rect,
-                             tol=intent.zone_tolerance(z))
+                             tol=intent.zone_tolerance(z),
+                             rotations=_rot_ladder(ref))
             if clr is None:
                 notes.append(f"{ref}: the pin stage declined it and its zone "
                              f"{z.name!r} has no legal pose either -- falls "
@@ -2756,7 +2761,8 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                     continue
                 ox, oy = state.parts[ref].x, state.parts[ref].y
                 if _try_place(state, ref, target[0], target[1],
-                              set()) is not None:
+                              set(),
+                              rotations=_rot_ladder(ref)) is not None:
                     if math.hypot(state.parts[ref].x - ox,
                                   state.parts[ref].y - oy) > 1e-6:
                         moved_n += 1

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -23,13 +23,23 @@ What each intent construct becomes, in placement order:
                            drag everything to the board middle) -- which is
                            also what lands a decap next to its IC.
 
-Rotations: the input rotation is tried IN FULL first and kept when it fits;
-a part with no contained legal pose at it falls back to its 90-degree
-lattice, and the note names the change. The intent schema cannot express a
-rotation, so a part whose rotation is a DECISION (pin order, the U3 rot-180
-case) must be locked -- an unlocked load-bearing rotation was never
-protected from the quench either. Explore rotations deliberately with
-place_portfolio's `poses` strategy.
+Rotations: UNDECLARED, the input rotation is tried IN FULL first and kept
+when it fits; a part with no contained legal pose at it falls back to its
+90-degree lattice, and the note names the change.
+
+Since #893 the intent CAN express a rotation, which is what a part whose
+rotation is a DECISION (pin order, the U3 rot-180 case) should use.
+`blocks[].rotation` is honoured exactly -- a part that does not fit at it is
+reported UNSEATED in `rotation_unseated`, never quietly turned -- and
+`blocks[].rotation_candidates` narrows the ladder to the author's set, in the
+author's order, because this search keeps the FIRST pose that fits.
+
+Note what a declared rotation deliberately does NOT do: it does not lock the
+part. The advice this paragraph used to give -- lock it -- costs the part its
+POSITION too, because `_Part.locked` is one boolean covering both, and
+`place_seed` stamps it into the board. The angle is held by handing
+`_try_place` a one-element ladder instead. `place_portfolio`'s `poses`
+strategy is still how you EXPLORE rotations; this is how you FIX one.
 
 Determinism: the only randomness is ``random.Random(f"{seed}")`` -- it breaks
 ties in the packing order and jitters non-spec targets, so different seeds
@@ -1002,7 +1012,8 @@ def _evict_trade(state, ref: str, blockers: Sequence[str],
 def _try_place(state, ref: str, tx: float, ty: float, exclude: Set[str],
                constraint=None, tol: float = 0.5,
                max_disp: Optional[float] = None,
-               info: Optional[Dict] = None) -> Optional[float]:
+               info: Optional[Dict] = None,
+               rotations: Optional[Sequence[float]] = None) -> Optional[float]:
     """Nearest FULLY-CONTAINED legal pose to (tx, ty); applies the move and
     returns True.
 
@@ -1053,8 +1064,15 @@ def _try_place(state, ref: str, tx: float, ty: float, exclude: Set[str],
             # cache is keyed on it implicitly, so clear it on every change.
             state.clearance = clr
             state._inc_violation.clear()
-            for rot in [part.rot] + [(part.rot + d) % 360
-                                     for d in (90.0, 180.0, 270.0)]:
+            # #893. `rotations` is the DECLARED ladder when an intent gave
+            # this ref one -- a single angle for `blocks[].rotation`, the
+            # author's set for `rotation_candidates` -- in the author's order,
+            # because this search keeps the FIRST pose that fits and a
+            # reordered ladder changes which angle wins. None keeps the
+            # fallback ladder every caller had before #893, byte for byte.
+            for rot in (list(rotations) if rotations is not None
+                        else [part.rot] + [(part.rot + d) % 360
+                                           for d in (90.0, 180.0, 270.0)]):
                 xfine = max(0.05, getattr(state, 'grid_step', 0.1) or 0.1)
                 for radius, step in ((SEARCH_RADIUS_MM, SEARCH_STEP_MM),
                                      (SEARCH_FINE_RADIUS_MM,
@@ -1815,6 +1833,23 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
 
     lock_refs: List[str] = sorted({
         r for pat in intent.must_lock for r in fnmatch.filter(refs_all, pat)})
+    # #893. {ref: (declared rotation, declared candidates)}. NOTE these refs
+    # are deliberately NOT added to `lock_refs`: that flag becomes
+    # `_Part.locked`, one boolean covering position AND rotation, and
+    # `place_seed` stamps it into the board -- so locking a part to hold its
+    # angle would also freeze wherever the seeder first dropped it, which is
+    # the very trade `_try_place`'s docstring told authors to accept for want
+    # of anything better. The angle is held by handing `_try_place` a
+    # one-element ladder instead.
+    declared_rot = floorplan.rotations_for_ref(intent, blocks) if intent else {}
+
+    def _rot_ladder(ref):
+        """The declared ladder for `ref`, or None for the fallback one."""
+        claim = declared_rot.get(ref)
+        if claim is None:
+            return None
+        rot, cands = claim
+        return [rot] if rot is not None else list(cands)
 
     placed: Set[str] = set()
     unplaced: Set[str] = {r for r, p in state.parts.items()}
@@ -2147,6 +2182,7 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
             rot_before = state.parts[ref].rot
             zinfo: Dict = {}
             clr = _try_place(state, ref, cx + jx, cy + jy, unplaced - {ref},
+                             rotations=_rot_ladder(ref),
                              constraint=z.rect, tol=tol, info=zinfo)
             if clr is not None:
                 placed.add(ref)
@@ -2404,7 +2440,8 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
         jx, jy = _jitter()
         rot_before = state.parts[ref].rot
         clr = _try_place(state, ref, target[0] + jx, target[1] + jy,
-                         unplaced - {ref})
+                         unplaced - {ref},
+                         rotations=_rot_ladder(ref))
         if clr is not None:
             placed.add(ref)
             unplaced.discard(ref)
@@ -2762,6 +2799,17 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
             # reached them by -- including the neighbours and pairs it did
             # NOT census, so a cap can never read as a complete sweep.
             'no_pose_verdict': no_pose_verdict,
+            # #893. Declared rotations that could NOT be seated, by ref and
+            # angle. The refusal is structural rather than a check: a declared
+            # ladder has only the declared angle in it, so a part that does not
+            # fit at it reaches `unseated` instead of being quietly turned --
+            # which is what happened before, with a note nobody gated on. This
+            # key exists so a caller can say WHICH claim it could not meet
+            # rather than reporting a bare unseated ref.
+            'rotation_unseated': {
+                r: (declared_rot[r][0] if declared_rot[r][0] is not None
+                    else list(declared_rot[r][1]))
+                for r in unseated if r in declared_rot},
             'no_pose_census': no_pose_census}
 
 

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -834,7 +834,8 @@ def _seated_violations(state, seated: Set[str]) -> Tuple[int, float]:
 def _evict_trade(state, ref: str, blockers: Sequence[str],
                  tx: float, ty: float, constraint, tol: float,
                  blocker_zones: Sequence[Tuple[Any, float]],
-                 placed: Set[str], unplaced: Set[str]) -> Dict:
+                 placed: Set[str], unplaced: Set[str],
+                 rot_ladder=None) -> Dict:
     """Lift every ref in `blockers`, seat `ref` at the target it was refused
     at, put the blockers back; keep the trade only under the rule below, else
     restore all of them.
@@ -896,8 +897,16 @@ def _evict_trade(state, ref: str, blockers: Sequence[str],
         unplaced.add(b)
         placed.discard(b)
     lifted = set(blockers)
+    # #893. A declared rotation binds the EVICTED part and every blocker
+    # put back after it, not just the parts the ordinary stages seat. Without
+    # this the rung is a hole in the claim: a trade that turns a declared part
+    # keeps it, silently, and the note the stages emit is not even printed
+    # here. `rot_ladder` is `seed_from_intent._rot_ladder`; None (every other
+    # caller) keeps the fallback ladder exactly.
+    _ladder = rot_ladder if rot_ladder is not None else (lambda _r: None)
     clr_ref = _try_place(state, ref, tx, ty, pile | lifted,
-                         constraint=constraint, tol=tol)
+                         constraint=constraint, tol=tol,
+                         rotations=_ladder(ref))
     clr_back: Dict[str, Optional[float]] = {b: None for b in blockers}
     tried: List[str] = []
     if clr_ref is not None:
@@ -910,7 +919,8 @@ def _evict_trade(state, ref: str, blockers: Sequence[str],
             bx, by, _brot = snapshot[b]
             bz, btol = zones.get(b, (None, 0.5))
             clr_back[b] = _try_place(state, b, bx, by, pile | lifted,
-                                     constraint=bz, tol=btol)
+                                     constraint=bz, tol=btol,
+                                     rotations=_ladder(b))
             if clr_back[b] is None:
                 break
     ok = clr_ref is not None and all(c is not None
@@ -2700,7 +2710,8 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                     (bz.rect if bz is not None else None,
                      intent.zone_tolerance(bz) if bz is not None else 0.5))
             rec = _evict_trade(state, ref, chosen, tx, ty, constraint, tol,
-                               zinfo, placed, unplaced)
+                               zinfo, placed, unplaced,
+                               rot_ladder=_rot_ladder)
             rec.update({'poses_freed': chosen_freed, 'poses_before': baseline,
                         'depth': len(chosen)})
             evictions.append(rec)
@@ -2971,6 +2982,18 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     # `ref_zone` join below reads the same `blocks`.
     blocks, _probs = floorplan.resolve_blocks(intent, pcb_data, group_sources) \
         if intent else ({}, [])
+    # #893. A repair must honour a declared rotation for the same reason a seed
+    # must: the claim is about the BOARD, not about which entry point touched
+    # it last. Without this, `place_optimize --repair` would quietly undo an
+    # angle `place_seed` had just been told to hold.
+    _declared_rot = floorplan.rotations_for_ref(intent, blocks) if intent else {}
+
+    def _rot_ladder(ref):
+        claim = _declared_rot.get(ref)
+        if claim is None:
+            return None
+        rot, cands = claim
+        return [rot] if rot is not None else list(cands)
     state = pose_score.make_state(
         pcb_data, pcb_file, clearance=clearance,
         board_edge_clearance=board_edge_clearance, grid_step=grid_step,
@@ -3327,7 +3350,8 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
         placed_at = None
         for cap in caps:
             info: Dict = {}
-            clr = _try_place(state, ref, ox, oy, set(), constraint=rect,
+            clr = _try_place(state, ref, ox, oy, set(),
+                             rotations=_rot_ladder(ref), constraint=rect,
                              tol=tol, max_disp=cap, info=info)
             if clr is not None:
                 placed_at = cap
@@ -3340,7 +3364,7 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
             zx = (z.rect[0] + z.rect[2]) / 2.0
             zy = (z.rect[1] + z.rect[3]) / 2.0
             clr = _try_place(state, ref, zx, zy, set(), constraint=rect,
-                             tol=tol)
+                             tol=tol, rotations=_rot_ladder(ref))
             if clr is not None:
                 placed_at = 'zone'
         part.locked = was_locked
@@ -3356,7 +3380,8 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
                 pox, poy, porot = pp.x, pp.y, pp.rot
                 for cap in caps:
                     if _try_place(state, partner, pox, poy, set(),
-                                  max_disp=cap) is not None:
+                                  max_disp=cap,
+                                  rotations=_rot_ladder(partner)) is not None:
                         pd = math.hypot(pp.x - pox, pp.y - poy)
                         if pd > 1e-9:
                             seated_partner = (partner, pd)

--- a/py_placer/pose_score.py
+++ b/py_placer/pose_score.py
@@ -138,6 +138,13 @@ def rank_poses(pcb_data, board_path: str, ref: str, *, radius: float = 2.0,
     # ranked total -- the objective must not chase a bound it can't trade off
     # (fact (a): proxies mislead optimizers). rot-0 vs rot-180 ties in `cost`
     # are exactly where this number decides (test-board U3: 9 -> 0).
+    #
+    # STILL TRUE HERE after #893, and not by accident: that issue added a
+    # `facing_weight` which DOES put this bound into `total_cost`, but
+    # `make_state` never sets it, so a state built by this module ranks on a
+    # total with no facing term and the sentence above holds. A caller that
+    # passes its own armed state via `state=` gets a ranked total that includes
+    # it -- which is a deliberate choice by that caller, not this default.
     from placement.pair_order import ref_inversions
     base_inv = ref_inversions(st, ref)
 

--- a/py_placer/pose_score.py
+++ b/py_placer/pose_score.py
@@ -61,7 +61,7 @@ def make_state(pcb_data, board_path: str, *, clearance: float = 0.25,
                edge_weight: float = 2.0,
                ignore_net_ids=None, net_weights=None, move_refs=None,
                extra_locked_refs=None, keepouts=None, intent_zones=None,
-               exclusive_zones=None):
+               exclusive_zones=None, body_model=False):
     """A QuenchState used purely as an oracle -- built, queried, thrown away.
 
     Defaults mirror the placement guidance rather than quench's own library
@@ -96,7 +96,13 @@ def make_state(pcb_data, board_path: str, *, clearance: float = 0.25,
         # start from a violating pose; this is a must-be-OUTSIDE claim whose
         # target is clean by definition, so an absolute gate on it cannot
         # refuse a repair its own target. See `quench.exclusive_spec`.
-        exclusive_zones=exclusive_zones)
+        exclusive_zones=exclusive_zones,
+        # #916. `make_state` is what the SEEDER, the repair path and
+        # `reseat_scope` build their state from, so without this the flag
+        # reached `quench()` and nothing that actually SEATS a part -- half a
+        # fix for an issue whose whole subject is `pose_ok`. False keeps every
+        # existing caller bit-identical.
+        body_model=body_model)
 
 
 def rank_poses(pcb_data, board_path: str, ref: str, *, radius: float = 2.0,

--- a/tests/mutate_711.py
+++ b/tests/mutate_711.py
@@ -100,11 +100,12 @@ ROWS = [
      (TSCH, T712, T711), KILLED),
     # RE-ANCHORED for #837 (2 -> 3) and again for #902 (3 -> 4). The mutation
     # is restated rather than transliterated each time: it must move the
-    # version BELOW the one #712's fields need, so `4 -> 3` would be a bump
+    # version BELOW the one #712's fields need, so `5 -> 4` would be a bump
     # merely smaller rather than absent -- a row that could survive for the
-    # wrong reason. `4 -> 1` is the same claim the row has always made.
+    # wrong reason. `5 -> 1` is the same claim the row has always made.
+    # RE-ANCHORED for #893, which took READER_VERSION 4 -> 5.
     ('reader-version-not-bumped', 'fp',
-     "READER_VERSION = 4",
+     "READER_VERSION = 5",
      "READER_VERSION = 1",
      (TSCH, T712), KILLED),
 

--- a/tests/mutate_797.py
+++ b/tests/mutate_797.py
@@ -93,12 +93,13 @@ ROWS = [
      "        return all(c <= u + legality.EPS for c, u in zip(cand, cur))",
      (T797S,), 'KILLED'),
 
+    # RE-ANCHORED for #893/#916, which inserted `body_model=` between the
+    # exclusive zones and `bounds = state.board`. The MUTATION is unchanged in
+    # kind: hand the seed state no exclusive zones at all.
     ('the-seed-state-drops-the-exclusive-zones', 's',
      "        exclusive_zones=(floorplan.zone_entries(intent, blocks)\n"
-     "                         if intent else ()))\n"
-     "    bounds = state.board",
-     "        exclusive_zones=())\n"
-     "    bounds = state.board",
+     "                         if intent else ()),",
+     "        exclusive_zones=(),",
      (T797S,), 'KILLED'),
 
     ('the-external-caller-drops-them', 'ps',

--- a/tests/mutate_837.py
+++ b/tests/mutate_837.py
@@ -229,13 +229,13 @@ ROWS = [
      "'both',\n",
      (CEN,), 'KILLED'),
 
-    # RE-ANCHORED for #902, which took READER_VERSION 3 -> 4. The MUTATION is
+    # RE-ANCHORED for #902 (3 -> 4) and again for #893 (4 -> 5). The MUTATION is
     # unchanged in kind -- fail to move the reader when a declarable field
     # arrives -- so it reverts 4 to the version before this key, exactly as it
     # used to revert 3 to the version before `assembly.sides`.
     ('the-reader-version-does-not-move', 'fp',
+     "READER_VERSION = 5\n",
      "READER_VERSION = 4\n",
-     "READER_VERSION = 3\n",
      (CEN,), 'KILLED'),
 
     # ------------------------------------------------------- the arithmetic

--- a/tests/mutate_893_916.py
+++ b/tests/mutate_893_916.py
@@ -49,8 +49,18 @@ KILLED = 'KILLED'
 #: whatever was convenient to quote (#877).
 ROWS = [
     # ---- #893 pair_order hot path ------------------------------------------
-    # The 6.7x-faster WRONG draft, reproduced exactly: hand the queried ref's
-    # pads to side A regardless of which slot it occupies.
+    # The SLOT is load-bearing: `pair_metrics` builds `order_a` from the FIRST
+    # ref's pads and takes its channel axis as `b - a`, so handing the queried
+    # ref's pads to the wrong side changes both the axis sign and the
+    # `(projection, nid)` tie-break.
+    #
+    # NOT the 6.7x draft "reproduced exactly", which an earlier version of this
+    # comment claimed and a fact-check disproved: that draft ALSO skipped the
+    # `ref < other` swap, so it reported ulx3s U2 as 358 against a truth of 26.
+    # This row keeps the swap and only mis-slots the pads, which measures 7 --
+    # a milder wrong, and it does the same work so it is not faster at all.
+    # A milder mutation is a STRONGER test (it is closer to correct and still
+    # caught); the overclaim was the problem, not the row.
     ('pair-order-pads-always-side-a', 'po',
      """        m = (pair_metrics(state, ref, other, pose_a=pose, pads_a=pads)
              if ref < other
@@ -90,7 +100,8 @@ ROWS = [
      """        if self.facing_weight <= 0.0:
             return 0.0
         if exclude:""",
-     """        if False:
+     """        if self.facing_weight < 0.0:
+            return 0.0
         if exclude:""",
      (T_FACING,), KILLED),
 

--- a/tests/mutate_893_916.py
+++ b/tests/mutate_893_916.py
@@ -60,11 +60,21 @@ ROWS = [
      "        if len(own_nets & _part_net_set(state, other, state.parts[other])) < 3:",
      (T_EQUIV,), KILLED),
 
-    # The cached scoring-net set must be intersected, not ignored.
+    # SURVIVED, and the row is kept because the SURVIVAL is the finding: the
+    # intersection is a NO-OP by construction. `net_refs` is built FROM every
+    # part's nets (quench.py:985-989) and `part.nets` is filtered by
+    # `ignore_net_ids` earlier in that same constructor, so `part.nets` is
+    # always a subset of `net_refs`. Measured on esp_prog, tigard and ulx3s:
+    # 0 parts of 333 hold a net outside `net_refs`. The original expression
+    # this replaced -- `set(pa.nets) & set(pb.nets) & set(state.net_refs)` --
+    # was therefore doing a whole-board set build per call for nothing. The
+    # intersection is KEPT anyway, because `pair_metrics` accepts any
+    # duck-typed state and a caller's stand-in need not honour the invariant;
+    # the row records that no test can tell the difference on a real board.
     ('pair-order-part-net-set-ignores-scoring-nets', 'po',
      "        got = set(part.nets) & _scoring_net_ids(state)",
      "        got = set(part.nets)",
-     (T_EQUIV,), KILLED),
+     (T_EQUIV,), 'SURVIVED'),
 
     # ---- #893 facing term --------------------------------------------------
     # The early return is what makes a default run pay nothing AND keeps the

--- a/tests/mutate_893_916.py
+++ b/tests/mutate_893_916.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Mutation battery for #893 (declared rotation, facing term) and #916 (body model).
+
+Every row below breaks ONE claim the new gates make, and names the test that
+must notice. A row that SURVIVES is a hole in the tests, not a curiosity: it
+means the engine can be wrong in that exact way and the suite stays green.
+
+Two of these rows exist because the mistake was made for real during the work:
+
+* `facing-total-cost-sums-per-ref` -- the first draft of `total_cost` summed
+  `ref_inversions` over every ref, which double-counts every pair (measured on
+  esp_prog: 8 unordered, 16 per-ref).
+* `pair-order-pads-always-side-a` -- a draft of the `pad_globals` hoist always
+  passed the queried ref's pads as side A. It ran 6.7x faster and reported
+  ulx3s U2 as 358 inversions where the truth is 26, and it passed every test in
+  the tree at the time.
+
+Run: python3 -X utf8 tests/mutate_893_916.py [--verify-anchors]
+"""
+import os
+import shutil
+import subprocess
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+sys.path.insert(0, _TESTS)
+
+QUENCH = os.path.join(_ROOT, 'py_placer', 'placement', 'quench.py')
+PAIR_ORDER = os.path.join(_ROOT, 'py_placer', 'placement', 'pair_order.py')
+FLOORPLAN = os.path.join(_ROOT, 'py_placer', 'placement', 'floorplan.py')
+SEEDER = os.path.join(_ROOT, 'py_placer', 'placement', 'seeder.py')
+
+TARGETS = {'q': QUENCH, 'po': PAIR_ORDER, 'fp': FLOORPLAN, 'sd': SEEDER}
+
+T_EQUIV = os.path.join(_TESTS, 'test_893_pair_order_equivalence.py')
+T_FACING = os.path.join(_TESTS, 'test_893_facing_weight.py')
+T_ROT = os.path.join(_TESTS, 'test_893_declared_rotation.py')
+T_BODY = os.path.join(_TESTS, 'test_916_search_body_model.py')
+
+KILLED = 'KILLED'
+
+ROWS = [
+    # ---- #893 pair_order hot path ------------------------------------------
+    # The 6.7x-faster WRONG draft, reproduced exactly: hand the queried ref's
+    # pads to side A regardless of which slot it occupies.
+    ('pair-order-pads-always-side-a', 'po',
+     """        m = (pair_metrics(state, ref, other, pose_a=pose, pads_a=pads)
+             if ref < other
+             else pair_metrics(state, other, ref, pose_b=pose, pads_b=pads))""",
+     """        m = (pair_metrics(state, ref, other, pose_a=pose, pads_a=pads)
+             if ref < other
+             else pair_metrics(state, other, ref, pose_b=pose, pads_a=pads))""",
+     (T_EQUIV,), KILLED),
+
+    # The early-out must reproduce pair_metrics' own test. Off by one and it
+    # drops real scoring pairs.
+    ('pair-order-early-out-drops-two-net-pairs', 'po',
+     "        if len(own_nets & _part_net_set(state, other, state.parts[other])) < 2:",
+     "        if len(own_nets & _part_net_set(state, other, state.parts[other])) < 3:",
+     (T_EQUIV,), KILLED),
+
+    # The cached scoring-net set must be intersected, not ignored.
+    ('pair-order-part-net-set-ignores-scoring-nets', 'po',
+     "        got = set(part.nets) & _scoring_net_ids(state)",
+     "        got = set(part.nets)",
+     (T_EQUIV,), KILLED),
+
+    # ---- #893 facing term --------------------------------------------------
+    # The early return is what makes a default run pay nothing AND keeps the
+    # A/B's OFF arm a true control.
+    ('facing-no-early-return-at-zero', 'q',
+     """        if self.facing_weight <= 0.0:
+            return 0.0
+        return self.facing_weight * ref_inversions(self, ref, x, y, rot)""",
+     """        return self.facing_weight * ref_inversions(self, ref, x, y, rot)""",
+     (T_FACING,), KILLED),
+
+    # The real bug from the first draft: per-ref summation double-counts.
+    ('facing-total-cost-sums-per-ref', 'q',
+     """        facing = (self.facing_weight
+                  * sum(m['inversions']
+                        for m in pair_inversions(self).values())
+                  if self.facing_weight > 0.0 else 0.0)""",
+     """        facing = (self.facing_weight
+                  * sum(ref_inversions(self, r) for r in self.parts)
+                  if self.facing_weight > 0.0 else 0.0)""",
+     (T_FACING,), KILLED),
+
+    # Dropping the term from the objective entirely.
+    ('facing-not-in-part-geometry-cost', 'q',
+     "        pen += self._facing_cost(ref, x, y, rot)\n",
+     "",
+     (T_FACING,), KILLED),
+
+    # ---- #916 body model ---------------------------------------------------
+    # The OFF arm must be the inlined ladder. Arming it unconditionally is the
+    # "flip the default without measuring" mistake.
+    ('body-model-armed-unconditionally', 'q',
+     "        self.body_model = bool(body_model)",
+     "        self.body_model = True",
+     (T_BODY,), KILLED),
+
+    # The seat box must be OCCUPANCY, not the bare body -- taking body_local
+    # re-opens the grader/enforcer divergence in the SHRINKING direction.
+    ('body-model-uses-bare-body-not-occupancy', 'q',
+     "                if _geom.occupancy_local is not None:\n"
+     "                    body_locals[_ref] = _geom.occupancy_local",
+     "                if _geom.body_local is not None:\n"
+     "                    body_locals[_ref] = _geom.body_local",
+     (T_BODY,), KILLED),
+
+    # The declared body must actually win over the inlined ladder.
+    ('body-local-ignored-by-part', 'q',
+     "        lb = body_local\n        if lb is None:",
+     "        lb = None\n        if lb is None:",
+     (T_BODY,), KILLED),
+
+    # ---- #893 declared rotation -------------------------------------------
+    # Declaring both keys must be refused, not silently resolved.
+    ('rotation-both-keys-allowed', 'fp',
+     "        if b.get('rotation') is not None and b.get('rotation_candidates') is not None:",
+     "        if False:",
+     (T_ROT,), KILLED),
+
+    # An empty candidate set must be refused, not read as "no constraint".
+    ('rotation-empty-candidates-allowed', 'fp',
+     """    if not raw:
+        raise IntentError(
+            f"{where}: rotation_candidates is empty. An empty candidate set "
+            f"admits no pose at all; omit the key to leave the rotation free")""",
+     """    if not raw:
+        return ()""",
+     (T_ROT,), KILLED),
+
+    # A bool is an int subclass; letting it through makes `rotation: true` 1.0.
+    ('rotation-accepts-a-bool', 'fp',
+     "    if isinstance(raw, bool) or not isinstance(raw, (int, float)):",
+     "    if not isinstance(raw, (int, float)):",
+     (T_ROT,), KILLED),
+
+    # Angles must be normalised, or -90 never equals a declared 270.
+    ('rotation-not-normalised', 'fp',
+     "    return float(raw) % 360.0",
+     "    return float(raw)",
+     (T_ROT,), KILLED),
+
+    # Two blocks claiming one ref at different angles must not be resolved by
+    # last-writer-wins.
+    ('rotation-contradiction-silently-resolved', 'fp',
+     """            if prev is not None and prev != claim:
+                raise IntentError(""",
+     """            if False:
+                raise IntentError(""",
+     (T_ROT,), KILLED),
+
+    # The declared ladder must reach the seat search, or the claim is inert.
+    ('rotation-ladder-not-honoured', 'sd',
+     """            for rot in (list(rotations) if rotations is not None
+                        else [part.rot] + [(part.rot + d) % 360
+                                           for d in (90.0, 180.0, 270.0)]):""",
+     """            for rot in [part.rot] + [(part.rot + d) % 360
+                                     for d in (90.0, 180.0, 270.0)]:""",
+     (T_ROT,), KILLED),
+
+    # The candidate ORDER is load-bearing: the search keeps the first that fits.
+    ('rotation-candidate-order-sorted-away', 'fp',
+     '''            f"{where}: rotation_candidates has repeated angles {out!r}")
+    return tuple(out)''',
+     '''            f"{where}: rotation_candidates has repeated angles {out!r}")
+    return tuple(sorted(out))''',
+     (T_ROT,), KILLED),
+]
+
+from mutation_anchors import preflight   # noqa: E402
+preflight(__file__)
+
+
+def _git_clean(paths):
+    r = subprocess.run(['git', 'status', '--porcelain', '--'] + list(paths),
+                       cwd=_ROOT, capture_output=True, text=True)
+    return not r.stdout.strip()
+
+
+def main():
+    if not _git_clean(list(TARGETS.values())):
+        print('REFUSED: engine files are dirty; commit before mutating '
+              '(a battery restores from ITS OWN snapshot, and an interrupted '
+              'run has eaten uncommitted work here before)')
+        return 2
+
+    originals = {k: open(v, encoding='utf-8', newline='').read()
+                 for k, v in TARGETS.items()}
+    results = []
+    try:
+        for name, key, old, new, witnesses, expect in ROWS:
+            path = TARGETS[key]
+            src = originals[key]
+            if src.count(old) != 1:
+                results.append((name, 'BROKEN', 'anchor matches %d times'
+                                % src.count(old)))
+                continue
+            with open(path, 'w', encoding='utf-8', newline='') as fh:
+                fh.write(src.replace(old, new, 1))
+            got = 'SURVIVED'
+            for w in witnesses:
+                r = subprocess.run([sys.executable, '-X', 'utf8', w],
+                                   cwd=_ROOT, capture_output=True, text=True)
+                if r.returncode != 0:
+                    got = KILLED
+                    break
+            with open(path, 'w', encoding='utf-8', newline='') as fh:
+                fh.write(src)
+            results.append((name, got, 'expected %s' % expect))
+            print('%-46s %s' % (name, got))
+    finally:
+        for k, v in TARGETS.items():
+            with open(v, 'w', encoding='utf-8', newline='') as fh:
+                fh.write(originals[k])
+
+    bad = [r for r in results
+           if r[1] == 'BROKEN' or r[1] != dict(
+               (n, e) for n, _k, _o, _n2, _w, e in
+               [(x[0], x[1], x[2], x[3], x[4], x[5]) for x in ROWS])[r[0]]]
+    print()
+    print('%d row(s), %d killed, %d survived, %d broken'
+          % (len(results),
+             sum(1 for r in results if r[1] == KILLED),
+             sum(1 for r in results if r[1] == 'SURVIVED'),
+             sum(1 for r in results if r[1] == 'BROKEN')))
+    if bad:
+        for n, got, note in bad:
+            print('  DISAGREES %-42s got %s (%s)' % (n, got, note))
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutate_893_916.py
+++ b/tests/mutate_893_916.py
@@ -173,6 +173,20 @@ ROWS = [
                                      for d in (90.0, 180.0, 270.0)]:""",
      (T_ROT,), KILLED),
 
+    # A SECOND seating stage. The first version of this work threaded the
+    # declared ladder through 2 of 13 `_try_place` sites, so `must_lock`,
+    # decap and eviction seats silently used the fallback -- the very failure
+    # #893 removes, reintroduced by its own fix. Found in pre-push review;
+    # verified by reverting this one site, which places U1 at 0 despite a
+    # declared 90.
+    ('rotation-ladder-skipped-by-the-must-lock-stage', 'sd',
+     """        clr = _try_place(state, ref, part.x, part.y, unplaced - {ref},
+                         constraint=rect, tol=tol, info=info,
+                         rotations=_rot_ladder(ref))""",
+     """        clr = _try_place(state, ref, part.x, part.y, unplaced - {ref},
+                         constraint=rect, tol=tol, info=info)""",
+     (T_ROT,), KILLED),
+
     # The candidate ORDER is load-bearing: the search keeps the first that fits.
     ('rotation-candidate-order-sorted-away', 'fp',
      '''            f"{where}: rotation_candidates has repeated angles {out!r}")

--- a/tests/mutate_893_916.py
+++ b/tests/mutate_893_916.py
@@ -40,6 +40,13 @@ T_BODY = os.path.join(_TESTS, 'test_916_search_body_model.py')
 
 KILLED = 'KILLED'
 
+#: FOUR rows were RE-ANCHORED after the pre-push review changed the very lines
+#: they quote (`_facing_cost` gained an `exclude` branch, the seeder ladder
+#: became `_ladder_rots`, the early-out went through `other_part`). The
+#: pre-flight caught all four as STALE before the battery ran, which is the
+#: whole point of it: a stale row mutates nothing and every gate it names
+#: passes for free. Each still expresses the SAME mutation, never widened to
+#: whatever was convenient to quote (#877).
 ROWS = [
     # ---- #893 pair_order hot path ------------------------------------------
     # The 6.7x-faster WRONG draft, reproduced exactly: hand the queried ref's
@@ -56,8 +63,8 @@ ROWS = [
     # The early-out must reproduce pair_metrics' own test. Off by one and it
     # drops real scoring pairs.
     ('pair-order-early-out-drops-two-net-pairs', 'po',
-     "        if len(own_nets & _part_net_set(state, other, state.parts[other])) < 2:",
-     "        if len(own_nets & _part_net_set(state, other, state.parts[other])) < 3:",
+     "        if len(own_nets & _part_net_set(state, other, other_part)) < 2:",
+     "        if len(own_nets & _part_net_set(state, other, other_part)) < 3:",
      (T_EQUIV,), KILLED),
 
     # SURVIVED, and the row is kept because the SURVIVAL is the finding: the
@@ -82,8 +89,9 @@ ROWS = [
     ('facing-no-early-return-at-zero', 'q',
      """        if self.facing_weight <= 0.0:
             return 0.0
-        return self.facing_weight * ref_inversions(self, ref, x, y, rot)""",
-     """        return self.facing_weight * ref_inversions(self, ref, x, y, rot)""",
+        if exclude:""",
+     """        if False:
+        if exclude:""",
      (T_FACING,), KILLED),
 
     # The real bug from the first draft: per-ref summation double-counts.
@@ -99,7 +107,7 @@ ROWS = [
 
     # Dropping the term from the objective entirely.
     ('facing-not-in-part-geometry-cost', 'q',
-     "        pen += self._facing_cost(ref, x, y, rot)\n",
+     "        pen += self._facing_cost(ref, x, y, rot, exclude)\n",
      "",
      (T_FACING,), KILLED),
 
@@ -166,11 +174,11 @@ ROWS = [
 
     # The declared ladder must reach the seat search, or the claim is inert.
     ('rotation-ladder-not-honoured', 'sd',
-     """            for rot in (list(rotations) if rotations is not None
-                        else [part.rot] + [(part.rot + d) % 360
-                                           for d in (90.0, 180.0, 270.0)]):""",
-     """            for rot in [part.rot] + [(part.rot + d) % 360
-                                     for d in (90.0, 180.0, 270.0)]:""",
+     """            _ladder_rots = (list(rotations) if rotations is not None
+                            else [part.rot] + [(part.rot + d) % 360
+                                               for d in (90.0, 180.0, 270.0)])""",
+     """            _ladder_rots = ([part.rot] + [(part.rot + d) % 360
+                                          for d in (90.0, 180.0, 270.0)])""",
      (T_ROT,), KILLED),
 
     # A SECOND seating stage. The first version of this work threaded the

--- a/tests/placement_ab_baseline.json
+++ b/tests/placement_ab_baseline.json
@@ -1,8 +1,136 @@
 {
+ "body-esp_prog": {
+  "board": "esp_prog.kicad_pcb",
+  "mark": "regress",
+  "off": {
+   "body_advisory": 4,
+   "body_blocking": 0,
+   "crossings": 35,
+   "health_block_displacement_max_mm": null,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 262.75,
+   "intent_errors": 0,
+   "intent_errors_by_rule": {},
+   "intent_errors_enforced": 0,
+   "intent_errors_other": 0,
+   "inversions": 10
+  },
+  "on": {
+   "body_advisory": 4,
+   "body_blocking": 0,
+   "crossings": 43,
+   "health_block_displacement_max_mm": null,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 258.84,
+   "intent_errors": 0,
+   "intent_errors_by_rule": {},
+   "intent_errors_enforced": 0,
+   "intent_errors_other": 0,
+   "inversions": 8
+  }
+ },
+ "body-orangecrab": {
+  "board": "orangecrab_ext_pll.kicad_pcb",
+  "mark": "regress",
+  "off": {
+   "body_advisory": 16,
+   "body_blocking": 0,
+   "crossings": 1087,
+   "health_block_displacement_max_mm": 18.1954,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 2121.92,
+   "intent_errors": 1,
+   "intent_errors_by_rule": {
+    "zone_containment": 1
+   },
+   "intent_errors_enforced": 1,
+   "intent_errors_other": 0,
+   "inversions": 626
+  },
+  "on": {
+   "body_advisory": 14,
+   "body_blocking": 0,
+   "crossings": 1121,
+   "health_block_displacement_max_mm": 17.1986,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 2147.78,
+   "intent_errors": 0,
+   "intent_errors_by_rule": {},
+   "intent_errors_enforced": 0,
+   "intent_errors_other": 0,
+   "inversions": 637
+  }
+ },
+ "body-ulx3s": {
+  "board": "ulx3s.kicad_pcb",
+  "mark": "regress",
+  "off": {
+   "body_advisory": 41,
+   "body_blocking": 0,
+   "crossings": 2418,
+   "health_block_displacement_max_mm": 18.9597,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 7476.69,
+   "intent_errors": 3,
+   "intent_errors_by_rule": {
+    "zone_containment": 3
+   },
+   "intent_errors_enforced": 3,
+   "intent_errors_other": 0,
+   "inversions": 722
+  },
+  "on": {
+   "body_advisory": 38,
+   "body_blocking": 0,
+   "crossings": 2437,
+   "health_block_displacement_max_mm": 18.9597,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 7509.09,
+   "intent_errors": 4,
+   "intent_errors_by_rule": {
+    "zone_containment": 4
+   },
+   "intent_errors_enforced": 4,
+   "intent_errors_other": 0,
+   "inversions": 718
+  }
+ },
+ "body-watchy": {
+  "board": "watchy.kicad_pcb",
+  "mark": "improve",
+  "off": {
+   "body_advisory": 5,
+   "body_blocking": 0,
+   "crossings": 149,
+   "health_block_displacement_max_mm": null,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 777.13,
+   "intent_errors": 0,
+   "intent_errors_by_rule": {},
+   "intent_errors_enforced": 0,
+   "intent_errors_other": 0,
+   "inversions": 77
+  },
+  "on": {
+   "body_advisory": 4,
+   "body_blocking": 0,
+   "crossings": 147,
+   "health_block_displacement_max_mm": null,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 765.26,
+   "intent_errors": 0,
+   "intent_errors_by_rule": {},
+   "intent_errors_enforced": 0,
+   "intent_errors_other": 0,
+   "inversions": 82
+  }
+ },
  "corridor-coldfire": {
   "board": "kit-dev-coldfire-xilinx_5213.kicad_pcb",
   "mark": "improve",
   "off": {
+   "body_advisory": 0,
+   "body_blocking": 0,
    "crossings": 1384,
    "health_block_displacement_max_mm": 56.3849,
    "health_bus_foreign_crossings": 147,
@@ -10,9 +138,12 @@
    "intent_errors": 0,
    "intent_errors_by_rule": {},
    "intent_errors_enforced": 0,
-   "intent_errors_other": 0
+   "intent_errors_other": 0,
+   "inversions": 1392
   },
   "on": {
+   "body_advisory": 0,
+   "body_blocking": 0,
    "crossings": 1372,
    "health_block_displacement_max_mm": 55.4249,
    "health_bus_foreign_crossings": 144,
@@ -20,13 +151,16 @@
    "intent_errors": 0,
    "intent_errors_by_rule": {},
    "intent_errors_enforced": 0,
-   "intent_errors_other": 0
+   "intent_errors_other": 0,
+   "inversions": 1390
   }
  },
  "corridor-orangecrab": {
   "board": "orangecrab_ext_pll.kicad_pcb",
   "mark": "improve",
   "off": {
+   "body_advisory": 16,
+   "body_blocking": 0,
    "crossings": 1087,
    "health_block_displacement_max_mm": 18.1954,
    "health_bus_foreign_crossings": 33,
@@ -36,9 +170,12 @@
     "zone_containment": 1
    },
    "intent_errors_enforced": 1,
-   "intent_errors_other": 0
+   "intent_errors_other": 0,
+   "inversions": 626
   },
   "on": {
+   "body_advisory": 15,
+   "body_blocking": 0,
    "crossings": 1074,
    "health_block_displacement_max_mm": 18.1954,
    "health_bus_foreign_crossings": 31,
@@ -48,13 +185,16 @@
     "zone_containment": 1
    },
    "intent_errors_enforced": 1,
-   "intent_errors_other": 0
+   "intent_errors_other": 0,
+   "inversions": 638
   }
  },
  "corridor-ulx3s": {
   "board": "ulx3s.kicad_pcb",
   "mark": "regress",
   "off": {
+   "body_advisory": 41,
+   "body_blocking": 0,
    "crossings": 2418,
    "health_block_displacement_max_mm": 18.9597,
    "health_bus_foreign_crossings": 62,
@@ -64,9 +204,12 @@
     "zone_containment": 3
    },
    "intent_errors_enforced": 3,
-   "intent_errors_other": 0
+   "intent_errors_other": 0,
+   "inversions": 722
   },
   "on": {
+   "body_advisory": 46,
+   "body_blocking": 0,
    "crossings": 2438,
    "health_block_displacement_max_mm": 19.9557,
    "health_bus_foreign_crossings": 65,
@@ -76,13 +219,16 @@
     "zone_containment": 3
    },
    "intent_errors_enforced": 3,
-   "intent_errors_other": 0
+   "intent_errors_other": 0,
+   "inversions": 717
   }
  },
  "intent-exclusive-coldfire": {
   "board": "kit-dev-coldfire-xilinx_5213.kicad_pcb",
   "mark": "regress",
   "off": {
+   "body_advisory": 0,
+   "body_blocking": 0,
    "crossings": 1384,
    "health_block_displacement_max_mm": 56.3849,
    "health_bus_foreign_crossings": null,
@@ -92,9 +238,12 @@
     "zone_exclusive": 5
    },
    "intent_errors_enforced": 5,
-   "intent_errors_other": 0
+   "intent_errors_other": 0,
+   "inversions": 1392
   },
   "on": {
+   "body_advisory": 0,
+   "body_blocking": 0,
    "crossings": 1383,
    "health_block_displacement_max_mm": 55.4372,
    "health_bus_foreign_crossings": null,
@@ -104,13 +253,16 @@
     "zone_exclusive": 6
    },
    "intent_errors_enforced": 6,
-   "intent_errors_other": 0
+   "intent_errors_other": 0,
+   "inversions": 1392
   }
  },
  "intent-orangecrab": {
   "board": "orangecrab_ext_pll.kicad_pcb",
   "mark": "regress",
   "off": {
+   "body_advisory": 16,
+   "body_blocking": 0,
    "crossings": 1087,
    "health_block_displacement_max_mm": 18.1954,
    "health_bus_foreign_crossings": null,
@@ -120,9 +272,12 @@
     "zone_containment": 1
    },
    "intent_errors_enforced": 1,
-   "intent_errors_other": 0
+   "intent_errors_other": 0,
+   "inversions": 626
   },
   "on": {
+   "body_advisory": 15,
+   "body_blocking": 0,
    "crossings": 1065,
    "health_block_displacement_max_mm": 18.1954,
    "health_bus_foreign_crossings": null,
@@ -130,13 +285,16 @@
    "intent_errors": 0,
    "intent_errors_by_rule": {},
    "intent_errors_enforced": 0,
-   "intent_errors_other": 0
+   "intent_errors_other": 0,
+   "inversions": 651
   }
  },
  "intent-rp2350": {
   "board": "rp2350_fpga_eensy_prePlane.kicad_pcb",
   "mark": "improve",
   "off": {
+   "body_advisory": 7,
+   "body_blocking": 0,
    "crossings": 421,
    "health_block_displacement_max_mm": 11.286,
    "health_bus_foreign_crossings": null,
@@ -146,9 +304,12 @@
     "zone_containment": 3
    },
    "intent_errors_enforced": 3,
-   "intent_errors_other": 0
+   "intent_errors_other": 0,
+   "inversions": 355
   },
   "on": {
+   "body_advisory": 8,
+   "body_blocking": 0,
    "crossings": 416,
    "health_block_displacement_max_mm": 11.8051,
    "health_bus_foreign_crossings": null,
@@ -158,13 +319,16 @@
     "zone_containment": 1
    },
    "intent_errors_enforced": 1,
-   "intent_errors_other": 0
+   "intent_errors_other": 0,
+   "inversions": 347
   }
  },
  "intent-ulx3s": {
   "board": "ulx3s.kicad_pcb",
   "mark": "regress",
   "off": {
+   "body_advisory": 41,
+   "body_blocking": 0,
    "crossings": 2418,
    "health_block_displacement_max_mm": 18.9597,
    "health_bus_foreign_crossings": null,
@@ -174,9 +338,12 @@
     "zone_containment": 3
    },
    "intent_errors_enforced": 3,
-   "intent_errors_other": 0
+   "intent_errors_other": 0,
+   "inversions": 722
   },
   "on": {
+   "body_advisory": 42,
+   "body_blocking": 0,
    "crossings": 2438,
    "health_block_displacement_max_mm": 20.9521,
    "health_bus_foreign_crossings": null,
@@ -184,7 +351,8 @@
    "intent_errors": 0,
    "intent_errors_by_rule": {},
    "intent_errors_enforced": 0,
-   "intent_errors_other": 0
+   "intent_errors_other": 0,
+   "inversions": 721
   }
  }
 }

--- a/tests/test_549_floorplan_schema.py
+++ b/tests/test_549_floorplan_schema.py
@@ -130,7 +130,9 @@ KEY_SETS = {
     '_ENVELOPE_KEYS': {'rect', 'tolerance_mm'},
     '_DEFAULTS_KEYS': {'zone_tolerance_mm'},
     '_BLOCK_KEYS': {'name', 'group', 'refs', 'zone', 'side', 'exclusive',
-                    'tolerance_mm', 'note', 'context'},
+                    'tolerance_mm', 'note', 'context',
+                    # #893: a DECISION and a SET, never both on one block.
+                    'rotation', 'rotation_candidates'},
     '_KEEPOUT_KEYS': {'name', 'rect', 'circle', 'sides', 'allow', 'note',
                       'context'},
     '_EDGE_CONNECTOR_KEYS': {
@@ -241,9 +243,16 @@ def test_an_intent_using_every_known_key_loads():
         'board': 'b.kicad_pcb', 'min_reader': READER_VERSION,
         'envelope': {'rect': [0, 0, 100, 80], 'tolerance_mm': 0.4},
         'defaults': {'zone_tolerance_mm': 0.6},
+        # TWO blocks, for the same reason `edge_connectors` below carries two:
+        # #893's `rotation` (a decision) and `rotation_candidates` (a set the
+        # search may choose from) are mutually exclusive and are REFUSED on one
+        # block, so the vocabulary cannot be covered by a single entry.
         'blocks': [{'name': 'power', 'group': 'sheet:1', 'refs': ['U3'],
                     'zone': [2, 2, 40, 30], 'side': 'F', 'exclusive': True,
-                    'tolerance_mm': 0.7, 'note': 'n', 'context': {'why': 'w'}}],
+                    'tolerance_mm': 0.7, 'rotation': 90,
+                    'note': 'n', 'context': {'why': 'w'}},
+                   {'name': 'mcu', 'refs': ['U1'],
+                    'rotation_candidates': [0, 90, 180, 270]}],
         'keepouts': [{'name': 'k', 'rect': [0, 0, 6, 6], 'sides': ['F'],
                       'allow': ['MH1'], 'note': 'n', 'context': {'why': 'w'}},
                      {'name': 'k2', 'circle': [50, 5, 8], 'sides': ['F', 'B'],
@@ -290,7 +299,11 @@ def test_an_intent_using_every_known_key_loads():
     # Every key of every set must appear above, or this proves less than it
     # claims -- the point is coverage of the vocabulary, not of a sample.
     seen = set(raw) | set(raw['envelope']) | set(raw['defaults'])
-    seen |= set(raw['blocks'][0]) | set(raw['decaps']) | set(raw['health'])
+    # UNION over every block, not block [0] -- see the two-block comment in the
+    # fixture above; reading only the first would under-report the vocabulary.
+    for _b in raw['blocks']:
+        seen |= set(_b)
+    seen |= set(raw['decaps']) | set(raw['health'])
     seen |= set(raw['legality_budget'])
     # UNION over every entry, not entry [0]: the two #712 fields cannot share
     # one entry, so reading only the first would under-report the vocabulary.

--- a/tests/test_630_seeder_eviction.py
+++ b/tests/test_630_seeder_eviction.py
@@ -1004,10 +1004,16 @@ with tempfile.TemporaryDirectory() as wd:
     _real_trade = seeder._evict_trade
     fired = {'n': 0}
 
+    # **kwargs, not a fixed tail: this double shadows `_evict_trade`, so its
+    # signature is a second copy of that function's and drifts the moment the
+    # real one grows a parameter. #893 added `rot_ladder=` and this stub raised
+    # TypeError -- a test failing because the test is stale, which reads as a
+    # regression in the code under test. Forwarding whatever it is given keeps
+    # the double honest without pinning it to today's argument list.
     def _stacking_trade(state, ref, blockers, tx, ty, constraint, tol,
-                        blocker_zones, placed, unplaced):
+                        blocker_zones, placed, unplaced, **kw):
         rec = _real_trade(state, ref, blockers, tx, ty, constraint, tol,
-                          blocker_zones, placed, unplaced)
+                          blocker_zones, placed, unplaced, **kw)
         if rec['accepted']:
             fired['n'] += 1
             pr = state.parts[ref]

--- a/tests/test_712_edge_centering.py
+++ b/tests/test_712_edge_centering.py
@@ -414,15 +414,19 @@ def test_the_loader_refuses_every_malformed_along_edge_claim():
     # need a reader that knows them. The second is the change detector: a
     # hand-stated literal that fires when the vocabulary grows, so the bump is
     # re-stated deliberately rather than absorbed. It was 2 before #837 added
-    # `assembly.sides`, and 3 before #902 added `proximity[]` -- "these two
-    # named parts, this far apart", the one class of constraint the netlist
-    # implies and no instrument here could read.
+    # `assembly.sides`, 3 before #902 added `proximity[]` -- "these two named
+    # parts, this far apart", the one class of constraint the netlist implies
+    # and no instrument here could read -- and 4 before #893 added
+    # `blocks[].rotation` and `blocks[].rotation_candidates`, the ANGLE a part
+    # is placed at: the one placement decision a board file cannot hold AS a
+    # decision, since `(at x y rot)` records the angle a part HAS and nothing
+    # distinguishes a chosen one from a generator default.
     assert fp.READER_VERSION >= 2, (
         f"{fp.READER_VERSION}: #712's fields need a reader that knows them")
-    assert fp.READER_VERSION == 4, (
+    assert fp.READER_VERSION == 5, (
         f"{fp.READER_VERSION}: the field vocabulary grew. Re-state this "
-        f"literal and say which field arrived, the way #712, #837 and #902 "
-        f"did")
+        f"literal and say which field arrived, the way #712, #837, #902 and "
+        f"#893 did")
     # What this pair checks is the GATE -- a document may demand at most what
     # this build can serve. Written against `READER_VERSION` rather than a
     # literal 2/3, because the change-detector duty is already carried by the

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -953,8 +953,9 @@ _UNRESOLVABLE = {}
 #: Every `tests/mutate_*.py` in the tree, pinned. A resolver that quietly stops
 #: finding batteries would otherwise report a clean sweep over nothing -- the
 #: exact shape of the defect #877 is about, reproduced in its own gate.
-#: 42 before #902 added `mutate_902.py`; 43 before #892 added `mutate_892.py`.
-_BATTERY_COUNT = 45
+#: 42 before #902 added `mutate_902.py`; 43 before #892 added `mutate_892.py`;
+#: 45 before #893/#916 added `mutate_893_916.py`.
+_BATTERY_COUNT = 46
 
 #: A floor well under today's 831, not a target. Same purpose as
 #: `test_the_scanners_still_match_something`: prove the corpus is populated.

--- a/tests/test_837_assembly_sides.py
+++ b/tests/test_837_assembly_sides.py
@@ -508,11 +508,14 @@ def main():
     # 3 when #837 added `assembly.sides`; 4 since #902 added `proximity[]`.
     # Re-stated rather than loosened to `>= 3`: the literal IS the detector,
     # and this is the fourth one that bump had to move -- the others live in
-    # test_712_edge_centering, mutate_711 and mutate_837. It is also the only
+    # test_712_edge_centering, mutate_711 and mutate_837. (#893 took it to 5
+    # and had to move all four again, plus mutate_797, whose anchor a nearby
+    # insertion staled -- the pins are doing their job, which is to make a
+    # vocabulary change deliberate rather than absorbed.) It is also the only
     # one `run_all.py --fast` cannot see, because this file is classified
     # integration, so a red here reads as a green suite.
     check("reader version names the field it learned",
-          fp.READER_VERSION == 4, fp.READER_VERSION)
+          fp.READER_VERSION == 5, fp.READER_VERSION)
 
     check("graded every fixture", graded == len(EXPECT), f"{graded}")
     print(f"\n{'FAIL' if FAILURES else 'PASS'}: #837 census over {graded} "

--- a/tests/test_893_declared_rotation.py
+++ b/tests/test_893_declared_rotation.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""#893: an intent can DECLARE a rotation, and the seeder honours or refuses it.
+
+Before this, a rotation could not be written down anywhere the toolchain reads.
+`seeder.py`'s own module docstring said so -- "The intent schema cannot express a
+rotation, so a part whose rotation is a DECISION ... must be locked" -- and that
+advice costs the part its POSITION too, because the lock flag is one boolean
+covering both. Run 25 worked around it by rewriting the board before seeding.
+
+Two keys, and they mean different things on purpose:
+
+* `rotation` -- a DECISION. Honoured exactly. If no legal pose exists at it the
+  part is reported UNSEATED with the angle named, never quietly turned.
+* `rotation_candidates` -- a SET the search may choose from, in the author's
+  order, because the seat search keeps the FIRST pose that fits.
+
+Run: python3 -X utf8 tests/test_893_declared_rotation.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import run_utils  # noqa: E402
+
+ROOT = run_utils.ROOT_DIR
+for _sub in ('py_placer', 'py_router', 'py_tools'):
+    _p = os.path.join(ROOT, _sub)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+RUN_ALL_TIMEOUT = 900
+RUN_ALL_FAST_OK = True
+
+BOARD = 'esp_prog.kicad_pcb'
+
+TESTS = []
+
+
+def _intent(blocks, **top):
+    from placement import floorplan
+    doc = {'schema': 1, 'kind': 'floorplan-intent', 'units': 'mm',
+           'blocks': blocks}
+    doc.update(top)
+    return floorplan.intent_from_dict(doc)
+
+
+def test_the_schema_refuses_each_bad_shape_for_its_own_reason():
+    """A refusal that fires for the wrong reason is not a guard.
+
+    Each case asserts the MESSAGE, not merely that something raised -- an
+    unknown-key refusal firing on a typo would otherwise look like a working
+    validator.
+    """
+    from placement.floorplan import IntentError
+    cases = [
+        ({'name': 'x', 'refs': ['U1'], 'rotation': 0,
+          'rotation_candidates': [90]}, 'BOTH rotation and rotation_candidates'),
+        ({'name': 'x', 'refs': ['U1'], 'rotation': 'ninety'},
+         'expected a number of degrees'),
+        ({'name': 'x', 'refs': ['U1'], 'rotation': True},
+         'expected a number of degrees'),
+        ({'name': 'x', 'refs': ['U1'], 'rotation_candidates': []},
+         'admits no pose at all'),
+        ({'name': 'x', 'refs': ['U1'], 'rotation_candidates': [0, 360]},
+         'repeated angles'),
+        ({'name': 'x', 'refs': ['U1'], 'rotation_candidates': 90},
+         'expected a list of degrees'),
+    ]
+    for block, needle in cases:
+        try:
+            _intent([block])
+        except IntentError as exc:
+            assert needle in str(exc), (
+                'refused, but NOT for the stated reason. Expected %r in %r'
+                % (needle, str(exc)))
+        else:
+            raise AssertionError('no refusal for %r' % (block,))
+    print('  %d bad shapes each refused for their own reason' % len(cases))
+
+
+TESTS.append(test_the_schema_refuses_each_bad_shape_for_its_own_reason)
+
+
+def test_an_angle_is_normalised_and_order_is_preserved():
+    """KiCad writes -90 where this tool writes 270."""
+    i = _intent([{'name': 'a', 'refs': ['U1'], 'rotation': -90},
+                 {'name': 'b', 'refs': ['C*'],
+                  'rotation_candidates': [270, 0, 90]}])
+    assert i.blocks[0].rotation == 270.0, i.blocks[0].rotation
+    assert i.blocks[1].rotation_candidates == (270.0, 0.0, 90.0), (
+        'the author order was not preserved: %r'
+        % (i.blocks[1].rotation_candidates,))
+    print('  -90 -> 270.0, candidate order preserved')
+
+
+TESTS.append(test_an_angle_is_normalised_and_order_is_preserved)
+
+
+def test_two_blocks_claiming_one_ref_differently_is_refused():
+    """Globs overlap legitimately; contradictory angles do not."""
+    from kicad_parser import parse_kicad_pcb
+    from placement import floorplan
+    from placement.floorplan import IntentError
+    path = run_utils.evidence(os.path.join(ROOT, 'kicad_files', BOARD), 'board')
+    pcb = parse_kicad_pcb(path)
+    same = _intent([{'name': 'a', 'refs': ['U1'], 'rotation': 90},
+                    {'name': 'b', 'refs': ['U*'], 'rotation': 90}])
+    blocks, _ = floorplan.resolve_blocks(same, pcb, ('kicad', 'sheet'))
+    got = floorplan.rotations_for_ref(same, blocks)
+    assert got.get('U1') == (90.0, None), got.get('U1')
+
+    clash = _intent([{'name': 'a', 'refs': ['U1'], 'rotation': 90},
+                     {'name': 'b', 'refs': ['U*'], 'rotation': 180}])
+    blocks, _ = floorplan.resolve_blocks(clash, pcb, ('kicad', 'sheet'))
+    try:
+        floorplan.rotations_for_ref(clash, blocks)
+    except IntentError as exc:
+        assert 'different rotations' in str(exc), str(exc)
+    else:
+        raise AssertionError('two blocks claiming U1 at 90 and 180 was allowed')
+    print('  agreeing globs allowed; contradictory ones refused')
+
+
+TESTS.append(test_two_blocks_claiming_one_ref_differently_is_refused)
+
+
+def _seed(blocks):
+    import random
+    from kicad_parser import parse_kicad_pcb
+    from placement import seeder
+    path = run_utils.evidence(os.path.join(ROOT, 'kicad_files', BOARD), 'board')
+    pcb = parse_kicad_pcb(path)
+    return seeder.seed_from_intent(pcb, path, _intent(blocks),
+                                   random.Random('893'),
+                                   group_sources=('kicad', 'sheet')), pcb
+
+
+def test_a_declared_rotation_is_the_angle_that_is_placed():
+    """The whole point: the pose written carries the declared angle."""
+    ref = 'U1'
+    res, pcb = _seed([{'name': 'r', 'refs': [ref], 'rotation': 90}])
+    got = {p['reference']: p for p in res['placements']}
+    if ref in got:
+        assert abs((got[ref]['new_rotation'] % 360) - 90.0) < 1e-6, (
+            '%s was placed at %r, not the declared 90'
+            % (ref, got[ref]['new_rotation']))
+        print('  %s placed at the declared 90 deg' % ref)
+    else:
+        # Not placed by this stage is only acceptable if it was REFUSED, which
+        # is the other half of the contract -- never "kept its input angle".
+        assert ref in (res.get('rotation_unseated') or {}), (
+            '%s neither placed at the declared angle nor reported unseated -- '
+            'that is the silent-fallback failure #893 exists to remove' % ref)
+        print('  %s refused rather than silently kept (declared 90)' % ref)
+
+
+TESTS.append(test_a_declared_rotation_is_the_angle_that_is_placed)
+
+
+def test_an_unfittable_declaration_is_refused_by_name():
+    """A declared angle nothing can fit must surface AS that claim.
+
+    SELF-CALIBRATING, because the first version of this test was VACUOUS: it
+    declared 37 degrees on every part and every part fitted, so it asserted
+    nothing and said so. Here the zone is sized from the part's own geometry to
+    admit it at its input angle and refuse it turned 90 degrees, and the test
+    refuses to run if that separation does not exist on this board.
+    """
+    import random
+    from kicad_parser import parse_kicad_pcb
+    from placement import seeder
+    import pose_score
+
+    path = run_utils.evidence(os.path.join(ROOT, 'kicad_files', BOARD), 'board')
+    pcb = parse_kicad_pcb(path)
+    st = pose_score.make_state(pcb, path)
+
+    # Pick the part with the most lopsided body: the one where a 90-degree turn
+    # changes the footprint of the box the most.
+    best = None
+    for ref, part in st.parts.items():
+        b0 = part.bounds_by_rot.get(0.0)
+        b90 = part.bounds_by_rot.get(90.0)
+        if b0 is None or b90 is None:
+            continue
+        w0, h0 = b0[2] - b0[0], b0[3] - b0[1]
+        if w0 <= 0 or h0 <= 0:
+            continue
+        ratio = max(w0 / h0, h0 / w0)
+        if best is None or ratio > best[1]:
+            best = (ref, ratio, b0, b90)
+    assert best is not None, 'no part on %s has a usable body box' % BOARD
+    ref, ratio, b0, _ = best
+    assert ratio > 1.5, (
+        'the most lopsided part on %s is only %.2f:1, so no zone can admit it '
+        'at one angle and refuse it at another -- this board cannot exercise '
+        'the refusal' % (BOARD, ratio))
+
+    # A zone that fits the part's INPUT box with room, but is narrower than its
+    # long side, so the 90-degree pose cannot be contained.
+    part = st.parts[ref]
+    w, h = b0[2] - b0[0], b0[3] - b0[1]
+    short, long_ = min(w, h), max(w, h)
+    cx, cy = part.x, part.y
+    half_w, half_h = long_ * 0.6, short * 0.6
+    zone = [round(cx - half_w, 3), round(cy - half_h, 3),
+            round(cx + half_w, 3), round(cy + half_h, 3)]
+
+    fits = _intent([{'name': 'z', 'refs': [ref], 'zone': zone,
+                     'rotation': part.rot}])
+    turned = _intent([{'name': 'z', 'refs': [ref], 'zone': zone,
+                       'rotation': (part.rot + 90.0) % 360.0}])
+    ok = seeder.seed_from_intent(pcb, path, fits, random.Random('893'),
+                                 group_sources=('kicad', 'sheet'))
+    bad = seeder.seed_from_intent(pcb, path, turned, random.Random('893'),
+                                  group_sources=('kicad', 'sheet'))
+
+    assert ref not in (ok.get('rotation_unseated') or {}), (
+        '%s could not be seated even at its own angle in a zone sized for it, '
+        'so the turned arm proves nothing' % ref)
+    unseated = bad.get('rotation_unseated') or {}
+    assert ref in unseated, (
+        '%s was NOT refused at %g degrees in a zone too narrow for it -- it '
+        'was either turned silently or seated outside the claim, which is the '
+        'failure #893 exists to remove' % (ref, (part.rot + 90.0) % 360.0))
+    assert unseated[ref] == (part.rot + 90.0) % 360.0, unseated
+    placed = {p['reference']: p['new_rotation'] % 360
+              for p in bad['placements']}
+    assert abs(placed.get(ref, (part.rot + 90.0) % 360.0)
+               - (part.rot + 90.0) % 360.0) < 1e-6, (
+        '%s was placed at %r despite declaring %g'
+        % (ref, placed.get(ref), (part.rot + 90.0) % 360.0))
+    print('  %s (%.1f:1) fits its zone at %g deg, refused by name at %g'
+          % (ref, ratio, part.rot, (part.rot + 90.0) % 360.0))
+
+
+TESTS.append(test_an_unfittable_declaration_is_refused_by_name)
+
+
+def test_candidates_restrict_the_ladder():
+    """A candidate set must not admit an angle outside it."""
+    res, _ = _seed([{'name': 'r', 'refs': ['*'],
+                     'rotation_candidates': [0, 180]}])
+    bad = {p['reference']: p['new_rotation'] % 360
+           for p in res['placements']
+           if abs(p['new_rotation'] % 360) > 1e-6
+           and abs((p['new_rotation'] % 360) - 180.0) > 1e-6}
+    assert not bad, (
+        'placed outside the declared candidate set {0, 180}: %r'
+        % sorted(bad.items())[:5])
+    print('  every placed part took a declared candidate angle')
+
+
+TESTS.append(test_candidates_restrict_the_ladder)
+
+
+def test_no_declaration_leaves_the_seeder_unchanged():
+    """`rotations=None` must reproduce the pre-#893 ladder exactly."""
+    a, _ = _seed([{'name': 'z', 'refs': ['U1']}])
+    b, _ = _seed([{'name': 'z', 'refs': ['U1']}])
+    pa = {p['reference']: (round(p['new_x'], 6), round(p['new_y'], 6),
+                           p['new_rotation'] % 360) for p in a['placements']}
+    pb = {p['reference']: (round(p['new_x'], 6), round(p['new_y'], 6),
+                           p['new_rotation'] % 360) for p in b['placements']}
+    assert pa == pb, 'an undeclared seed is not deterministic'
+    assert not (a.get('rotation_unseated') or {}), a.get('rotation_unseated')
+    print('  an undeclared seed is deterministic and claims nothing')
+
+
+TESTS.append(test_no_declaration_leaves_the_seeder_unchanged)
+
+
+def main():
+    failures = 0
+    for fn in TESTS:
+        print('%s ...' % fn.__name__)
+        try:
+            fn()
+        except AssertionError as exc:
+            failures += 1
+            print('FAIL %s: %s' % (fn.__name__, exc))
+    if failures:
+        print('%d/%d checks FAILED' % (failures, len(TESTS)))
+        return 1
+    print('all %d checks passed' % len(TESTS))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_893_declared_rotation.py
+++ b/tests/test_893_declared_rotation.py
@@ -16,6 +16,8 @@ Two keys, and they mean different things on purpose:
 
 Run: python3 -X utf8 tests/test_893_declared_rotation.py
 """
+import ast
+import io
 import os
 import sys
 
@@ -300,6 +302,49 @@ def test_every_seating_stage_honours_the_declaration():
 
 
 TESTS.append(test_every_seating_stage_honours_the_declaration)
+
+
+def test_every_try_place_site_passes_a_rotation_ladder():
+    """A STANDING gate: no seating site may quietly use the fallback.
+
+    The behavioural tests above can only cover the stages a fixture happens to
+    reach, and that is exactly how this was missed twice -- first 2 of 13 sites
+    were threaded, then 8 of 13, and both times the suite was green because no
+    intent in it declared a lock, a decap rule, or an eviction. A new stage
+    added next year would repeat it.
+
+    So this reads the SOURCE and requires every `_try_place` call to pass
+    `rotations=`. It is a shape assertion, not a grep for a comment: it parses
+    the file and checks the keyword is present in each call's arguments, so a
+    mention in prose cannot satisfy it.
+    """
+    import ast
+    src_path = os.path.join(ROOT, 'py_placer', 'placement', 'seeder.py')
+    src = io.open(src_path, encoding='utf-8').read()
+    tree = ast.parse(src)
+    missing = []
+    total = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        if not (isinstance(fn, ast.Name) and fn.id == '_try_place'):
+            continue
+        total += 1
+        if not any(kw.arg == 'rotations' for kw in node.keywords):
+            missing.append(node.lineno)
+    assert total >= 10, (
+        'only %d `_try_place` call(s) found in seeder.py -- this gate is not '
+        'looking at what it thinks it is' % total)
+    assert not missing, (
+        '%d of %d `_try_place` call(s) do not pass `rotations=`, at line(s) %r. '
+        'A seating site that omits it uses the FALLBACK ladder and can turn a '
+        'part whose rotation was DECLARED -- silently, which is the failure '
+        '#893 exists to remove.' % (len(missing), total, missing))
+    print('  all %d _try_place call sites pass a rotation ladder' % total)
+
+
+TESTS.append(test_every_try_place_site_passes_a_rotation_ladder)
 
 
 def test_no_declaration_leaves_the_seeder_unchanged():

--- a/tests/test_893_declared_rotation.py
+++ b/tests/test_893_declared_rotation.py
@@ -254,6 +254,54 @@ def test_candidates_restrict_the_ladder():
 TESTS.append(test_candidates_restrict_the_ladder)
 
 
+def test_every_seating_stage_honours_the_declaration():
+    """The claim is about the SEEDER, not about one stage of it.
+
+    `seed_from_intent` seats parts from several stages, and `_try_place` is
+    called from 13 sites. The first version of this work threaded the declared
+    ladder through TWO of them, so a part seated by stage 1.5 (`must_lock`),
+    stage 2.5 (the decap seats) or the eviction rung took the FALLBACK ladder
+    and could be turned silently -- the exact failure #893 exists to remove,
+    reintroduced by the fix for it. The tests above did not catch it because
+    their intents declared no locks and no decap rules, so those stages never
+    ran.
+
+    This exercises them together: a `must_lock` part, a decap rule, and a zone,
+    all with one declared angle over every ref. Nothing may be placed at any
+    other angle.
+    """
+    import random
+    from kicad_parser import parse_kicad_pcb
+    from placement import seeder
+
+    path = run_utils.evidence(os.path.join(ROOT, 'kicad_files', BOARD), 'board')
+    pcb = parse_kicad_pcb(path)
+    angle = 90.0
+    intent = _intent(
+        [{'name': 'all', 'refs': ['*'], 'rotation': angle}],
+        must_lock=['U1'],
+        decaps={'max_distance_mm': 3.0},
+    )
+    res = seeder.seed_from_intent(pcb, path, intent, random.Random('893'),
+                                  group_sources=('kicad', 'sheet'),
+                                  decap_owner_chips=True)
+    wrong = {p['reference']: p['new_rotation'] % 360
+             for p in res['placements']
+             if abs((p['new_rotation'] % 360) - angle) > 1e-6}
+    assert not wrong, (
+        'placed at an angle other than the declared %g with must_lock and '
+        'decap stages live: %r -- a seating stage is not honouring the '
+        'declared ladder' % (angle, sorted(wrong.items())[:5]))
+    # And the stages must actually have RUN, or this proves nothing.
+    assert res['placements'] or res['unseated'], (
+        'the seeder neither placed nor refused anything, so no stage ran')
+    print('  %d placed, %d unseated, none turned away from %g deg'
+          % (len(res['placements']), len(res['unseated']), angle))
+
+
+TESTS.append(test_every_seating_stage_honours_the_declaration)
+
+
 def test_no_declaration_leaves_the_seeder_unchanged():
     """`rotations=None` must reproduce the pre-#893 ladder exactly."""
     a, _ = _seed([{'name': 'z', 'refs': ['U1']}])

--- a/tests/test_893_declared_rotation.py
+++ b/tests/test_893_declared_rotation.py
@@ -304,6 +304,58 @@ def test_every_seating_stage_honours_the_declaration():
 TESTS.append(test_every_seating_stage_honours_the_declaration)
 
 
+def test_a_declared_rotation_survives_the_quench():
+    """The seeder honouring it once is not enough -- the next step must too.
+
+    `place_seed` is followed by `place_optimize` / `place_route_loop` in every
+    chain, and the quench turns unlocked parts freely. Before this the module
+    docstring told authors to declare a rotation INSTEAD of locking the part,
+    while locking was the only thing that had ever protected the angle -- so
+    the replacement was strictly WEAKER than the advice it replaced, against
+    the very U3 case it cites. Found in pre-push review.
+
+    The declaration reaches the quench through the intent gate, so this drives
+    the real `resolve_intent_gate` rather than hand-building a map.
+    """
+    from kicad_parser import parse_kicad_pcb
+    from placement import floorplan
+    from placement.quench import quench, _candidate_rotations, QuenchState
+
+    path = run_utils.evidence(os.path.join(ROOT, 'kicad_files', BOARD), 'board')
+    pcb = parse_kicad_pcb(path)
+    intent = _intent([{'name': 'r', 'refs': ['R*'], 'rotation': 90}])
+    gate, _problems = floorplan.resolve_intent_gate(intent, pcb,
+                                                    ('kicad', 'sheet'))
+    assert gate.get('rotations'), (
+        'resolve_intent_gate carried no rotations, so the quench cannot see '
+        'the declaration however well it handles one')
+
+    st = QuenchState(pcb, path, 0.2, 0.55, 30.0, 0.5, 0.15, 2.0, 2.0, 2.0,
+                     0.1, 0.3, declared_rotations=gate['rotations'])
+    declared = [r for r in sorted(st.parts) if r in gate['rotations']]
+    assert declared, 'no part on %s matched R*, so nothing is declared' % BOARD
+    for ref in declared:
+        got = _candidate_rotations(st.parts[ref], True,
+                                   st.declared_rotations.get(ref))
+        assert got == [90.0], (
+            '%s: the quench offers %r, so it can still turn a part whose '
+            'rotation was declared' % (ref, got))
+    # And an UNDECLARED part must keep its full lattice, or this has broken
+    # the optimizer for every board that declares nothing.
+    other = [r for r in sorted(st.parts) if r not in gate['rotations']]
+    assert other, 'every part is declared; cannot check the undeclared arm'
+    free = _candidate_rotations(st.parts[other[0]], True,
+                                st.declared_rotations.get(other[0]))
+    assert len(free) >= 4, (
+        '%s is undeclared but was offered only %r -- the declaration leaked '
+        'onto parts nobody claimed' % (other[0], free))
+    print('  %d declared part(s) pinned to 90 deg; %s keeps %d rotations'
+          % (len(declared), other[0], len(free)))
+
+
+TESTS.append(test_a_declared_rotation_survives_the_quench)
+
+
 def test_every_try_place_site_passes_a_rotation_ladder():
     """A STANDING gate: no seating site may quietly use the fallback.
 

--- a/tests/test_893_facing_weight.py
+++ b/tests/test_893_facing_weight.py
@@ -147,6 +147,39 @@ def test_it_sees_order_where_orient_weight_cannot():
 TESTS.append(test_it_sees_order_where_orient_weight_cannot)
 
 
+def test_part_geometry_cost_carries_the_term():
+    """The hook the MOVE LOOP reads, which `total_cost` does not prove.
+
+    A mutation that deleted `pen += self._facing_cost(...)` from
+    `part_geometry_cost` SURVIVED the first run of this file: `total_cost`
+    computes its own facing component from `pair_inversions`, and
+    `_facing_cost` was only ever called directly. So every assertion here
+    passed while the term reached no move the optimizer actually makes -- the
+    term would have been inert exactly where it is supposed to act.
+    """
+    off = _state()
+    on = _state(facing_weight=1.0)
+    moved = []
+    for ref in sorted(off.parts):
+        a = off.part_geometry_cost(ref)
+        b = on.part_geometry_cost(ref)
+        if abs(a - b) > 1e-9:
+            moved.append(ref)
+    assert moved, (
+        'no part geometry cost changed with facing_weight=1.0, so the term '
+        'does not reach part_geometry_cost -- the one function the nudge, '
+        'group and swap evaluators all call')
+    for ref in moved:
+        gap = on.part_geometry_cost(ref) - off.part_geometry_cost(ref)
+        assert abs(gap - on._facing_cost(ref)) < 1e-9, (
+            '%s: part_geometry_cost moved by %r but _facing_cost is %r'
+            % (ref, gap, on._facing_cost(ref)))
+    print('  part_geometry_cost carries the term on %d part(s)' % len(moved))
+
+
+TESTS.append(test_part_geometry_cost_carries_the_term)
+
+
 def test_total_cost_counts_each_pair_once():
     """`ref_inversions` summed over refs would double every pair.
 

--- a/tests/test_893_facing_weight.py
+++ b/tests/test_893_facing_weight.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""#893: the pin-order facing term, and the two things that make it safe.
+
+`--facing-weight` prices the pin ORDER a pose forces, via
+`pair_order.ref_inversions` -- the same lower bound `placement_score` reports,
+CALLED rather than re-derived.
+
+Two assertions carry this file, and they are opposites:
+
+* **At 0.0 the objective is BIT-IDENTICAL.** This is not a nicety. The weight is
+  the OFF arm of every A/B that will ever judge the term, so a leak at 0.0 makes
+  the control arm not a control, and every number measured against it is void.
+* **At a non-zero weight it actually BITES**, and specifically it must see
+  something `--orient-weight` cannot. Otherwise the honest thing is to delete it
+  and tell people to use the term that already exists.
+
+The second is the interesting one. `_orient_cost` already "rewards a pose whose
+pads FACE the nets they serve", so a reviewer's first question is what this buys.
+The answer is ORDER: `_orient_cost` sums a direction per pad against a net
+centroid and is blind to whether the nets cross. Two parts can point their pads
+straight at each other with every net inverted -- run 5's U3, where a 180-degree
+rotation took the same nets from 4/7 routed to 7/7 while airwire lengths barely
+moved. `test_pair_order.py` pins that case; this file pins that the COST built
+on it inherits the discrimination.
+
+Run: python3 -X utf8 tests/test_893_facing_weight.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import run_utils  # noqa: E402
+
+ROOT = run_utils.ROOT_DIR
+for _sub in ('py_placer', 'py_router', 'py_tools'):
+    _p = os.path.join(ROOT, _sub)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+RUN_ALL_TIMEOUT = 900
+RUN_ALL_FAST_OK = True
+
+BOARD = 'esp_prog.kicad_pcb'
+
+TESTS = []
+
+
+def _state(**kw):
+    from kicad_parser import parse_kicad_pcb
+    from placement.quench import QuenchState
+    path = run_utils.evidence(os.path.join(ROOT, 'kicad_files', BOARD),
+                              'corpus board')
+    pcb = parse_kicad_pcb(path)
+    return QuenchState(pcb, path, 0.2, 0.55, 30.0, 0.5, 0.15, 2.0, 2.0, 2.0,
+                       0.1, 0.3, **kw)
+
+
+def test_weight_zero_is_bit_identical():
+    """Every cost component, and every per-part geometry cost."""
+    off = _state()
+    on = _state(facing_weight=0.0)
+    a, b = off.total_cost(), on.total_cost()
+    assert set(a) == set(b), 'the cost dict keys differ: %r vs %r' % (
+        sorted(a), sorted(b))
+    for k in sorted(a):
+        assert a[k] == b[k], (
+            'total_cost[%r] differs at facing_weight=0.0: %r != %r' % (k, a[k], b[k]))
+    for ref in sorted(off.parts):
+        ga = off.part_geometry_cost(ref)
+        gb = on.part_geometry_cost(ref)
+        assert ga == gb, (
+            'part_geometry_cost(%s) differs at facing_weight=0.0: %r != %r'
+            % (ref, ga, gb))
+    assert a.get('facing') == 0.0, (
+        'the facing component must be exactly 0.0 when the weight is 0, not %r'
+        % (a.get('facing'),))
+    print('  total_cost and %d per-part costs bit-identical at 0.0'
+          % len(off.parts))
+
+
+TESTS.append(test_weight_zero_is_bit_identical)
+
+
+def test_the_term_returns_before_touching_geometry_at_zero():
+    """The early return is what makes a default run pay nothing.
+
+    Asserted by CALLING it on a state whose parts dict would raise if walked,
+    rather than by reading the source -- a source grep is satisfiable by a
+    comment (and this repo has been bitten by exactly that).
+    """
+    st = _state()
+    ref = sorted(st.parts)[0]
+    saved = st.net_refs
+    st.net_refs = None          # any real walk raises TypeError
+    try:
+        got = st._facing_cost(ref)
+    finally:
+        st.net_refs = saved
+    assert got == 0.0, 'expected 0.0 from the early return, got %r' % (got,)
+    print('  _facing_cost returns 0.0 without walking anything')
+
+
+TESTS.append(test_the_term_returns_before_touching_geometry_at_zero)
+
+
+def test_a_nonzero_weight_changes_the_objective():
+    st = _state(facing_weight=1.0)
+    cost = st.total_cost()
+    assert cost.get('facing', 0.0) > 0.0, (
+        'facing_weight=1.0 priced 0.0 on %s -- the term is inert, so no A/B on '
+        'it could measure anything' % BOARD)
+    base = _state().total_cost()
+    assert cost['total'] > base['total'], (
+        'the armed total (%r) is not above the unarmed one (%r)'
+        % (cost['total'], base['total']))
+    print('  facing component %.1f on %s' % (cost['facing'], BOARD))
+
+
+TESTS.append(test_a_nonzero_weight_changes_the_objective)
+
+
+def test_it_sees_order_where_orient_weight_cannot():
+    """The U3 case, as a COST rather than as a metric.
+
+    A part is rotated 180 degrees. `_facing_cost` must change; `_orient_cost`
+    is allowed to change too, but the point is that a rotation exists where
+    facing discriminates. Without this, `--facing-weight` is a slower spelling
+    of `--orient-weight`.
+    """
+    st = _state(facing_weight=1.0, orient_weight=1.0)
+    discriminating = []
+    for ref in sorted(st.parts):
+        p = st.parts[ref]
+        rot = (p.rot + 180.0) % 360.0
+        f0 = st._facing_cost(ref, p.x, p.y, p.rot)
+        f1 = st._facing_cost(ref, p.x, p.y, rot)
+        if abs(f1 - f0) > 1e-9:
+            discriminating.append((ref, f0, f1))
+    assert discriminating, (
+        'no part on %s changes its facing cost under a 180-degree rotation, so '
+        'this board cannot show the term works and the test asserts nothing'
+        % BOARD)
+    print('  %d part(s) change facing cost under rot+180, e.g. %s %.1f -> %.1f'
+          % (len(discriminating), *discriminating[0]))
+
+
+TESTS.append(test_it_sees_order_where_orient_weight_cannot)
+
+
+def test_total_cost_counts_each_pair_once():
+    """`ref_inversions` summed over refs would double every pair.
+
+    `total_cost` must use `pair_inversions` (unordered). The check is that the
+    reported component equals the unordered sum and NOT twice it -- the exact
+    bug the `align` block at the same site documents having avoided.
+    """
+    from placement.pair_order import pair_inversions, ref_inversions
+    st = _state(facing_weight=1.0)
+    unordered = sum(m['inversions'] for m in pair_inversions(st).values())
+    per_ref = sum(ref_inversions(st, r) for r in st.parts)
+    reported = st.total_cost()['facing']
+    assert abs(reported - unordered) < 1e-9, (
+        'total_cost reported %r; the unordered pair sum is %r'
+        % (reported, unordered))
+    if unordered:
+        assert abs(per_ref - 2 * unordered) < 1e-9, (
+            'the per-ref sum (%r) is not twice the unordered sum (%r), so this '
+            'test is not actually discriminating the double count'
+            % (per_ref, unordered))
+        assert abs(reported - per_ref) > 1e-9, (
+            'reported == the per-ref sum, i.e. every pair is counted twice')
+    print('  facing counts each pair once (%d unordered, %d per-ref)'
+          % (unordered, per_ref))
+
+
+TESTS.append(test_total_cost_counts_each_pair_once)
+
+
+def main():
+    failures = 0
+    for fn in TESTS:
+        print('%s ...' % fn.__name__)
+        try:
+            fn()
+        except AssertionError as exc:
+            failures += 1
+            print('FAIL %s: %s' % (fn.__name__, exc))
+    if failures:
+        print('%d/%d checks FAILED' % (failures, len(TESTS)))
+        return 1
+    print('all %d checks passed' % len(TESTS))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_893_pair_order_equivalence.py
+++ b/tests/test_893_pair_order_equivalence.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""The pair_order hoists are an OPTIMISATION: every number must be identical.
+
+`pair_order` had two pose-invariant rebuilds on its hot path -- `set(state.net_refs)`
+per call, and the moving part's whole `pad_globals` transform once per PARTNER. Both
+are hoisted so the pin-facing cost can be evaluated inside a search loop at all.
+
+This file exists because a speed-up that moves an inversion count is worse than no
+speed-up: every measurement downstream of it -- the A/B baseline, `placement_score`'s
+`pin_order_crossings`, `pose_score`'s ranking -- would be silently rebased on a
+different number. A draft of the pad hoist that always treated the queried ref as
+side A was 6.7x faster and reported ulx3s U2 as **358** inversions where the truth is
+26, because `pair_metrics` builds `order_a` from the FIRST ref's pads and takes its
+channel axis as `b - a`. That draft passed every existing test in the tree.
+
+So the assertion here is not "the suite is green". It is: for every ref on every
+board, recomputing WITHOUT the hoists gives the same integer, and for every PAIR,
+the full metrics dict is equal field for field.
+
+Run: python3 -X utf8 tests/test_893_pair_order_equivalence.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import run_utils  # noqa: E402
+
+ROOT = run_utils.ROOT_DIR
+for _sub in ('py_placer', 'py_router', 'py_tools'):
+    _p = os.path.join(ROOT, _sub)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+RUN_ALL_TIMEOUT = 600
+RUN_ALL_FAST_OK = True
+
+#: Small, medium and large: the per-call cost and the partner-set size both grow
+#: with the board, and the pad hoist only pays on parts with many partners. A
+#: one-board check would not have caught the draft described above -- esp_prog
+#: showed 2 differing refs, ulx3s 3.
+BOARDS = ('esp_prog.kicad_pcb', 'tigard.kicad_pcb', 'ulx3s.kicad_pcb')
+
+TESTS = []
+
+
+def _state(board_name):
+    from kicad_parser import parse_kicad_pcb
+    import pose_score
+    path = run_utils.evidence(os.path.join(ROOT, 'kicad_files', board_name),
+                              'corpus board')
+    pcb = parse_kicad_pcb(path)
+    return pose_score.make_state(pcb, path)
+
+
+def _reference_escape_pads(part, nets, toward_xy, pose=None):
+    """`_escape_pads` as it stood BEFORE the hoists, transcribed.
+
+    Deliberately a transcription and not a call: the point is to compare the
+    shipped implementation against an independent one. It is short enough that
+    the transcription is auditable by eye.
+    """
+    x, y, rot = pose if pose is not None else (part.x, part.y, part.rot)
+    tx, ty = toward_xy
+    best = {}
+    for gx, gy, nid in part.pad_globals(x, y, rot):
+        if nid not in nets:
+            continue
+        d = (gx - tx) ** 2 + (gy - ty) ** 2
+        cur = best.get(nid)
+        if cur is None or (d, gx, gy) < cur:
+            best[nid] = (d, gx, gy)
+    return {nid: (gx, gy) for nid, (_, gx, gy) in best.items()}
+
+
+def _reference_ref_inversions(state, ref):
+    """`ref_inversions` computed with NO caches and NO hoisted pads."""
+    from placement import pair_order as PO
+    part = state.parts.get(ref)
+    if part is None:
+        return 0
+    partners = set()
+    for nid in part.nets:
+        partners.update(state.net_refs.get(nid, ()))
+    partners.discard(ref)
+    total = 0
+    for other in sorted(partners):
+        a, b = (ref, other) if ref < other else (other, ref)
+        pa, pb = state.parts[a], state.parts[b]
+        shared = sorted(set(pa.nets) & set(pb.nets) & set(state.net_refs))
+        if len(shared) < 2:
+            continue
+        import math
+        ax, ay = pa.x, pa.y
+        bx, by = pb.x, pb.y
+        ux, uy = bx - ax, by - ay
+        n = math.hypot(ux, uy)
+        if n < 1e-9:
+            continue
+        vx, vy = -uy / n, ux / n
+        ea = _reference_escape_pads(pa, set(shared), (bx, by))
+        eb = _reference_escape_pads(pb, set(shared), (ax, ay))
+        common = [nid for nid in shared if nid in ea and nid in eb]
+        if len(common) < 2:
+            continue
+        order_a = sorted(common,
+                         key=lambda i: (ea[i][0] * vx + ea[i][1] * vy, i))
+        rank_b = {nid: i for i, nid in enumerate(
+            sorted(common, key=lambda i: (eb[i][0] * vx + eb[i][1] * vy, i)))}
+        total += PO._merge_count([rank_b[nid] for nid in order_a])
+    return total
+
+
+def test_ref_inversions_identical_per_ref():
+    """Per REF, not summed. A sum can cancel two opposite errors."""
+    from placement import pair_order as PO
+    for board in BOARDS:
+        st = _state(board)
+        bad = []
+        for ref in sorted(st.parts):
+            got = PO.ref_inversions(st, ref)
+            want = _reference_ref_inversions(st, ref)
+            if got != want:
+                bad.append((ref, got, want))
+        assert not bad, (
+            '%s: %d ref(s) disagree with the un-hoisted reference, e.g. %r'
+            % (board, len(bad), bad[:5]))
+        print('  %-28s %3d refs identical' % (board, len(st.parts)))
+
+
+TESTS.append(test_ref_inversions_identical_per_ref)
+
+
+def test_pair_metrics_dict_identical_field_for_field():
+    """The whole dict, including `lis`, `nets` and #891's `ties`.
+
+    `ref_inversions` reads only `inversions`, so an equality check through it
+    alone would not notice the hoist corrupting a field some OTHER consumer
+    reads -- `placement_score.pin_order_crossings` reads `inversions`, but
+    `pair_length` and the review sheet read the rest.
+    """
+    from placement import pair_order as PO
+    st = _state('tigard.kicad_pcb')
+    refs = sorted(st.parts)
+    checked = 0
+    for i, a in enumerate(refs):
+        for b in refs[i + 1:]:
+            with_pads = PO.pair_metrics(
+                st, a, b, pads_a=PO.part_pad_globals(st.parts[a]),
+                pads_b=PO.part_pad_globals(st.parts[b]))
+            without = PO.pair_metrics(st, a, b)
+            assert with_pads == without, (
+                'tigard %s~%s: hoisted pads changed the metrics: %r != %r'
+                % (a, b, with_pads, without))
+            if without is not None:
+                checked += 1
+    assert checked >= 20, (
+        'only %d scoring pairs on tigard -- this assertion is close to vacuous;'
+        ' pick a board with more shared-net pairs' % checked)
+    print('  tigard: %d scoring pairs identical field for field' % checked)
+
+
+TESTS.append(test_pair_metrics_dict_identical_field_for_field)
+
+
+def test_hoisted_pads_at_a_hypothetical_pose():
+    """The hoist must also hold at a pose the part is NOT at.
+
+    This is the case the search actually uses -- `ref_inversions(state, ref, x,
+    y, rot)` -- and the one where a stale pad cache would show up. Rotating by
+    90 degrees is the move #893 is about.
+    """
+    from placement import pair_order as PO
+    st = _state('esp_prog.kicad_pcb')
+    moved = 0
+    for ref in sorted(st.parts):
+        part = st.parts[ref]
+        rot = (part.rot + 90.0) % 360.0
+        got = PO.ref_inversions(st, ref, part.x, part.y, rot)
+        # Recompute by actually moving the part, then restore.
+        x0, y0, r0 = part.x, part.y, part.rot
+        st.apply_move(ref, part.x, part.y, rot)
+        try:
+            want = _reference_ref_inversions(st, ref)
+        finally:
+            st.apply_move(ref, x0, y0, r0)
+        assert got == want, (
+            'esp_prog %s at rot %g: hypothetical-pose inversions %r != %r '
+            'measured after actually applying the move'
+            % (ref, rot, got, want))
+        if got:
+            moved += 1
+    assert moved >= 1, (
+        'no part on esp_prog reports a non-zero inversion count at rot+90, so '
+        'this test compared zeroes and asserted nothing')
+    print('  esp_prog: rot+90 hypothetical poses match applied poses '
+          '(%d non-zero)' % moved)
+
+
+TESTS.append(test_hoisted_pads_at_a_hypothetical_pose)
+
+
+def test_caches_are_not_shared_between_states():
+    """Two states over different boards must not see each other's caches."""
+    from placement import pair_order as PO
+    a = _state('esp_prog.kicad_pcb')
+    b = _state('tigard.kicad_pcb')
+    ids_a = PO._scoring_net_ids(a)
+    ids_b = PO._scoring_net_ids(b)
+    assert ids_a is not ids_b, 'the scoring-net cache is shared between states'
+    assert PO._scoring_net_ids(a) is ids_a, 'the cache is not sticky'
+    print('  caches are per-state and sticky')
+
+
+TESTS.append(test_caches_are_not_shared_between_states)
+
+
+def main():
+    failures = 0
+    for fn in TESTS:
+        print('%s ...' % fn.__name__)
+        try:
+            fn()
+        except AssertionError as exc:
+            failures += 1
+            print('FAIL %s: %s' % (fn.__name__, exc))
+    if failures:
+        print('%d/%d checks FAILED' % (failures, len(TESTS)))
+        return 1
+    print('all %d checks passed' % len(TESTS))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_896_one_body_implementation.py
+++ b/tests/test_896_one_body_implementation.py
@@ -97,15 +97,23 @@ _DECLARED = {
     #    here, and the one a follow-up issue owns.
     (os.path.join('py_placer', 'placement', 'quench.py'),
      '_Part.__init__'): (
-        2, 'the SEARCH ladder -- #916 owns it. Adopting the model here '
-        'changes which poses '
-        '`seeder.pose_ok` admits -- it reads these baked bounds -- and so the '
-        'basin the anneal lands in: a placement-engine change needing its own '
-        'A/B, not a ride-along on a reporting one. Measured, it would grow 23 '
-        'of 1349 corpus parts and shrink none, on 4 of 22 boards.'),
+        2, 'the SEARCH ladder, now the OFF ARM of `body_model` (#916). '
+        '`placement.body` supplies `occupancy_local` when the flag is armed; '
+        'these two calls remain as the unarmed path, deliberately, so the '
+        'A/B control arm is the OLD CODE rather than a re-derivation that '
+        'happens to agree. NOTE FOR WHOEVER FLIPS THE DEFAULT: this census '
+        'compares COUNTS and PRESENCE, never this sentence, so it cannot tell '
+        'you the reason has gone stale -- update it by hand when the default '
+        'moves. Adopting the model changes which poses `seeder.pose_ok` '
+        'admits (it reads these baked bounds) and so the basin the anneal '
+        'lands in: an engine change needing its own A/B, not a ride-along on '
+        'a reporting one. Measured at #896: it grows 23 of 1349 corpus parts '
+        'and shrinks none, on 4 of 22 boards. Re-measured at #916 on '
+        'esp_prog: 5 parts grow, 0 shrink, largest U2 5.707 -> 27.04 mm2.'),
     (os.path.join('py_placer', 'placement', 'quench.py'),
-     'QuenchState.__init__'): (1, 'builds the courtyard map _Part consumes; '
-                               'same deferral'),
+     'QuenchState.__init__'): (1, 'builds the courtyard map the _Part OFF arm '
+                               'consumes; the armed path reads '
+                               'placement.body.board_bodies beside it'),
     (os.path.join('py_placer', 'placement', 'quench.py'),
      'QuenchState.fab_rect'): (1, 'the fab body for the quench containment '
                                'test, on the same deferred ladder'),

--- a/tests/test_916_search_body_model.py
+++ b/tests/test_916_search_body_model.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""#916: the SEARCH seats against `placement.body`, behind `body_model`.
+
+#896 wired every GRADING consumer to `placement/body.py` and deliberately left the
+SEARCH on an inlined `courtyard -> pad bbox` ladder. So on a library that draws no
+courtyard the optimizer seated parts against PAD BOXES while every instrument that
+graded the result saw drawn bodies -- and `pose_ok` reads those baked bounds, so the
+divergence moves which basin the anneal lands in, not merely what a report says.
+
+Two things have to be true and they pull in opposite directions, which is why both
+are asserted here:
+
+* **OFF is the OLD CODE.** `body_model=False` must take the inlined ladder, not a
+  re-derivation through `placement.body` that happens to agree. The A/B's control arm
+  is only a control if it is untouched, and "it agrees on the corpus I tried" is not
+  the same claim.
+* **ON must actually MOVE something**, on a board where #896 measured that it should.
+  A flag that changes no rectangle would sail through an A/B as "no regression" while
+  fixing nothing -- the failure `test_896_one_body_implementation.py` calls a
+  ride-along.
+
+Run: python3 -X utf8 tests/test_916_search_body_model.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import run_utils  # noqa: E402
+
+ROOT = run_utils.ROOT_DIR
+for _sub in ('py_placer', 'py_router', 'py_tools'):
+    _p = os.path.join(ROOT, _sub)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+RUN_ALL_TIMEOUT = 900
+RUN_ALL_FAST_OK = True
+
+#: esp_prog is the board #896 was filed from: 0 of its 21 footprints draw a
+#: courtyard, so today EVERY part is seated against a pad box. tigard draws
+#: courtyards widely and is the control for "a courtyard board barely moves".
+BOARDS = ('esp_prog.kicad_pcb', 'tigard.kicad_pcb')
+
+TESTS = []
+
+
+def _board(name):
+    return run_utils.evidence(os.path.join(ROOT, 'kicad_files', name),
+                              'corpus board')
+
+
+def _state(name, body_model):
+    from kicad_parser import parse_kicad_pcb
+    from placement.quench import QuenchState
+    path = _board(name)
+    pcb = parse_kicad_pcb(path)
+    return QuenchState(pcb, path, 0.2, 0.55, 30.0, 0.5, 0.15, 2.0, 2.0, 2.0,
+                       0.1, 0.3, body_model=body_model)
+
+
+def _bounds(state):
+    return {ref: dict(p.bounds_by_rot) for ref, p in state.parts.items()}
+
+
+def test_off_is_the_inlined_ladder_not_a_rederivation():
+    """OFF must equal the ladder computed directly, rect for rect."""
+    from kicad_parser import parse_kicad_pcb
+    from placement.parser import courtyard_for_side, extract_courtyard_sides
+    from placement.utility import compute_footprint_bbox_local
+    from placement.legality import rotate_local_bounds
+    from placement.quench import ROTATIONS
+    for name in BOARDS:
+        path = _board(name)
+        pcb = parse_kicad_pcb(path)
+        courtyards = extract_courtyard_sides(path)
+        st = _state(name, False)
+        bad = []
+        for ref, part in st.parts.items():
+            fp = pcb.footprints.get(ref)
+            if fp is None:
+                continue
+            lb = courtyard_for_side(courtyards.get(ref), part.side)
+            if lb is None:
+                lb = compute_footprint_bbox_local(fp)
+            for r in ROTATIONS:
+                want = rotate_local_bounds(*lb, r)
+                got = part.bounds_by_rot.get(r)
+                if got is None or max(abs(a - b) for a, b in zip(got, want)) > 1e-9:
+                    bad.append((ref, r, got, want))
+        assert not bad, (
+            '%s: body_model=False is NOT the inlined ladder on %d (ref, rot); '
+            'e.g. %r' % (name, len(bad), bad[:3]))
+        print('  %-22s OFF == inlined ladder for %d parts'
+              % (name, len(st.parts)))
+
+
+TESTS.append(test_off_is_the_inlined_ladder_not_a_rederivation)
+
+
+def test_on_grows_boxes_on_a_courtyardless_board_and_shrinks_none():
+    """`occupancy_local` is monotone: it may grow a box, never shrink one.
+
+    Monotonicity is the whole safety argument for arming this in a search --
+    a shrinking box would admit poses the grader then flags.
+    """
+    off = _state('esp_prog.kicad_pcb', False)
+    on = _state('esp_prog.kicad_pcb', True)
+    grew, shrank = [], []
+    for ref, p_off in off.parts.items():
+        p_on = on.parts.get(ref)
+        if p_on is None:
+            continue
+        a = p_off.bounds_by_rot[0.0]
+        b = p_on.bounds_by_rot[0.0]
+        area_a = (a[2] - a[0]) * (a[3] - a[1])
+        area_b = (b[2] - b[0]) * (b[3] - b[1])
+        if area_b > area_a + 1e-9:
+            grew.append((ref, round(area_a, 3), round(area_b, 3)))
+        elif area_b < area_a - 1e-9:
+            shrank.append((ref, round(area_a, 3), round(area_b, 3)))
+    assert not shrank, (
+        'esp_prog: occupancy_local SHRANK %d part(s) -- it is meant to be '
+        'monotone, and a shrinking seat box admits poses the grader flags: %r'
+        % (len(shrank), shrank[:5]))
+    assert grew, (
+        'esp_prog: body_model=True changed NO part box. On the board #896 was '
+        'filed from (0 of 21 footprints draw a courtyard) that means the flag '
+        'is inert and an A/B on it would measure nothing.')
+    print('  esp_prog: %d part(s) grew, 0 shrank; largest %s %s -> %s mm2'
+          % (len(grew), *max(grew, key=lambda t: t[2] - t[1])))
+
+
+TESTS.append(test_on_grows_boxes_on_a_courtyardless_board_and_shrinks_none)
+
+
+def test_on_is_occupancy_not_the_bare_body():
+    """The seat box must be `occupancy_local`, never `body_local`.
+
+    They differ exactly where a pad sticks out past the drawn body, which is
+    the case that matters: `legality.part_local_bounds` takes occupancy for
+    the same reason, so taking the bare body here would re-open the
+    grader/enforcer divergence #916 exists to close -- in the SHRINKING
+    direction.
+    """
+    from kicad_parser import parse_kicad_pcb
+    from placement import body as B
+    path = _board('esp_prog.kicad_pcb')
+    pcb = parse_kicad_pcb(path)
+    bodies = B.board_bodies(pcb, path)
+    on = _state('esp_prog.kicad_pcb', True)
+    differ = 0
+    for ref, geom in bodies.items():
+        part = on.parts.get(ref)
+        if part is None or geom.occupancy_local is None:
+            continue
+        got = part.bounds_by_rot[0.0]
+        want = geom.occupancy_local
+        assert max(abs(a - b) for a, b in zip(got, want)) <= 1e-9, (
+            'esp_prog %s: seat box %r is not occupancy_local %r'
+            % (ref, got, want))
+        if (geom.body_local is not None
+                and max(abs(a - b) for a, b
+                        in zip(geom.body_local, geom.occupancy_local)) > 1e-9):
+            differ += 1
+    assert differ >= 1, (
+        'on esp_prog no part has body_local != occupancy_local, so this test '
+        'cannot tell the two apart and asserts nothing about which was used')
+    print('  esp_prog: seat box is occupancy_local (%d part(s) where it '
+          'differs from body_local)' % differ)
+
+
+TESTS.append(test_on_is_occupancy_not_the_bare_body)
+
+
+def test_fab_rect_is_unchanged_by_the_flag():
+    """Containment is a DIFFERENT question and must not follow the seat box.
+
+    `QuenchState.fab_rect`'s own docstring: a courtyard is body + margin +
+    shell overhang, the corpus ships frac-1.0 courtyard containment on four
+    healthy boards against zero non-exempt fab containment, and "a
+    courtyard-based containment test is a false-veto machine".
+    `occupancy_local` IS courtyard-based whenever a courtyard is drawn, so
+    #916 deliberately stops at the seat box.
+    """
+    for name in BOARDS:
+        off = _state(name, False)
+        on = _state(name, True)
+        for ref in sorted(off.parts):
+            a = off.fab_rect(ref)
+            b = on.fab_rect(ref)
+            if a is None and b is None:
+                continue
+            assert a is not None and b is not None, (
+                '%s %s: fab_rect presence changed with body_model (%r vs %r)'
+                % (name, ref, a, b))
+            assert max(abs(x - y) for x, y in zip(a, b)) <= 1e-9, (
+                '%s %s: fab_rect moved with body_model: %r -> %r'
+                % (name, ref, a, b))
+        print('  %-22s fab_rect identical under both arms' % name)
+
+
+TESTS.append(test_fab_rect_is_unchanged_by_the_flag)
+
+
+def main():
+    failures = 0
+    for fn in TESTS:
+        print('%s ...' % fn.__name__)
+        try:
+            fn()
+        except AssertionError as exc:
+            failures += 1
+            print('FAIL %s: %s' % (fn.__name__, exc))
+    if failures:
+        print('%d/%d checks FAILED' % (failures, len(TESTS)))
+        return 1
+    print('all %d checks passed' % len(TESTS))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_placement_ab.py
+++ b/tests/test_placement_ab.py
@@ -521,8 +521,17 @@ def _inversions(pcb_data, board_path):
 
     `pair_inversions` counts each unordered pair once (summing `ref_inversions`
     over every ref would double every pair, once from each end). None rather
-    than 0 when the state cannot be built: `record_for` refuses a measurement
-    missing a compared key, and a 0 here would read as a perfect board.
+    than 0 when the state cannot be built, because a 0 here would read as a
+    perfect board.
+
+    WHAT ACTUALLY CATCHES A None, since an earlier draft of this docstring
+    named the wrong guard: `record_for` refuses a measurement missing the KEY,
+    and its own docstring says a key present and None is fine. The instrument
+    that notices is `compare_baseline`'s `(c is None) != (e is None)` DRIFT
+    arm -- and only if the baseline was recorded non-None. If a board ever
+    failed on BOTH arms and were baselined that way, this column would die
+    quietly, which is the `health_blocks_displaced` failure this file exists
+    to prevent. The print below is the only live signal; treat it as one.
     """
     try:
         import pose_score

--- a/tests/test_placement_ab.py
+++ b/tests/test_placement_ab.py
@@ -60,10 +60,12 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BOARDS = os.path.join(ROOT, 'kicad_files')
 
-# Fourteen full quenches (7 rows x off/on) over four distinct boards. 233-340 s
-# of row time for the first three rows; the #702 rows add roughly as much
-# again. Declared with headroom so a slower box reports FAIL, not TIME.
-RUN_ALL_TIMEOUT = 1800
+# Twenty-two full quenches (11 rows x off/on) over six distinct boards.
+# 233-340 s of row time for the first three rows; the #702 rows add roughly as
+# much again, and #916's four `body-*` rows add two large boards (ulx3s,
+# orangecrab) plus two cheap ones (esp_prog 21 parts, watchy 86). Declared with
+# headroom so a slower box reports FAIL, not TIME.
+RUN_ALL_TIMEOUT = 3600
 
 DEFAULT_BASELINE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                 'placement_ab_baseline.json')
@@ -85,6 +87,7 @@ GROUP_SOURCES = ('kicad', 'sheet')
 # "0.0 -> 806.84" is not a regression, it is a comparison that was never made,
 # and recording it as evidence would pin a fiction.
 BASELINE_INT_KEYS = ('crossings', 'health_bus_foreign_crossings',
+                     'inversions', 'body_blocking', 'body_advisory',
                      'intent_errors', 'intent_errors_enforced',
                      'intent_errors_other')
 BASELINE_FLOAT_KEYS = ('hpwl', 'health_block_displacement_max_mm')
@@ -344,6 +347,80 @@ ROWS = [
                 'four is not a term, and deleting the dissenting row is how '
                 'that becomes folklore.'),
     },
+    # --- #916: the SEARCH's body currency -------------------------------
+    #
+    # ON TRIAL, deliberately. #916's acceptance asks for this table "run as a
+    # GATE: three trial boards, paired and directional", so these rows carry
+    # no `expect` and `gate()` judges them by the N-1 rule. The alternative --
+    # pinning them, the way #834's currency change moved every row and added
+    # none -- would record what happened without ever letting it fail.
+    #
+    # FOUR boards, and they are not the table's usual four. #916 measured
+    # WHERE bodies actually change: ulx3s 9 parts, watchy 5, esp_prog 5,
+    # orangecrab_ext_pll 4, out of 23 growing parts on 4 of 22 corpus boards.
+    # Two of the incumbent four (coldfire, rp2350) are not among them, so a
+    # row there would be inert -- and under the trial rule a neutral board
+    # counts in N while never counting as an improvement, i.e. it can only
+    # hurt. esp_prog and watchy are added for that reason and no other.
+    #
+    # SIGNAL `body_advisory`, not the quench's own `overlap_area`: see
+    # `_body_overlap`. The seat boxes GROW under this flag, so any metric
+    # measured in the search's own currency rises mechanically. The signal is
+    # re-derived from the written board with the same ruler on both arms.
+    #
+    # esp_prog and watchy emit ZERO blocks (no kicad/sheet groups), so
+    # `intent_errors*` is 0 on both arms there and
+    # `health_bus_foreign_crossings` is None. That is fine for these rows --
+    # their signal and guards are all block-independent -- but it is why they
+    # could not have used the `intent-*` rows' signal.
+    {
+        'name': 'body-esp_prog',
+        'board': 'esp_prog.kicad_pcb',
+        'corridors': [],
+        'quench_on': {'body_model': True},
+        'signal': 'body_advisory',
+        'guard': ('body_blocking', 'crossings', 'hpwl'),
+        'why': ('MECHANISM: the board #896 was filed from -- 0 of its 21 '
+                'footprints draw a courtyard, so every part is seated against '
+                'a pad box today while every grader sees a drawn body. '
+                'Measured: 5 parts grow, 0 shrink, largest U2 by 4.7x.'),
+    },
+    {
+        'name': 'body-ulx3s',
+        'board': 'ulx3s.kicad_pcb',
+        'corridors': [],
+        'ignore_nets': ['GND', '+3V3', '+5V', 'VCC*'],
+        'quench_on': {'body_model': True},
+        'signal': 'body_advisory',
+        'guard': ('body_blocking', 'crossings', 'hpwl'),
+        'why': ('MECHANISM: the largest board where #916 measured growth (9 '
+                'parts), and the one whose two incumbent rows make an OFF arm '
+                'directly comparable to the rest of the table.'),
+    },
+    {
+        'name': 'body-orangecrab',
+        'board': 'orangecrab_ext_pll.kicad_pcb',
+        'corridors': [],
+        'ignore_nets': ['GND', '+3V3', '+1V1', 'VCC*'],
+        'quench_on': {'body_model': True},
+        'signal': 'body_advisory',
+        'guard': ('body_blocking', 'crossings', 'hpwl'),
+        'why': ('MECHANISM: named by #916 (4 parts grow), and it carries a '
+                'container footprint (U8), which is the class whose waiver '
+                'behaviour changes when a body crosses CONTAINER_RATIO.'),
+    },
+    {
+        'name': 'body-watchy',
+        'board': 'watchy.kicad_pcb',
+        'corridors': [],
+        'quench_on': {'body_model': True},
+        'signal': 'body_advisory',
+        'guard': ('body_blocking', 'crossings', 'hpwl'),
+        'why': ('MECHANISM: named by #916 (5 parts grow), and the board '
+                'candidate_valid names as the one where nearly every part '
+                'starts in violation -- so it is the most sensitive to a seat '
+                'box that only ever grows.'),
+    },
 ]
 
 QUENCH_BASE = dict(
@@ -390,6 +467,53 @@ def _intent_for(board_path, corridors, workdir, zone_flags=None):
     with open(path, 'w') as fh:
         json.dump(doc, fh, indent=2)
     return floorplan.load_intent(path)
+
+
+def _body_overlap(pcb_data, board_path, clearance):
+    """`legality.grade_body_overlap` on the WRITTEN board -> (blocking, advisory).
+
+    THE CURRENCY IS FIXED ACROSS ARMS, and that is the whole point. The
+    quench's own `legality_metrics()['overlap_area']` is measured with the
+    state's own rects, so under `body_model=True` it rises mechanically
+    because the boxes grew -- comparing that between arms compares two
+    different rulers and would report the #916 fix as a large regression.
+    `grade_body_overlap` re-derives bodies from the file through
+    `placement.body` regardless of what the search was seated on, so both arms
+    are measured with the same ruler and a difference means the PLACEMENT
+    moved, not the yardstick.
+
+    `advisory` is the body channel (unwaived fab/courtyard pairs) and is what a
+    seat-geometry change should move; `blocking` is the pad-intersection hard
+    channel, carried as a guard.
+    """
+    try:
+        from placement import legality
+        doc = legality.grade_body_overlap(pcb_data, clearance,
+                                          pcb_file=board_path)
+        return int(doc.get('blocking') or 0), int(doc.get('advisory') or 0)
+    except Exception as exc:                       # pragma: no cover - evidence
+        print('    body overlap unmeasurable: %s: %s'
+              % (type(exc).__name__, exc))
+        return None, None
+
+
+def _inversions(pcb_data, board_path):
+    """Total pin-order inversions on a written board, or None if unmeasurable.
+
+    `pair_inversions` counts each unordered pair once (summing `ref_inversions`
+    over every ref would double every pair, once from each end). None rather
+    than 0 when the state cannot be built: `record_for` refuses a measurement
+    missing a compared key, and a 0 here would read as a perfect board.
+    """
+    try:
+        import pose_score
+        from placement.pair_order import pair_inversions
+        st = pose_score.make_state(pcb_data, board_path)
+        return int(sum(m['inversions'] for m in pair_inversions(st).values()))
+    except Exception as exc:                       # pragma: no cover - evidence
+        print('    inversions unmeasurable: %s: %s'
+              % (type(exc).__name__, exc))
+        return None
 
 
 def _run(board_path, out_path, intent, quench_kw, group_sources=GROUP_SOURCES):
@@ -446,6 +570,7 @@ def _run(board_path, out_path, intent, quench_kw, group_sources=GROUP_SOURCES):
     enforced = sum(n for r, n in by_rule.items()
                    if r in INTENT_ENFORCED_RULES)
     gate = metrics.get('intent_gate')
+    _bb, _ba = _body_overlap(graded, out_path, quench_kw.get('clearance', 0.2))
     return {
         'seconds': round(time.time() - t0, 1),
         'crossings': after.get('crossings'),
@@ -465,6 +590,27 @@ def _run(board_path, out_path, intent, quench_kw, group_sources=GROUP_SOURCES):
         # threshold-free and always live.
         'health_block_displacement_max_mm':
             summary.get('health_block_displacement_max_mm'),
+        # #893/#916. Pin-order inversions over the WRITTEN board -- the same
+        # lower bound `placement_score.pin_order_crossings` reads, summed over
+        # unordered pairs by `pair_inversions` so each physical pair counts
+        # once. Re-derived here from the final poses, like every other column
+        # in this dict, rather than read out of the optimizer's own state.
+        #
+        # ON THE CIRCULARITY, STATED RATHER THAN HIDDEN: for a row whose ON arm
+        # arms `facing_weight`, this is the quantity the search minimises, so
+        # "it improved" is nearly tautological and the GUARDS are what carry
+        # the row. It is not circular for the `body-*` rows, which change the
+        # seat geometry and not the objective. The honest use is as evidence a
+        # rotation actually moved, paired with `crossings`/`hpwl` guards that
+        # the term does not optimise.
+        'inversions': _inversions(graded, out_path),
+        # #916. The body channel, in a currency fixed across arms -- see
+        # `_body_overlap`. `body_advisory` is what a seat-geometry change is
+        # expected to move; `body_blocking` is the pad-intersection hard
+        # channel, carried as a guard so a row cannot buy advisory pairs with
+        # real shorts.
+        'body_blocking': _bb,
+        'body_advisory': _ba,
         'intent_errors': summary.get('errors'),
         'intent_errors_by_rule': by_rule,
         'intent_errors_enforced': enforced,
@@ -912,6 +1058,7 @@ def _self_test():
             'health_bus_foreign_crossings': 62,
             'health_block_displacement_max_mm': 17.95,
             'intent_errors': 14,
+            'inversions': 40, 'body_blocking': 2, 'body_advisory': 9,
             'intent_errors_enforced': 4, 'intent_errors_other': 10,
             'intent_gate_rejected': None,
             'intent_errors_by_rule': {'block_unresolved': 10,
@@ -920,6 +1067,7 @@ def _self_test():
            'health_bus_foreign_crossings': 55,
            'health_block_displacement_max_mm': 18.09,
            'intent_errors': 17,
+           'inversions': 38, 'body_blocking': 2, 'body_advisory': 7,
            'intent_errors_enforced': 7, 'intent_errors_other': 10,
            'intent_gate_rejected': None,
            'intent_errors_by_rule': {'block_unresolved': 10,

--- a/tests/test_placement_ab.py
+++ b/tests/test_placement_ab.py
@@ -349,11 +349,32 @@ ROWS = [
     },
     # --- #916: the SEARCH's body currency -------------------------------
     #
-    # ON TRIAL, deliberately. #916's acceptance asks for this table "run as a
-    # GATE: three trial boards, paired and directional", so these rows carry
-    # no `expect` and `gate()` judges them by the N-1 rule. The alternative --
-    # pinning them, the way #834's currency change moved every row and added
-    # none -- would record what happened without ever letting it fail.
+    # RUN AS A GATE, AND THE GATE SAID NO. #916's acceptance asked for this
+    # table "run as a GATE: three trial boards, paired and directional". It was
+    # run that way -- four boards, no `expect` -- and it FAILED: improved 1 of
+    # 4, regressed 3, against a rule of improve >= N-1 and regress == 0. The
+    # rows are now pinned to what was MEASURED and marked `rejected`, which is
+    # what this table does with a term that did not earn its default; the flag
+    # stays off.
+    #
+    # READ THE COLUMNS, NOT THE MARK. The mark is an aggregate and #694 is the
+    # standing warning about that. The signal `body_advisory` IMPROVED on three
+    # of the four boards -- ulx3s 41 -> 38, orangecrab 16 -> 14, watchy 5 -> 4,
+    # esp_prog 4 -> 4 -- so the body model does exactly what #916 says it does:
+    # the search stops seating parts whose real bodies collide. What sank it is
+    # the GUARDS: `crossings` and `hpwl` worsen on esp_prog, ulx3s and
+    # orangecrab, because an `occupancy_local` box only ever GROWS and a more
+    # constrained search finds fewer moves. Measured on esp_prog: the OFF arm
+    # moved 11 footprints, the ON arm 3.
+    #
+    # So this is a real TRADE and not a failure of the mechanism: less body
+    # overlap, bought with wirelength and crossings. Whether that is worth it
+    # is a judgement about what a placement is FOR, and this table is not the
+    # instrument that settles it -- `crossings` and `hpwl` are the proxies
+    # docs/placement-optimization.md measured as weakly correlated with
+    # routability in the first place. The honest state is: implemented, wired,
+    # measured, OFF, with the numbers recorded so the decision can be made on
+    # evidence rather than re-run from scratch.
     #
     # FOUR boards, and they are not the table's usual four. #916 measured
     # WHERE bodies actually change: ulx3s 9 parts, watchy 5, esp_prog 5,
@@ -380,10 +401,9 @@ ROWS = [
         'quench_on': {'body_model': True},
         'signal': 'body_advisory',
         'guard': ('body_blocking', 'crossings', 'hpwl'),
-        'why': ('MECHANISM: the board #896 was filed from -- 0 of its 21 '
-                'footprints draw a courtyard, so every part is seated against '
-                'a pad box today while every grader sees a drawn body. '
-                'Measured: 5 parts grow, 0 shrink, largest U2 by 4.7x.'),
+        'expect': 'regress',
+        'rejected': True,
+        'why': ('MEASURED: signal NEUTRAL (4 -> 4) and `crossings` 35 -> 43. The board #896 was filed from and the clearest freeze evidence: OFF moved 11 footprints, ON moved 3, because 0 of its 21 footprints draw a courtyard so every seat box grows at once.'),
     },
     {
         'name': 'body-ulx3s',
@@ -393,9 +413,9 @@ ROWS = [
         'quench_on': {'body_model': True},
         'signal': 'body_advisory',
         'guard': ('body_blocking', 'crossings', 'hpwl'),
-        'why': ('MECHANISM: the largest board where #916 measured growth (9 '
-                'parts), and the one whose two incumbent rows make an OFF arm '
-                'directly comparable to the rest of the table.'),
+        'expect': 'regress',
+        'rejected': True,
+        'why': ('MEASURED: signal IMPROVED 41 -> 38, but `crossings` 2418 -> 2437, `hpwl` 7476.69 -> 7509.09 and zone_containment 3 -> 4. The largest board, and the clearest statement of the trade.'),
     },
     {
         'name': 'body-orangecrab',
@@ -405,9 +425,9 @@ ROWS = [
         'quench_on': {'body_model': True},
         'signal': 'body_advisory',
         'guard': ('body_blocking', 'crossings', 'hpwl'),
-        'why': ('MECHANISM: named by #916 (4 parts grow), and it carries a '
-                'container footprint (U8), which is the class whose waiver '
-                'behaviour changes when a body crosses CONTAINER_RATIO.'),
+        'expect': 'regress',
+        'rejected': True,
+        'why': ('MEASURED: signal IMPROVED 16 -> 14, `crossings` 1087 -> 1121, `hpwl` 2121.92 -> 2147.78. Same trade as ulx3s.'),
     },
     {
         'name': 'body-watchy',
@@ -416,10 +436,9 @@ ROWS = [
         'quench_on': {'body_model': True},
         'signal': 'body_advisory',
         'guard': ('body_blocking', 'crossings', 'hpwl'),
-        'why': ('MECHANISM: named by #916 (5 parts grow), and the board '
-                'candidate_valid names as the one where nearly every part '
-                'starts in violation -- so it is the most sensitive to a seat '
-                'box that only ever grows.'),
+        'expect': 'improve',
+        'rejected': True,
+        'why': ('MEASURED: the board where the trade goes the OTHER way -- signal 5 -> 4 AND both guards improve (crossings 149 -> 147, hpwl 777.13 -> 765.26). Kept because it is the row that disagrees with the other three, and deleting it is how a finding becomes folklore.'),
     },
 ]
 

--- a/tests/test_placement_ab.py
+++ b/tests/test_placement_ab.py
@@ -362,10 +362,15 @@ ROWS = [
     # of the four boards -- ulx3s 41 -> 38, orangecrab 16 -> 14, watchy 5 -> 4,
     # esp_prog 4 -> 4 -- so the body model does exactly what #916 says it does:
     # the search stops seating parts whose real bodies collide. What sank it is
-    # the GUARDS: `crossings` and `hpwl` worsen on esp_prog, ulx3s and
-    # orangecrab, because an `occupancy_local` box only ever GROWS and a more
-    # constrained search finds fewer moves. Measured on esp_prog: the OFF arm
-    # moved 11 footprints, the ON arm 3.
+    # the GUARDS, and they are not uniform: `crossings` worsens on all three of
+    # esp_prog, ulx3s and orangecrab, while `hpwl` worsens on ulx3s and
+    # orangecrab only -- on esp_prog it IMPROVES (262.75 -> 258.84). An earlier
+    # draft of this paragraph said both worsened on all three; a fact-check
+    # caught it against this table's own baseline, which is the point of
+    # recording numbers in the baseline rather than in prose.
+    #
+    # The mechanism is that an `occupancy_local` box only ever GROWS, so a more
+    # constrained search finds fewer moves.
     #
     # So this is a real TRADE and not a failure of the mechanism: less body
     # overlap, bought with wirelength and crossings. Whether that is worth it
@@ -403,7 +408,7 @@ ROWS = [
         'guard': ('body_blocking', 'crossings', 'hpwl'),
         'expect': 'regress',
         'rejected': True,
-        'why': ('MEASURED: signal NEUTRAL (4 -> 4) and `crossings` 35 -> 43. The board #896 was filed from and the clearest freeze evidence: OFF moved 11 footprints, ON moved 3, because 0 of its 21 footprints draw a courtyard so every seat box grows at once.'),
+        'why': ('MECHANISM: the board #896 was filed from -- 0 of its 21 footprints draw a courtyard, so every seat box grows at once and the search is the most constrained it can be. Its numbers are in the baseline; an earlier draft of this string quoted them here, which is what CLAUDE.md forbids.'),
     },
     {
         'name': 'body-ulx3s',
@@ -415,7 +420,7 @@ ROWS = [
         'guard': ('body_blocking', 'crossings', 'hpwl'),
         'expect': 'regress',
         'rejected': True,
-        'why': ('MEASURED: signal IMPROVED 41 -> 38, but `crossings` 2418 -> 2437, `hpwl` 7476.69 -> 7509.09 and zone_containment 3 -> 4. The largest board, and the clearest statement of the trade.'),
+        'why': ('MECHANISM: the largest board where #916 measured growth, and the one whose two incumbent rows make an OFF arm directly comparable to the rest of the table. Both guards and zone_containment move against the signal here -- the trade in its clearest form.'),
     },
     {
         'name': 'body-orangecrab',
@@ -427,7 +432,7 @@ ROWS = [
         'guard': ('body_blocking', 'crossings', 'hpwl'),
         'expect': 'regress',
         'rejected': True,
-        'why': ('MEASURED: signal IMPROVED 16 -> 14, `crossings` 1087 -> 1121, `hpwl` 2121.92 -> 2147.78. Same trade as ulx3s.'),
+        'why': ('MECHANISM: named by #916, and it carries a container footprint (U8) -- the class whose waiver behaviour changes when a body crosses CONTAINER_RATIO. Same shape of trade as ulx3s.'),
     },
     {
         'name': 'body-watchy',
@@ -438,7 +443,7 @@ ROWS = [
         'guard': ('body_blocking', 'crossings', 'hpwl'),
         'expect': 'improve',
         'rejected': True,
-        'why': ('MEASURED: the board where the trade goes the OTHER way -- signal 5 -> 4 AND both guards improve (crossings 149 -> 147, hpwl 777.13 -> 765.26). Kept because it is the row that disagrees with the other three, and deleting it is how a finding becomes folklore.'),
+        'why': ('MECHANISM: the board candidate_valid names as the one where nearly every part starts in violation, so it is the most sensitive to a seat box that only grows -- and the one board where the trade goes the OTHER way, signal and both guards together. Kept because it DISAGREES with the other three, and deleting the dissenting row is how a finding becomes folklore.'),
     },
 ]
 


### PR DESCRIPTION
Closes #893
Closes #916

Rotation becomes something a board can **declare** and something the objective can be **told to price**; the search gains the #896 body model behind a flag. One of the two engine defaults ships on, one does not, and the measurement is why.

## What shipped ON

**`blocks[].rotation` and `blocks[].rotation_candidates` (#893 item 1).** Before this a rotation could not be written down anywhere the toolchain reads. `seeder.py`'s own module docstring said so — *"The intent schema cannot express a rotation, so a part whose rotation is a DECISION (pin order, the U3 rot-180 case) must be locked"* — and that advice costs the part its **position** too, because `_Part.locked` is one boolean covering both and `place_seed` stamps it into the board. Run 25 rewrote the board before seeding for want of a document that could hold the decision.

- `rotation` is a **decision**: honoured exactly, and a part with no legal pose at it is reported in the new `rotation_unseated` rather than quietly turned. The refusal is structural, not a check — a declared ladder contains only the declared angle, so the fallback cannot fire.
- `rotation_candidates` is a **set**, in the author's order, because the seat search keeps the first pose that fits.
- Declaring both on one block is refused. Angles normalise (`-90` → `270`); an empty list and repeated angles are refused rather than silently fixed (`[0, 360]` is caught after normalisation).
- **It does not lock the part**, which is the whole point.

`READER_VERSION` 4 → 5 per the rule its own comment block states. Contrast `blocks[].side`, declarable already and whose rule the docs call *"vacuous, not conservative"* because no search move carries a side — rotation is carried by every nudge.

## What shipped OFF, and why that is the finding rather than a hedge

**`--facing-weight` (#893 items 2–4), default 0.0.** Prices the pin *order* a pose forces via `pair_order.ref_inversions` — the same lower bound `placement_score.pin_order_crossings` reports, called rather than re-derived.

**`quench(body_model=…)` (#916), default False.** The search seats against `placement.body`'s `occupancy_local` instead of an inlined `courtyard → pad bbox` ladder.

#916 asked for `tests/test_placement_ab.py` "run as a GATE: three trial boards, paired and directional". It was run that way, on four boards, with no `expect`. **It failed: improved 1 of 4, regressed 3.**

Read the columns, not the mark (#694 is the standing warning that an aggregate cannot say which input moved):

| row | `body_advisory` (signal) | `crossings` | `hpwl` | mark |
|---|---|---|---|---|
| body-ulx3s | **41 → 38** | 2418 → 2437 | 7476.69 → 7509.09 | regress |
| body-orangecrab | **16 → 14** | 1087 → 1121 | 2121.92 → 2147.78 | regress |
| body-watchy | **5 → 4** | **149 → 147** | **777.13 → 765.26** | improve |
| body-esp_prog | 4 → 4 | 35 → 43 | 262.75 → 258.84 | regress |

The signal improved on three of four boards — the body model does exactly what #916 says it does. What sank it is the guards, and they are **not uniform**: `crossings` worsens on all three of esp_prog, ulx3s and orangecrab, while `hpwl` worsens on ulx3s and orangecrab only — on esp_prog it *improves*. (An earlier draft of this section said both worsened on all three; the fact-check caught it against the table's own baseline.) The mechanism is that an `occupancy_local` box only ever **grows**, so a more constrained search finds fewer moves: on esp_prog the OFF arm moved **11** footprints and the ON arm **3**.

So this is a **trade**, not a broken mechanism: less real body overlap, bought with wirelength and crossings. Whether that is worth paying is a judgement about what a placement is for, and this table cannot settle it — `crossings` and `hpwl` are the proxies `docs/placement-optimization.md` itself measured as weakly correlated with routability. Implemented, wired, measured, off, with the numbers recorded so the call can be made on evidence rather than re-run from scratch. `body-watchy` is kept precisely because it disagrees.

## Corrections to the issues' own premises

**#893's "Rotation is not a variable anywhere in the placement engine" is wrong for the quench.** `_candidate_rotations` returns the part's 90° lattice, the nudge searches it gated by `candidate_valid` and priced at a flat `rot_charge = 0.5`, and `allow_rotations` defaults **True**. `portfolio.perturb_poses` turns parts deliberately, pruned by this same inversion bound. What was missing is a *declarable* rotation and a *scored* one, which is what this PR adds.

**#893's acceptance bullet 2 asks for something rotation cannot do.** `pair_metrics`' own docstring records #891's measurement: on esp_prog, U1↔USB1's overall order agrees while the two USB pair nets are crossed, and *"that parity cannot be fixed by rotating either part; only a mirror or a via hop flips it."* The fixture test therefore asserts what rotation *can* do.

**#916's acceptance names two conversion sites; the enforcing test declares three.** `QuenchState.fab_rect` is the third. It is deliberately **not** converted: its docstring calls a courtyard-based containment test *"a false-veto machine"*, naming four corpus boards that ship frac-1.0 courtyard containment against zero non-exempt fab containment — and `occupancy_local` is courtyard-based whenever a courtyard is drawn. Routing it through `body.drawn_local` would also swap in a silk rung the calibration never covered.

## Two mistakes worth recording

**A 6.7× speed-up that was wrong.** Hoisting `_escape_pads`' pad transform by always treating the queried ref as side A ran 6.7× faster and reported ulx3s `U2` as **358** inversions where the truth is 26 — `pair_metrics` builds `order_a` from the *first* ref's pads and takes its channel axis as `b − a`, so the slot a ref occupies is load-bearing. **It passed every test in the tree at the time.** `tests/test_893_pair_order_equivalence.py` asserts numbers, not green: per-ref equality against an un-hoisted transcription on three boards, per-pair dict equality field for field, the hypothetical-pose case the search actually uses, and cache isolation.

Done correctly that hoist is worth nothing on its own — `_escape_pads` is only reached after the shared-net test passes, and scoring pairs are rare (209 of 3916 on tigard). The real win was an early-out for the rejected majority.

**Treat any single speed-up figure as an anecdote from one machine.** Measured here as 1.35× / 1.11× / 1.34× on esp_prog / tigard / ulx3s; measured independently on another box as 1.25× / 1.75× / 2.53× — same direction, different magnitudes, and a different per-board *order*. What does not vary, and what the equivalence gate actually pins, is that the inversion counts are unchanged: 16 / 384 / 1138.

**A cost figure that flattered a design I preferred.** I first measured the facing term at +226 s/arm in the nudge loop and concluded it needed its own move phase. That multiplied every (position × rotation) candidate, when only **10.3 %** survive `candidate_valid` before `eval_at` runs — the honest figure is ~8 s/arm. The term goes in `part_geometry_cost` beside `_orient_cost`, and no phase is added. That also avoids a livelock: a phase minimising `nets+geo+facing` while the nudge minimises `nets+geo` gives the loop two objectives, and the nudge's rotation candidates always include the current angle, so it would revert every rotation the phase made and `moves` would never reach 0.

## What the pre-push review found

An adversarial review by an agent that did not write the code found **four P0
defects**, one of them in the commit that had just "finished" the same area.
All are fixed here; the list is in the PR because each is a thing a reader
should know the code once did.

- **The facing term mis-priced the group and swap moves.** `_facing_cost` sat
  beside `_align_cost` in `part_geometry_cost` but took no `exclude`. The swap
  passes `exclude={partner}` to each half and adds the a–b halo and align pairs
  back at the *candidate* poses; there is no such add-back for a term needing
  both parts moved at once, so the pair was counted twice, each time with one
  part at its pre-swap pose. It is now nudge-only — a correctness bound, since
  `exclude` is non-empty only on those two paths and on the single-part nudge
  `ref_inversions` *is* the exact delta.
- **A declared angle off the 90° lattice was seated against rot-0 geometry.**
  `_Part.rect` silently falls back to `bounds_by_rot[0.0]`, so `rotation: 45`
  on a part seeded at 0 was judged for overlap, halo and containment on the
  **unrotated** box and then written out at 45°. `_try_place` now materialises
  the entry the way the quench's nudge loop does. After the fix a declared 45°
  on esp_prog's `CON2` is correctly *refused*.
- **A declared rotation did not survive the quench**, which made the feature
  strictly *weaker than the advice it replaced* — locking a part did protect
  its angle, and the seeder docstring now tells authors to declare instead of
  lock. The claim travels on the intent gate and `_candidate_rotations` returns
  it instead of the lattice; an undeclared part still gets all four.
- **Two more seating paths**: `_seat_edge` (not a `_try_place` site, so the AST
  gate could not see it) turns connectors on its own ladder, and stage 1 seated
  a declared connector at its *input* angle.

Also: the `READER_VERSION` justification cited a `rule_rotation` that **never
existed**; `body_model` reached `quench()` but not `pose_score.make_state` —
the factory the seeder, the repair path and `reseat_scope` build from, i.e.
everything except the search #916 is about; `rotation_unseated` had no
production consumer; and a `state.parts[other]` could raise `KeyError` where
`pair_metrics` returned `None`.

**The rotation ladder was incomplete three times** (2 of 13 sites, then 8 of
13, then the paths that are not `_try_place` sites at all). Each fix was
verified against the stages the fixtures happened to reach. That is why there
is now a source-shape gate asserting every `_try_place` call passes
`rotations=`, and why the behavioural test declares a lock, a decap rule and a
zone together so the stages actually run.

## Gates

`tests/mutate_893_916.py`: 17 rows, **16 killed, 1 survived-as-declared, 0 broken**. Two rows reproduce mistakes made during the work. The anchor pre-flight caught a 17th before the first run (an anchor matching three sites, so `replace(..., 1)` would have mutated the wrong one and the row would have passed for an unrelated reason).

Its first run found a **real hole**: deleting `pen += self._facing_cost(...)` from `part_geometry_cost` SURVIVED, because `total_cost` computes its own facing component and `_facing_cost` was only ever called directly — every assertion passed while the term reached no move the optimizer makes. Closed.

The surviving row is kept because the survival is the finding: `& _scoring_net_ids(state)` is a **no-op by construction** (`net_refs` is built from every part's nets, so `part.nets` is always a subset — 0 of 333 parts across three boards hold a net outside it). The expression it replaced was building a whole-board set per call for nothing.

New: `test_893_pair_order_equivalence.py`, `test_893_facing_weight.py`, `test_893_declared_rotation.py`, `test_916_search_body_model.py`. One test in the rotation file was **vacuous on its first run and said so** — it declared 37° on every esp_prog part and every part fitted. It is now self-calibrating: it picks the most lopsided part (CON2, 9.6:1), sizes a zone admitting it at its own angle but not turned 90°, and refuses to run if that separation does not exist.

`READER_VERSION` 4 → 5 staled two mutation anchors (`mutate_711`, `mutate_837`); both re-anchored, and `_BATTERY_COUNT` went 45 → 46 for the new battery — a pinned literal exactly so a resolver that stops finding batteries cannot report a clean sweep over nothing. `test_549_floorplan_schema.py` restates `_BLOCK_KEYS` as a literal and requires every key backticked in the docs, so both moved; its every-known-key fixture needed a second block, for the same reason `edge_connectors` already carries two.

## What the fact-check found

A separate agent checked every number in the diff and the commit messages
against the committed data. It caught **two gates that were lying**:

- **The anchor census was failing while a commit message said it passed.** This
  PR staled a *third* anchor, not two — the `body_model=` insertion landed
  inside the exact span `mutate_797`'s `the-seed-state-drops-the-exclusive-zones`
  quotes. The claim "census back to 1029/1029 across 45 batteries" was wrong on
  the count (1046 across 46) *and* on the fact. Re-anchored; census green.
- **A mutation row was killed by a `SyntaxError`, not by a test.** A re-anchored
  row produced `if False:` immediately followed by `if exclude:` — no indented
  block, so the mutant did not compile and the witness died on import. The
  runner scores KILLED on a non-zero exit, so it read as a pass. That is the
  "a non-zero exit is not evidence — assert the REASON" failure, reproduced
  inside the battery meant to enforce it.

Plus: the esp_prog hpwl claim above; a battery comment that overclaimed a row
"reproduced exactly" the 6.7× draft (it measures 7, not 358, and does identical
work so it is not faster — a *milder* wrong, which makes it a stronger test);
four `why` strings that had grown tables of measurements, which CLAUDE.md
forbids and the baseline file exists to prevent; and a docs section inserted
into the middle of a bullet list.

## Not done

`check_floorplan --declare-rotations` is not included. `--emit-intent` must not start declaring every part's current angle — an incidental angle is not a decision, and turning one into a locked claim would freeze boards that are merely being read. #893's acceptance does not require it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wa54dFaXWdK4aw3VsV8ay
