### PR TITLE
#908 + #907 + #909 + #910: a footprint's own copper is copper, and three siblings from run 25

### DIFF
--- a/.claude/skills/plan-pcb-placement-and-routing/scripts/board_score.py
+++ b/.claude/skills/plan-pcb-placement-and-routing/scripts/board_score.py
@@ -959,10 +959,18 @@ def quality(board: str) -> dict:
         from kicad_parser import parse_kicad_pcb
         import math
         pcb = parse_kicad_pcb(board)
+        # ROUTED copper only (#908). A footprint's own drawn copper -- a SOT89
+        # tab, a PCB antenna -- parses as `graphic=True` Segments, and it is
+        # identical in every candidate placement of the same board: counting
+        # it adds a constant to `copper_mm` and, worse, makes a copper-FREE
+        # board look like it has a quality key that can rank. A board carrying
+        # a meander antenna can reach dozens of such segments with not one
+        # routed track on it.
+        segs = [s for s in pcb.segments if not getattr(s, 'graphic', False)]
         mm = sum(math.dist((s.start_x, s.start_y), (s.end_x, s.end_y))
-                 for s in pcb.segments)
+                 for s in segs)
         return {'vias': len(pcb.vias), 'copper_mm': round(mm, 2),
-                'segments': len(pcb.segments)}
+                'segments': len(segs)}
     except Exception as e:
         return {'error': str(e)}
 

--- a/.claude/skills/plan-pcb-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-routing/SKILL.md
@@ -53,7 +53,10 @@ for layer in pcb.board_info.stackup:  # List[StackupLayer], ordered top to botto
   speed detection in Step 4), lead the report with a clear warning: impedance and
   time-matching calculations will not match the user's fab, and `/recommend-stackup`
   should be run before impedance-controlled routing. Take plane-layer assignments from
-  its output when available.
+  its output when available. **Carry the achievability numbers with that warning**
+  (`impedance.achievability_note`, Step 10 rule 1) — on many 2-layer boards the honest
+  verdict is that the target is neither achievable nor needed, and that is a stronger
+  result than "skipped".
 - A 2-layer board with multiple differential pairs or planes-worth of power nets is
   itself worth flagging (no inner layers for reference planes).
 - If the stackup looks deliberate, say so in one line and move on.
@@ -2592,11 +2595,37 @@ the budget doctrine above.
 
 Lessons from a dry-run audit (an agent following this skill end-to-end):
 
-1. **No stackup ⇒ no impedance passes, period.** When the board has KiCad's
-   default stackup, SKIP every `--impedance` step (including the DDR SSTL
-   40Ω pass) and lead the plan with the /recommend-stackup warning. The
-   no-stackup rule OUTRANKS every interface-specific impedance
-   recommendation.
+1. **No stackup ⇒ STATE THE NUMBERS, then no impedance passes.** When the
+   board has KiCad's default stackup, SKIP every `--impedance` step
+   (including the DDR SSTL 40Ω pass) and lead the plan with the
+   /recommend-stackup warning. The no-stackup rule OUTRANKS every
+   interface-specific impedance recommendation.
+
+   But "skipped, no stackup" is not a verdict — it does not say whether
+   authoring a stackup would have helped, and #909 was filed because a run
+   skipped impedance correctly and reported nothing a reader could act on.
+   Compute the answer instead; it is one call, and it needs no stackup:
+
+   ```python
+   from impedance import achievability_note, tightest_pin_gap
+   note, detail = achievability_note(
+       pcb, 'F.Cu', 90.0, is_differential=True, spacing=0.15,
+       min_pitch_gap=tightest_pin_gap(pcb, [net_id, ...]))
+   ```
+
+   It solves against a NOMINAL FR4 stack (`impedance.nominal_stackup`) and
+   says so; the detail dict carries `width_mm`, `channel_mm` and
+   `channel_over_pin_gap`. On esp_prog that reads: *90 Ω on a 2-layer 1.6 mm
+   FR4 stack needs a 1.133 mm differential leg (2.416 mm for the pair)
+   against a 0.325 mm pin gap — 7.4x. Not achievable here.* That is the line
+   the plan should carry. `route.py` and `route_diff.py` print it themselves
+   when `--impedance` is given on a stackup-less board.
+
+   **Do not author a stackup to make the numbers appear.** No tool in this
+   repo writes one (the board's author owns it), and a written default would
+   only make the width solver print 1.133 mm and clamp it straight back to
+   `--track-width` with a "this trace will be ~169 ohm, not 90" warning — a
+   stated non-goal turned into a clamp warning.
 2. **Populated-array escape:** `dogbone` supersedes the older
    "channel-infeasible → underpad" advice for populated BGAs; underpad is
    for WLCSP/inner-row cases where no inter-pad gap exists at all.

--- a/.claude/skills/plan-pcb-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-routing/SKILL.md
@@ -2615,11 +2615,12 @@ Lessons from a dry-run audit (an agent following this skill end-to-end):
 
    It solves against a NOMINAL FR4 stack (`impedance.nominal_stackup`) and
    says so; the detail dict carries `width_mm`, `channel_mm` and
-   `channel_over_pin_gap`. On esp_prog that reads: *90 Ω on a 2-layer 1.6 mm
-   FR4 stack needs a 1.133 mm differential leg (2.416 mm for the pair)
-   against a 0.325 mm pin gap — 7.4x. Not achievable here.* That is the line
-   the plan should carry. `route.py` and `route_diff.py` print it themselves
-   when `--impedance` is given on a stackup-less board.
+   `channel_over_pin_gap`. On a 2-layer 1.6 mm board with a USB pair leaving
+   0.65 mm-pitch pins it reads: *90 Ω needs a 1.13 mm differential leg
+   (2.42 mm for the pair) against a 0.33 mm pin gap — 7.4x. Not achievable
+   here.* That is the line the plan should carry. `route.py` and
+   `route_diff.py` print it themselves when `--impedance` is given on a
+   stackup-less board.
 
    **Do not author a stackup to make the numbers appear.** No tool in this
    repo writes one (the board's author owns it), and a written default would

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -643,6 +643,27 @@ pcb = parse_kicad_pcb('path/to/file.kicad_pcb')
   on how the outline was spelled; and a round window's bounding-box CORNER
   escapes a round board while the circle does not. Both parse paths fill these,
   sharing one decision function (`kicad_parser.classify_outline_owners`).
+- **A footprint's own COPPER is copper (#908).** `fp_poly`/`fp_line`/`fp_arc`/
+  `fp_rect`/`fp_circle` on `F.Cu`/`B.Cu` inside a footprint block — a SOT89
+  tab, a PCB antenna, a solder-jumper bridge — parse as net-0
+  `Segment(graphic=True, owner_ref=<footprint key>)`, exactly like #337's
+  board-level `gr_*`, in BOTH parse paths. A footprint shape cannot carry a
+  `(net ...)` in KiCad, so #337's "net-tied is functional, net-less is a logo"
+  guard cannot split them: **`footprint_copper_is_functional(pad_count)` does,
+  and the writer's silkscreen mover reads the same predicate** — a footprint
+  with copper pads owns a land pattern (modelled, and NOT relocated to silk any
+  more; it used to be, on every write, on both fronts), a pad-less one is a
+  logo (relocated, as #146 has always done, and therefore not modelled). NPTH
+  pads do not count. Only the PERIMETER is modelled, never the interior fill.
+  **The obstacle map's own-pad lift is the half that is not free**: net-0
+  copper is foreign to every net including the pad it was drawn around, so
+  `check_drc.graphic_own_pad_nets` lifts the graphic segments that touch a pad
+  of their OWN footprint, per SEGMENT — never the whole cluster, or a GND route
+  would cross watchy's whole antenna. It is a subset of
+  `graphic_effective_nets(include_mutable=False)` (attrs + pads), which is a
+  subset of the checker's `include_mutable=True` answer, so **the generator can
+  never be more permissive than the checker**; do not "simplify" it onto the
+  full answer.
 - `footprint.ref_label` - Optional[RefLabel]: the Reference silkscreen text's
   geometry (#481): `at_x/at_y` (footprint-LOCAL mm), `rotation` (the stored
   angle, which is ABSOLUTE board angle — probed on KiCad 10, `% 360`

--- a/README.md
+++ b/README.md
@@ -493,6 +493,11 @@ python py_router/check_drc.py kicad_files/output.kicad_pcb
 # bogus zone-clearance errors from stale pours - see tests/README.md for details)
 kicad-cli pcb drc --refill-zones --format json -o drc.json kicad_files/output.kicad_pcb
 
+# ...because a routed board ships zone OUTLINES with no filled_polygon, so an
+# unrefilled grade reports plane opens that are not real (#910). To ship a
+# board that already carries its fills, add --write-fill to the route step, or:
+python py_tools/fill_for_delivery.py kicad_files/output.kicad_pcb -o delivered.kicad_pcb
+
 # Check connectivity (detects unrouted nets, broken routes, and T-junctions)
 python py_router/check_connected.py kicad_files/output.kicad_pcb
 

--- a/docs/api-kicad-parser.md
+++ b/docs/api-kicad-parser.md
@@ -202,6 +202,7 @@ pads owns a land pattern (modelled, kept on copper), a pad-less one is a logo
 (relocated to silk by the writer, as #146 has always done, and therefore not
 modelled). Only the **perimeter** is modelled, never the interior fill, which
 is the same limit board-level graphics have.
+
 ### `Zone`
 
 | Field | Type | Meaning |

--- a/docs/api-kicad-parser.md
+++ b/docs/api-kicad-parser.md
@@ -140,6 +140,9 @@ whose resolved copper overlaps a different-net neighbour (a modelling error).
 | `net_id` | int | Net ID |
 | `uuid` | str | UUID from the file (`''` for newly created segments and for uuid-less file items — KiCad treats the token as optional, PR #534) |
 | `start_x_str`, … | str | Original coordinate strings, kept for exact file matching |
+| `graphic` | bool | This copper came from a **graphic**, not a track (issue #337, extended to footprint shapes by #908). It is real copper for obstacles and DRC, and it is immutable: cleanup passes must never prune it and writers cannot strip it, because there is no `(segment …)` block to match. It never conducts — connectivity gives a graphic no credit, so KiCad will keep calling such a net unconnected (#513 item 6). |
+| `locked` | bool | KiCad `(locked yes)`: the user pinned this copper. Its net is never rip-eligible (#521, no override); locked copper was already an obstacle (#150). Both parse paths set it. |
+| `owner_ref` | str | For copper drawn **inside a footprint**, the disambiguated footprint key that owns it (`'U2'`, `'TP4~2'`); `''` for board-level graphics and every routed track (#908). It is what lets a DRC report name the object the way KiCad does — `net_0 [Polygon(U2)]` beside KiCad's *"Polygon [\<no net\>] of U2 on F.Cu"* — and what scopes the own-pad obstacle lift to the owning part. |
 
 ### `Via`
 
@@ -185,6 +188,20 @@ default for vias you ADD.
 | `owns_edge_cuts` | bool | The footprint draws Edge.Cuts geometry of its own (`fp_line`/`fp_rect`/`fp_arc`/`fp_circle`/`fp_poly`/`fp_curve` on that layer, issue #829). Its `(at x y rot)` therefore transforms part of the board outline. |
 | `owns_board_outline` | bool | ...and that geometry is **the board's own boundary** rather than a relief the part carries, so moving the footprint would resize the board (issue #829). A footprint is *carried* (this stays `False`, and it remains movable) only when its Edge.Cuts segments **close on themselves** — a window, slot or milled relief — **and** that shape lies inside the outline the board draws without it. An open path cannot be a cut-out, so it is always the boundary. crkbd draws 184 per-LED windows as carried geometry, and #628 measured that freezing such a part costs it every legal pose it has. **Movers gate on this field, never on `owns_edge_cuts`.** Computed by `kicad_parser.footprint_outline_owners` (text) and `footprint_outline_owners_from_pcbnew` (live board), which share the one decision function `classify_outline_owners`. |
 
+
+**Footprint copper** (issue #908). A footprint may draw copper of its own on
+`F.Cu`/`B.Cu` — the tab of a SOT89/DPAK, a PCB antenna, a solder-jumper
+bridge. Those `fp_poly`/`fp_line`/`fp_arc`/`fp_rect`/`fp_circle` shapes are
+modelled exactly like board-level graphics: net-0 `Segment`s with
+`graphic=True` and an `owner_ref`, so they are obstacles and DRC copper for
+free. A footprint shape **cannot carry a `(net …)` in KiCad**, so #337's
+"net-tied copper is functional, net-less copper is a logo" rule cannot tell
+the two apart; `footprint_copper_is_functional(pad_count)` does, and the
+writer's silkscreen mover reads the same predicate — a footprint with copper
+pads owns a land pattern (modelled, kept on copper), a pad-less one is a logo
+(relocated to silk by the writer, as #146 has always done, and therefore not
+modelled). Only the **perimeter** is modelled, never the interior fill, which
+is the same limit board-level graphics have.
 ### `Zone`
 
 | Field | Type | Meaning |

--- a/docs/api-kicad-writer.md
+++ b/docs/api-kicad-writer.md
@@ -323,6 +323,15 @@ logos/artwork (graphic polys, lines, arcs). The GUI plugin mirrors both moves on
 apply (via `kicad_routing_plugin/gui_utils.move_copper_graphics_to_silkscreen_board`)
 so its output matches the CLI writer (issue #146).
 
+**Board-level `gr_*` only, since #908.** A footprint shape cannot carry a
+`(net …)` in KiCad, so the "net-tied copper is functional, leave it" guard was
+a no-op for `fp_*` and every footprint copper shape was relocated on every
+write — including a part's own land-pattern copper. Both fronts now ask
+`kicad_parser.footprint_copper_is_functional(pad_count)`: a footprint **with**
+copper pads keeps its copper (the parser models it, so nothing routes over it
+any more), a **pad-less** one is a logo and is relocated exactly as before.
+The pass reports what it kept as well as what it moved.
+
 ```python
 add_teardrops_to_pads(content: str, best_length_ratio=0.5, max_length=1.0,
                       best_width_ratio=1.0, max_width=2.0,

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1799,6 +1799,58 @@ python3 -X utf8 py_tools/check_pockets.py placed.kicad_pcb \
 python3 -X utf8 py_tools/check_pockets.py placed.kicad_pcb --bin 1.0 --top 16
 ```
 
+## Fill for Delivery (`fill_for_delivery.py`)
+
+A routed board ships zone **outlines** with no `(filled_polygon ...)`: the
+writer emits the `(fill yes ...)` properties, and nothing in the plane path
+ever writes a fill. Opened in KiCad before a refill — or graded by `kicad-cli
+pcb drc` **without** `--refill-zones` — such a board reports plane-net opens
+that are not real. Measured on `lvds_converter_dualclk_gnd` with its fills
+stripped: **54 unconnected without the flag, 42 with the fill written** — 12
+phantom opens that were never a routing defect.
+
+This is the opt-in delivery step (issue #910). It runs KiCad's own
+`ZONE_FILLER` through the bundled interpreter and saves with
+`aSkipSettings=True`, so the sibling `.kicad_pro` — and every non-Default net
+class in it — survives; the tool re-reads the classes afterwards and
+**refuses**, deleting its own output, if any went missing.
+
+### Usage
+
+```bash
+python3 py_tools/fill_for_delivery.py routed.kicad_pcb -o delivered.kicad_pcb
+```
+
+| Flag | Meaning |
+|------|---------|
+| `-o, --output` | Destination board. Its siblings (`.kicad_pro`, `.kicad_prl`, `.kicad_dru`, design brief) are copied first, via `copy_board`. |
+| `--timeout N` | Seconds to allow the KiCad fill (default: the exact-fill budget). |
+| `--exit-zero` | Report problems but exit 0. |
+
+`route.py --write-fill` does the same thing in place, at the very end of a
+run, after the DRC-floor writeback — so the fill is graded against the
+project's real net classes.
+
+### Output
+
+```
+Filled: delivered.kicad_pcb
+  filled_polygon blocks: 1
+  net classes preserved: 2
+  unconnected (no --refill-zones): 54 -> 42
+```
+
+The before/after line is the record that the fill **revealed** connectivity
+rather than changing it.
+
+### Requirements and exit codes
+
+Needs KiCad's bundled python (`KICAD_PYTHON` overrides the search). Without
+it the step refuses with `no_kicad_python` and writes nothing — the copied
+board is simply unfilled, and `kicad-cli pcb drc --refill-zones` (or **B** in
+KiCad) still grades it correctly. Exit 0 when filled with classes intact,
+1 when the fill did not run or a class went missing.
+
 ## Common Workflows
 
 ### Route and Verify

--- a/kicad_routing_plugin/gui_utils.py
+++ b/kicad_routing_plugin/gui_utils.py
@@ -594,7 +594,20 @@ def move_copper_graphics_to_silkscreen_board(board):
         # pattern. The loop already holds the owning FOOTPRINT, so the pad
         # count is read here rather than through a parent lookup (board-level
         # drawings have no parent to look up).
-        if footprint_copper_is_functional(len(footprint.Pads())):
+        # NPTH pads are not copper, so they cannot make a footprint
+        # "functional" -- the text writer and BOTH parse paths exclude them by
+        # name, and counting them here is how the one front that shares the
+        # predicate still answers differently (a logo footprint carrying a
+        # mounting hole would be kept on copper here and modelled nowhere).
+        _npads = 0
+        for _pd in footprint.Pads():
+            try:
+                if _pd.GetAttribute() == pcbnew.PAD_ATTRIB_NPTH:
+                    continue
+            except Exception:
+                pass
+            _npads += 1
+        if footprint_copper_is_functional(_npads):
             continue
         for item in footprint.GraphicalItems():
             _relocate(item)

--- a/kicad_routing_plugin/gui_utils.py
+++ b/kicad_routing_plugin/gui_utils.py
@@ -552,8 +552,15 @@ def move_copper_graphics_to_silkscreen_board(board):
     frequently a footprint fp_poly (e.g. the orangecrab OSHW logo). Footprint text
     and board text are handled separately by the copper-text mover, so only
     PCB_SHAPE items are touched here. Returns the number of shapes moved.
+
+    #908: the net guard cannot separate a logo from a part's own land-pattern
+    copper, because a footprint shape carries no net at all -- so a footprint
+    WITH pads is exempted here and its copper stays on copper, which the parser
+    now models. Same shared predicate as the CLI writer, so the two fronts
+    cannot answer this differently. Returns the number of shapes moved.
     """
     import pcbnew
+    from kicad_parser import footprint_copper_is_functional
 
     moved = 0
 
@@ -583,6 +590,12 @@ def move_copper_graphics_to_silkscreen_board(board):
     for drawing in board.GetDrawings():
         _relocate(drawing)
     for footprint in board.GetFootprints():
+        # #908: a pad-bearing footprint's copper is the part's own land
+        # pattern. The loop already holds the owning FOOTPRINT, so the pad
+        # count is read here rather than through a parent lookup (board-level
+        # drawings have no parent to look up).
+        if footprint_copper_is_functional(len(footprint.Pads())):
+            continue
         for item in footprint.GraphicalItems():
             _relocate(item)
     return moved

--- a/krt_capabilities.py
+++ b/krt_capabilities.py
@@ -62,6 +62,11 @@ KNOWN_MODULES = (
     'check_impedance.py', 'check_orphan_stubs.py', 'check_pads.py',
     'check_pockets.py', 'place_seed.py',
     'kicad_unconnected.py', 'net_forensics.py', 'copy_board.py',
+    # #910. The opt-in DELIVERY step: a routed board ships zone
+    # outlines with no filled_polygon, so an unrefilled grade reports
+    # plane opens that are not real. A tool nobody can discover gets
+    # used by nobody.
+    'fill_for_delivery.py',
     'make_movie.py', 'render_placement.py', 'list_nets.py', 'route_summary.py',
     # The two pre-route placement instruments. `check_channels.py` is the
     # per-face lane ledger the placement skill tells an operator to run before

--- a/py_placer/placement/placement_state.py
+++ b/py_placer/placement/placement_state.py
@@ -100,7 +100,14 @@ def assess_placement(pcb_data, pcb_file: Optional[str] = None,
 
     fps = [fp for fp in (pcb_data.footprints or {}).values() if fp.pads]
     st.n_footprints = len(fps)
-    st.segments = len(pcb_data.segments or [])
+    # ROUTED copper only (#908). A footprint's own drawn copper -- a SOT89
+    # tab, a PCB antenna -- now parses as `graphic=True` Segments, and it is
+    # not something a placement run would strand: it MOVES WITH ITS PART.
+    # Counting it made watchy's 48 antenna edges read as a routed board, and
+    # every placement CLI refused an unrouted board with "moving a footprint
+    # would strand its tracks".
+    st.segments = len([s for s in (pcb_data.segments or [])
+                       if not getattr(s, 'graphic', False)])
     st.vias = len(pcb_data.vias or [])
     st.has_copper = (st.segments + st.vias) > 0
     if not fps:

--- a/py_router/check_drc.py
+++ b/py_router/check_drc.py
@@ -694,21 +694,30 @@ def graphic_effective_nets(pcb_data, include_mutable=True):
     into the OUT nets, so its 68um "grazes" are internal spacing of one
     electrical net, which KiCad correctly ignores.
 
-    `include_mutable` (#908) is the one thing a GENERATOR must get right:
+    `include_mutable` (#908):
 
-      * True  -- attributes + pads + tracks + vias. check_drc's answer, and
-        the right one for a CHECKER, which grades the board in front of it.
-      * False -- attributes + PADS ONLY. The right one for the obstacle map,
-        because tracks and vias move during a route: a rip can delete the very
-        track that granted net X after the router has already used that
-        permission, and check_drc on the output would then flag copper the
-        router thought was allowed.
+      * True  -- attributes + pads + tracks + vias. THE ONLY VALUE PRODUCTION
+        PASSES. It is check_drc's own answer, and the right one for a CHECKER,
+        which grades the board in front of it.
+      * False -- attributes + PADS ONLY. **No production caller.** It exists
+        as the STABLE middle term of the subset proof below, and
+        tests/test_908_own_pad_lift.py is what exercises it.
 
-    Pads never move or vanish mid-route, so the False answer is a SUBSET of
-    the True answer at every instant -- the generator can therefore never be
-    more permissive than the checker, which is the only direction that
-    matters. Do not "simplify" the obstacle side onto the full answer;
-    tests/test_908_own_pad_lift.py asserts the subset relation.
+    Why a stable term is needed at all: tracks and vias MOVE during a route,
+    so a permission derived from them can be withdrawn after the router has
+    used it -- a rip deletes the track that granted net X, and check_drc on
+    the output then flags copper the router thought was allowed. Pads do not
+    move. So, with the obstacle map's own answer being the narrowest of the
+    three:
+
+        graphic_own_pad_nets                (what obstacle_map.py:229 uses)
+          subset-of  graphic_effective_nets(include_mutable=False)
+          subset-of  graphic_effective_nets(include_mutable=True)   [checker]
+
+    the generator can never be more permissive than the checker -- the only
+    direction that matters. Do not "simplify" the obstacle side onto the full
+    answer, and do not delete the False arm because nothing calls it: it is
+    the term that makes the chain checkable.
     """
     import math as _m
     out = {}
@@ -814,8 +823,9 @@ def graphic_own_pad_nets(pcb_data):
     would let a GND route cross the entire antenna -- graded clean by that
     same reasoning, and a destroyed part. Lifting only the edges that actually
     touch the pad opens the pocket and leaves the rest of the shape blocking:
-    on esp_prog exactly the three notch edges around pad 2 lift, and the five
-    outer tab edges keep blocking.
+    on esp_prog **5 of the 8 tab edges lift** (the three around pad 2's notch
+    plus the two diagonals whose inner corner also lands within a half-width
+    of the pad), and the 3 outer tab edges keep blocking. On watchy 6 of 48.
 
     Subset chain, asserted in tests/test_908_own_pad_lift.py:
         own-pad  subset-of  effective(include_mutable=False)

--- a/py_router/check_drc.py
+++ b/py_router/check_drc.py
@@ -675,20 +675,46 @@ _GRAPHIC_EFFECTIVE_NETS = None  # set per check run by _build_graphic_unificatio
 
 
 def _build_graphic_unification(pcb_data):
-    """KiCad derives a copper GRAPHIC's net from CONNECTIVITY, unifying every
+    """Set the module-level map `check_drc` reads. See `graphic_effective_nets`."""
+    global _GRAPHIC_EFFECTIVE_NETS, _GRAPHIC_OWN_PAD_NETS
+    _GRAPHIC_EFFECTIVE_NETS = graphic_effective_nets(pcb_data)
+    _GRAPHIC_OWN_PAD_NETS = graphic_own_pad_nets(pcb_data)
+
+
+def graphic_effective_nets(pcb_data, include_mutable=True):
+    """`{id(graphic_segment): frozenset(net_ids)}` -- KiCad's own answer to
+    "what net is this copper GRAPHIC on?".
+
+    KiCad derives a copper GRAPHIC's net from CONNECTIVITY, unifying every
     net whose copper physically touches the art (#337). Cluster touching
     graphics (flood over edge-contact), then record each cluster's EFFECTIVE
     net set = the file attributes plus every net whose segment/via/pad touches
     the cluster. Pair checks treat a graphic as same-net with any effective
     net -- eurorack's jack art carries a stale +12V attribute yet is soldered
     into the OUT nets, so its 68um "grazes" are internal spacing of one
-    electrical net, which KiCad correctly ignores."""
+    electrical net, which KiCad correctly ignores.
+
+    `include_mutable` (#908) is the one thing a GENERATOR must get right:
+
+      * True  -- attributes + pads + tracks + vias. check_drc's answer, and
+        the right one for a CHECKER, which grades the board in front of it.
+      * False -- attributes + PADS ONLY. The right one for the obstacle map,
+        because tracks and vias move during a route: a rip can delete the very
+        track that granted net X after the router has already used that
+        permission, and check_drc on the output would then flag copper the
+        router thought was allowed.
+
+    Pads never move or vanish mid-route, so the False answer is a SUBSET of
+    the True answer at every instant -- the generator can therefore never be
+    more permissive than the checker, which is the only direction that
+    matters. Do not "simplify" the obstacle side onto the full answer;
+    tests/test_908_own_pad_lift.py asserts the subset relation.
+    """
     import math as _m
-    global _GRAPHIC_EFFECTIVE_NETS
-    _GRAPHIC_EFFECTIVE_NETS = {}
+    out = {}
     graphics = [sg for sg in pcb_data.segments if getattr(sg, 'graphic', False)]
     if not graphics:
-        return
+        return out
 
     def seg_seg_touch(a, b):
         if a.layer != b.layer:
@@ -744,16 +770,17 @@ def _build_graphic_unification(pcb_data):
         eff = {g.net_id for g in members}
         for g in members:
             hw = g.width / 2.0
-            # touching routed/input segments
-            for sg in pcb_data.segments:
-                if getattr(sg, 'graphic', False) or sg.layer != g.layer:
-                    continue
-                if _seg_seg_distance(g, sg) <= hw + sg.width / 2.0 + 1e-6:
-                    eff.add(sg.net_id)
-            # touching vias (barrel spans all layers)
-            for v in pcb_data.vias:
-                if _pt_seg_d(v.x, v.y, g) <= hw + (v.size or 0.5) / 2.0 + 1e-6:
-                    eff.add(v.net_id)
+            if include_mutable:
+                # touching routed/input segments
+                for sg in pcb_data.segments:
+                    if getattr(sg, 'graphic', False) or sg.layer != g.layer:
+                        continue
+                    if _seg_seg_distance(g, sg) <= hw + sg.width / 2.0 + 1e-6:
+                        eff.add(sg.net_id)
+                # touching vias (barrel spans all layers)
+                for v in pcb_data.vias:
+                    if _pt_seg_d(v.x, v.y, g) <= hw + (v.size or 0.5) / 2.0 + 1e-6:
+                        eff.add(v.net_id)
             # touching pads (on the graphic's layer)
             for pads in pcb_data.pads_by_net.values():
                 for pd in pads:
@@ -764,8 +791,108 @@ def _build_graphic_unification(pcb_data):
                                 point_to_pad_distance(g.end_x, g.end_y, pd))
                     if mid_d <= hw + 1e-6:
                         eff.add(pd.net_id)
+        eff = frozenset(eff)
         for g in members:
-            _GRAPHIC_EFFECTIVE_NETS[id(g)] = eff
+            out[id(g)] = eff
+    return out
+
+
+def graphic_own_pad_nets(pcb_data):
+    """`{id(graphic_segment): frozenset(net_ids)}` -- for each piece of copper
+    a FOOTPRINT draws, the nets of that same footprint's pads it touches.
+
+    #908, the obstacle side. A footprint's own copper is net-0 foreign copper
+    to every net, so stamping it whole would SEAL the pad it was drawn around:
+    esp_prog's U2 tab notches around pad 2 (`Net-(C1-Pad1)`), whose west edge
+    is coincident with the poly's, and the router could no longer reach it --
+    the failure mode of sibling #907, manufactured by the fix for #908.
+
+    Deliberately PER SEGMENT and OWN FOOTPRINT ONLY, not per cluster. The
+    whole-cluster answer (`graphic_effective_nets`) is what the CHECKER uses
+    and it is much wider: watchy's twelve antenna polys are one connected
+    cluster touching both the feed pad and a GND pad, so a cluster-wide lift
+    would let a GND route cross the entire antenna -- graded clean by that
+    same reasoning, and a destroyed part. Lifting only the edges that actually
+    touch the pad opens the pocket and leaves the rest of the shape blocking:
+    on esp_prog exactly the three notch edges around pad 2 lift, and the five
+    outer tab edges keep blocking.
+
+    Subset chain, asserted in tests/test_908_own_pad_lift.py:
+        own-pad  subset-of  effective(include_mutable=False)
+                 subset-of  effective(include_mutable=True)   [the checker]
+    so the generator can never permit copper the checker will flag.
+
+    Endpoint distance, matching `graphic_effective_nets`' own pad arm -- the
+    two must not disagree about what "touches" means, and erring narrow lifts
+    less, which is the safe direction for a generator.
+    """
+    out = {}
+    fps = getattr(pcb_data, 'footprints', None) or {}
+    for g in pcb_data.segments:
+        if not getattr(g, 'graphic', False):
+            continue
+        owner = getattr(g, 'owner_ref', '')
+        fp = fps.get(owner) if owner else None
+        if fp is None:
+            continue
+        hw = g.width / 2.0
+        nets = set()
+        for pd in fp.pads:
+            if not pd.net_id:
+                continue
+            lys = pd.layers or []
+            if g.layer not in lys and '*.Cu' not in lys:
+                continue
+            if min(point_to_pad_distance(g.start_x, g.start_y, pd),
+                   point_to_pad_distance(g.end_x, g.end_y, pd)) <= hw + 1e-6:
+                nets.add(pd.net_id)
+        if nets:
+            out[id(g)] = frozenset(nets)
+    return out
+
+
+_GRAPHIC_OWN_PAD_NETS = {}  # set per check run beside _GRAPHIC_EFFECTIVE_NETS
+
+
+def _graphic_own_pad_pair(seg_a, seg_b, net_a, net_b) -> bool:
+    """Is this pair "a footprint's own copper and its own pad's net"? (#908)
+
+    Unlike `_graphic_pair_is_same_net` this cannot be satisfied by the item
+    being tested: the map is built from the owning FOOTPRINT'S PADS, so a
+    foreign track that merely touches the art never appears in it.
+    """
+    for g, other in ((seg_a, net_b), (seg_b, net_a)):
+        if getattr(g, 'graphic', False) and                 other in _GRAPHIC_OWN_PAD_NETS.get(id(g), ()):
+            return True
+    return False
+
+
+def _fmt_item(v, key) -> str:
+    """Printer-side: ` [Polygon(U2)]` when a violation carries that label."""
+    lbl = v.get(key)
+    return f' [{lbl}]' if lbl else ''
+
+
+def graphic_item_label(seg) -> str:
+    """How to NAME a piece of copper in a violation, KiCad's way (#908).
+
+    A routed track is named by its net and that is enough. A copper GRAPHIC
+    carries no net, so it reported as the anonymous `net_0` -- true, but it
+    names no object on the board and a reader cannot find it. KiCad says
+    "Polygon [<no net>] of U2 on F.Cu"; this says `Polygon(U2)`.
+
+    Returns '' for anything that is not a graphic, so a caller can append it
+    unconditionally.
+    """
+    if not getattr(seg, 'graphic', False):
+        return ''
+    owner = getattr(seg, 'owner_ref', '')
+    return f'Polygon({owner})' if owner else 'Graphic'
+
+
+def _label_suffix(seg) -> str:
+    lbl = graphic_item_label(seg)
+    return f' [{lbl}]' if lbl else ''
 
 
 def _graphic_pair_is_same_net(seg_a, seg_b, net_a, net_b):
@@ -2249,6 +2376,9 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
                              else 'segment-segment'),
                     'net1': net1_str,
                     'net2': net2_str,
+                    'item1': graphic_item_label(seg1),
+                    'item2': graphic_item_label(seg2),
+                    'no_net': net1 == 0 or net2 == 0,
                     'layer': seg1.layer,
                     'overlap_mm': overlap,
                     'loc1': (seg1.start_x, seg1.start_y, seg1.end_x, seg1.end_y),
@@ -2264,6 +2394,17 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
 
             # Also check for segment crossings (different nets)
             crosses, cross_point = segments_cross(seg1, seg2)
+            if crosses and _graphic_own_pad_pair(seg1, seg2, net1, net2):
+                # #908: a net's own track crossing its own footprint's copper
+                # -- the whole point of a SOT89 tab -- is not a violation. The
+                # exemption deliberately uses the OWN-PAD map, not
+                # `_graphic_pair_is_same_net`: the connectivity unification
+                # adds the net of every track that touches the art, so a
+                # FOREIGN track grazing it would exempt ITSELF and the
+                # crossing would go unreported. The own-pad map is derived
+                # from the owning footprint's pads alone and cannot be
+                # self-justified by the item under test.
+                crosses = False
             if crosses:
                 net1_name = pcb_data.nets.get(net1, None)
                 net2_name = pcb_data.nets.get(net2, None)
@@ -2273,6 +2414,9 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
                     'type': 'segment-crossing',
                     'net1': net1_str,
                     'net2': net2_str,
+                    'item1': graphic_item_label(seg1),
+                    'item2': graphic_item_label(seg2),
+                    'no_net': net1 == 0 or net2 == 0,
                     'layer': seg1.layer,
                     'cross_point': cross_point,
                     'loc1': (seg1.start_x, seg1.start_y, seg1.end_x, seg1.end_y),
@@ -2422,6 +2566,7 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
                     seg_net_str = seg_net_name.name if seg_net_name else f"net_{seg_net}"
                     violations.append(_mark_required({
                         'type': 'via-segment',
+                        'item2': graphic_item_label(seg),
                         'net1': via_net_str,
                         'net2': seg_net_str,
                         'layer': seg.layer,
@@ -2512,6 +2657,8 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
                 seg_net_str = seg_net_name.name if seg_net_name else f"net_{seg_net}"
                 violations.append(_mark_required({
                     'type': 'pad-segment',
+                    'item2': graphic_item_label(seg),
+                    'no_net': pad_net == 0 or seg_net == 0,
                     'net1': pad_net_str,
                     'net2': seg_net_str,
                     'layer': seg.layer,
@@ -3034,6 +3181,7 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
             if s_edge != "off-board" and use_poly and _seg_edge_all_in_pads(seg):
                 _accepted_edge.append({
                     'type': 'segment-board-edge', 'net1': net_str, 'edge': s_edge,
+                    'item1': graphic_item_label(seg),
                     'layer': seg.layer, 'overlap_mm': s_overlap,
                     'seg_loc': (seg.start_x, seg.start_y, seg.end_x, seg.end_y),
                     'accepted': 'edge-exempt-pad',
@@ -3046,6 +3194,7 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
             if s_edge == "off-board" or s_overlap > _grade_tol(effective_board_edge_clearance, clearance_margin):
                 violations.append({
                     'type': 'segment-board-edge', 'net1': net_str, 'edge': s_edge,
+                    'item1': graphic_item_label(seg),
                     'layer': seg.layer, 'overlap_mm': s_overlap,
                     'seg_loc': (seg.start_x, seg.start_y, seg.end_x, seg.end_y),
                 })
@@ -3058,6 +3207,7 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
                 # publish-don't-drop contract as the pad-covered class above).
                 _accepted_edge.append({
                     'type': 'segment-board-edge', 'net1': net_str, 'edge': s_edge,
+                    'item1': graphic_item_label(seg),
                     'layer': seg.layer, 'overlap_mm': s_overlap,
                     'seg_loc': (seg.start_x, seg.start_y, seg.end_x, seg.end_y),
                     'accepted': 'quantization-margin',
@@ -3187,6 +3337,7 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
                     net_str = net_name.name if net_name else f"net_{seg.net_id}"
                     _v = {
                         'type': 'segment-board-edge', 'net1': net_str,
+                        'item1': graphic_item_label(seg),
                         'edge': 'npth-slot', 'layer': seg.layer,
                         'overlap_mm': float(_ovl[_k]), 'slot_ref': _slot_ref,
                         'seg_loc': (seg.start_x, seg.start_y, seg.end_x, seg.end_y),
@@ -3417,14 +3568,16 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
                 print("-" * 40)
                 for v in vlist[:limit]:  # Show first `limit` of each type
                     if vtype in ('segment-segment', 'segment-segment-track-rule'):
-                        print(f"  {v['net1']} <-> {v['net2']}")
+                        print(f"  {v['net1']}{_fmt_item(v, 'item1')} <-> "
+                              f"{v['net2']}{_fmt_item(v, 'item2')}")
                         print(f"    Layer: {v['layer']}, Overlap: {v['overlap_mm']:.3f}mm")
                         if v.get('track_rule'):
                             print(f"    Track rule: '{v['track_rule']}' (floor-governed pair)")
                         print(f"    Seg1: ({v['loc1'][0]:.2f},{v['loc1'][1]:.2f})-({v['loc1'][2]:.2f},{v['loc1'][3]:.2f})")
                         print(f"    Seg2: ({v['loc2'][0]:.2f},{v['loc2'][1]:.2f})-({v['loc2'][2]:.2f},{v['loc2'][3]:.2f})")
                     elif vtype == 'via-segment':
-                        print(f"  Via:{v['net1']} <-> Seg:{v['net2']}")
+                        print(f"  Via:{v['net1']} <-> "
+                              f"Seg:{v['net2']}{_fmt_item(v, 'item2')}")
                         print(f"    Layer: {v['layer']}, Overlap: {v['overlap_mm']:.3f}mm")
                         print(f"    Via: ({v['via_loc'][0]:.2f},{v['via_loc'][1]:.2f})")
                         print(f"    Seg: ({v['seg_loc'][0]:.2f},{v['seg_loc'][1]:.2f})-({v['seg_loc'][2]:.2f},{v['seg_loc'][3]:.2f})")
@@ -3434,7 +3587,8 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
                         print(f"    Via1: ({v['loc1'][0]:.2f},{v['loc1'][1]:.2f})")
                         print(f"    Via2: ({v['loc2'][0]:.2f},{v['loc2'][1]:.2f})")
                     elif vtype in ('segment-crossing', 'segment-crossing-same-net'):
-                        print(f"  {v['net1']} <-> {v['net2']}")
+                        print(f"  {v['net1']}{_fmt_item(v, 'item1')} <-> "
+                              f"{v['net2']}{_fmt_item(v, 'item2')}")
                         print(f"    Layer: {v['layer']}, Cross at: ({v['cross_point'][0]:.3f},{v['cross_point'][1]:.3f})")
                         print(f"    Seg1: ({v['loc1'][0]:.2f},{v['loc1'][1]:.2f})-({v['loc1'][2]:.2f},{v['loc1'][3]:.2f})")
                         print(f"    Seg2: ({v['loc2'][0]:.2f},{v['loc2'][1]:.2f})-({v['loc2'][2]:.2f},{v['loc2'][3]:.2f})")
@@ -3445,7 +3599,8 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
                         print(f"    Ends: ({v['loc1'][0]:.3f},{v['loc1'][1]:.3f}) <-> "
                               f"({v['loc2'][0]:.3f},{v['loc2'][1]:.3f})")
                     elif vtype == 'pad-segment':
-                        print(f"  Pad:{v['net1']} ({v['pad_ref']}) <-> Seg:{v['net2']}")
+                        print(f"  Pad:{v['net1']} ({v['pad_ref']}) <-> "
+                              f"Seg:{v['net2']}{_fmt_item(v, 'item2')}")
                         print(f"    Layer: {v['layer']}, Overlap: {v['overlap_mm']:.3f}mm")
                         print(f"    Pad: ({v['pad_loc'][0]:.2f},{v['pad_loc'][1]:.2f})")
                         print(f"    Seg: ({v['seg_loc'][0]:.2f},{v['seg_loc'][1]:.2f})-({v['seg_loc'][2]:.2f},{v['seg_loc'][3]:.2f})")
@@ -3484,7 +3639,7 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
                         print(f"    Via: ({v['via_loc'][0]:.2f},{v['via_loc'][1]:.2f})")
                     elif vtype == 'segment-board-edge':
                         where = _edge_phrase(v['edge'])
-                        print(f"  {v['net1']} {where}")
+                        print(f"  {v['net1']}{_fmt_item(v, 'item1')} {where}")
                         print(f"    Layer: {v['layer']}, Overlap: {v['overlap_mm']:.3f}mm")
                         print(f"    Seg: ({v['seg_loc'][0]:.2f},{v['seg_loc'][1]:.2f})-({v['seg_loc'][2]:.2f},{v['seg_loc'][3]:.2f})")
                     elif vtype == 'via-board-edge':

--- a/py_router/check_drc.py
+++ b/py_router/check_drc.py
@@ -877,6 +877,16 @@ def _graphic_own_pad_pair(seg_a, seg_b, net_a, net_b) -> bool:
     return False
 
 
+def _no_net_note(v) -> str:
+    """`  (no net: a clearance issue, not a short)` when one side is netless.
+
+    The `no_net` key follows the pad-pad idiom (a pad with no net cannot
+    electrically short a net); without a printer arm it would be written and
+    read by nothing, which is how a key becomes decoration.
+    """
+    return '  (no net: a clearance issue, not a short)' if v.get('no_net') else ''
+
+
 def _fmt_item(v, key) -> str:
     """Printer-side: ` [Polygon(U2)]` when a violation carries that label."""
     lbl = v.get(key)
@@ -898,11 +908,6 @@ def graphic_item_label(seg) -> str:
         return ''
     owner = getattr(seg, 'owner_ref', '')
     return f'Polygon({owner})' if owner else 'Graphic'
-
-
-def _label_suffix(seg) -> str:
-    lbl = graphic_item_label(seg)
-    return f' [{lbl}]' if lbl else ''
 
 
 def _graphic_pair_is_same_net(seg_a, seg_b, net_a, net_b):
@@ -3197,6 +3202,23 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
                     'accepted': 'edge-exempt-pad',
                 })
                 continue
+            if getattr(seg, 'graphic', False):
+                # #908: a GRAPHIC near the board edge is the board author's
+                # own library art -- watchy's PCB antenna runs 0.218mm into
+                # its own edge zone. No routing pass can fix it (moving a
+                # part's copper is precisely what #908 forbids), so counting
+                # it would put a permanent, unactionable regression into every
+                # corpus A/B and every review-routed-board sign-off. PUBLISHED
+                # as an accepted class, not dropped -- the same
+                # publish-don't-drop contract as the pad-covered class above.
+                _accepted_edge.append({
+                    'type': 'segment-board-edge', 'net1': net_str,
+                    'edge': s_edge, 'item1': graphic_item_label(seg),
+                    'layer': seg.layer, 'overlap_mm': s_overlap,
+                    'seg_loc': (seg.start_x, seg.start_y, seg.end_x, seg.end_y),
+                    'accepted': 'immutable-graphic',
+                })
+                continue
             # not exempt -> real only if it clears the grid-quantization margin.
             # Derived from the STRICT result already computed above (identical
             # distances, only the tolerance differs) -- re-running the check at
@@ -3579,7 +3601,8 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
                 for v in vlist[:limit]:  # Show first `limit` of each type
                     if vtype in ('segment-segment', 'segment-segment-track-rule'):
                         print(f"  {v['net1']}{_fmt_item(v, 'item1')} <-> "
-                              f"{v['net2']}{_fmt_item(v, 'item2')}")
+                              f"{v['net2']}{_fmt_item(v, 'item2')}"
+                              + _no_net_note(v))
                         print(f"    Layer: {v['layer']}, Overlap: {v['overlap_mm']:.3f}mm")
                         if v.get('track_rule'):
                             print(f"    Track rule: '{v['track_rule']}' (floor-governed pair)")
@@ -3598,7 +3621,8 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
                         print(f"    Via2: ({v['loc2'][0]:.2f},{v['loc2'][1]:.2f})")
                     elif vtype in ('segment-crossing', 'segment-crossing-same-net'):
                         print(f"  {v['net1']}{_fmt_item(v, 'item1')} <-> "
-                              f"{v['net2']}{_fmt_item(v, 'item2')}")
+                              f"{v['net2']}{_fmt_item(v, 'item2')}"
+                              + _no_net_note(v))
                         print(f"    Layer: {v['layer']}, Cross at: ({v['cross_point'][0]:.3f},{v['cross_point'][1]:.3f})")
                         print(f"    Seg1: ({v['loc1'][0]:.2f},{v['loc1'][1]:.2f})-({v['loc1'][2]:.2f},{v['loc1'][3]:.2f})")
                         print(f"    Seg2: ({v['loc2'][0]:.2f},{v['loc2'][1]:.2f})-({v['loc2'][2]:.2f},{v['loc2'][3]:.2f})")
@@ -3610,7 +3634,8 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
                               f"({v['loc2'][0]:.3f},{v['loc2'][1]:.3f})")
                     elif vtype == 'pad-segment':
                         print(f"  Pad:{v['net1']} ({v['pad_ref']}) <-> "
-                              f"Seg:{v['net2']}{_fmt_item(v, 'item2')}")
+                              f"Seg:{v['net2']}{_fmt_item(v, 'item2')}"
+                              + _no_net_note(v))
                         print(f"    Layer: {v['layer']}, Overlap: {v['overlap_mm']:.3f}mm")
                         print(f"    Pad: ({v['pad_loc'][0]:.2f},{v['pad_loc'][1]:.2f})")
                         print(f"    Seg: ({v['seg_loc'][0]:.2f},{v['seg_loc'][1]:.2f})-({v['seg_loc'][2]:.2f},{v['seg_loc'][3]:.2f})")

--- a/py_router/impedance.py
+++ b/py_router/impedance.py
@@ -1512,6 +1512,161 @@ def get_layer_epsilon_eff(pcb: PCBData, layer_name: str,
     return (er + 1) / 2
 
 
+#: A nominal FR4 stackup, for the ONE question that can be answered without a
+#: real one: "is this target impedance achievable on a board like this at all?"
+#: (#909). These are KiCad's own defaults for a 1.6 mm two-layer board -- see
+#: `kicad_files/flat_hierarchy.kicad_pcb`, which stores exactly 0.035 mm copper
+#: over a 1.51 mm er-4.5 core plus 0.01 mm masks. Nothing here WRITES a stackup;
+#: the board's author owns that (`/recommend-stackup`), and a written default
+#: would only make the width solver print a number and clamp it straight back.
+NOMINAL_BOARD_THICKNESS_MM = 1.6
+NOMINAL_COPPER_THICKNESS_MM = 0.035
+NOMINAL_MASK_THICKNESS_MM = 0.01
+NOMINAL_EPSILON_R = 4.5
+
+
+def nominal_stackup(n_copper_layers: int = 2,
+                    board_thickness: float = NOMINAL_BOARD_THICKNESS_MM):
+    """A synthetic `List[StackupLayer]` for a board that declares none (#909).
+
+    Copper of `NOMINAL_COPPER_THICKNESS_MM`, masks of
+    `NOMINAL_MASK_THICKNESS_MM`, and the remaining height split evenly into
+    er-`NOMINAL_EPSILON_R` dielectric between the copper layers. It is an
+    ASSUMPTION and every caller must print it as one.
+    """
+    from kicad_parser import StackupLayer
+    n = max(2, int(n_copper_layers))
+    cu = NOMINAL_COPPER_THICKNESS_MM
+    msk = NOMINAL_MASK_THICKNESS_MM
+    diel_total = max(0.05, board_thickness - n * cu - 2 * msk)
+    each = diel_total / (n - 1)
+    names = (['F.Cu'] + [f'In{i}.Cu' for i in range(1, n - 1)] + ['B.Cu'])
+    out = [StackupLayer('F.Mask', 'solder_mask', msk, 3.3, 0.0, 'mask')]
+    for i, nm in enumerate(names):
+        out.append(StackupLayer(nm, 'copper', cu, 0.0, 0.0, 'copper'))
+        if i < n - 1:
+            out.append(StackupLayer(f'dielectric {i + 1}',
+                                    'core' if n == 2 else 'prepreg',
+                                    each, NOMINAL_EPSILON_R, 0.02, 'FR4'))
+    out.append(StackupLayer('B.Mask', 'solder_mask', msk, 3.3, 0.0, 'mask'))
+    return out
+
+
+def _impedance_scope_net_ids(pcb: PCBData, net_names) -> list:
+    """Net ids the caller's `net_names` selects, globs included (#909).
+
+    The scope is resolved here rather than reused from the routing loop
+    because this note is printed BEFORE the loop resolves anything, and an
+    empty/None selection means "every net", which is what the CLIs mean by it.
+    """
+    import fnmatch as _fn
+    nets = getattr(pcb, 'nets', None) or {}
+    if not net_names:
+        return [nid for nid in nets if nid]
+    out = []
+    for nid, net in nets.items():
+        if not nid:
+            continue
+        nm = getattr(net, 'name', '') or ''
+        if any(nm == pat or _fn.fnmatch(nm, pat) for pat in net_names):
+            out.append(nid)
+    return out
+
+
+def tightest_pin_gap(pcb: PCBData, net_ids) -> float:
+    """Smallest edge-to-edge gap a trace of these nets has to leave through.
+
+    For every pad of `net_ids`, the gap to the NEAREST OTHER PAD OF THE SAME
+    FOOTPRINT -- i.e. the channel between the pins of the part it escapes
+    from. That is the number the impedance width has to be compared against
+    (#909): a 90 ohm leg is meaningless if it is three times the pin gap,
+    because it necks down at both ends anyway. Returns 0.0 when it cannot be
+    computed.
+    """
+    want = {int(n) for n in (net_ids or []) if n}
+    if not want or not getattr(pcb, 'footprints', None):
+        return 0.0
+    best = 0.0
+    for fp in pcb.footprints.values():
+        pads = list(getattr(fp, 'pads', None) or [])
+        if len(pads) < 2:
+            continue
+        mine = [p for p in pads if p.net_id in want]
+        for a in mine:
+            for b in pads:
+                if b is a:
+                    continue
+                dx = abs(a.global_x - b.global_x) - (a.size_x + b.size_x) / 2
+                dy = abs(a.global_y - b.global_y) - (a.size_y + b.size_y) / 2
+                gap = max(dx, dy)
+                if gap > 0 and (best == 0.0 or gap < best):
+                    best = gap
+    return best
+
+
+def achievability_note(pcb: PCBData, layer_name: str, target_z0: float, *,
+                       is_differential: bool = False, spacing: float = 0.0,
+                       min_pitch_gap: float = 0.0,
+                       board_thickness: float = NOMINAL_BOARD_THICKNESS_MM):
+    """"Is `target_z0` reachable on a board like this?" -- with NUMBERS (#909).
+
+    A board with no `(stackup ...)` gets one line today: "No stackup found in
+    PCB file. Using fixed track width." True, and it tells the reader nothing
+    about whether authoring a stackup would have helped. The repo's own
+    solvers can answer that in one call against a NOMINAL stackup, and the
+    answer is usually decisive: on a 2-layer 1.6 mm FR4 board a 90 ohm
+    differential leg is 1.13 mm wide, against the 0.325 mm gap between the
+    0.65 mm-pitch pins it has to leave from -- not achievable, and on a run
+    that short not needed either.
+
+    Returns `(text, detail_dict)`; `('', None)` when the board HAS a stackup
+    (then the real solver runs and this has nothing to add) or when the
+    solver cannot answer.
+    """
+    import copy as _copy
+    if pcb is None or not target_z0:
+        return '', None
+    bi = getattr(pcb, 'board_info', None)
+    if bi is None or getattr(bi, 'stackup', None):
+        return '', None            # a real stackup: the real path runs
+    n_cu = len(getattr(bi, 'copper_layers', None) or []) or 2
+    probe = _copy.copy(pcb)
+    probe_bi = _copy.copy(bi)
+    probe_bi.stackup = nominal_stackup(n_cu, board_thickness)
+    probe.board_info = probe_bi
+    try:
+        res = calculate_width_for_impedance(
+            probe, layer_name, target_z0, spacing=spacing,
+            is_differential=is_differential)
+    except Exception:
+        return '', None
+    width = (res or {}).get('calculated_width_mm')
+    if not width:
+        return '', None
+    kind = 'differential leg' if is_differential else 'trace'
+    channel = (2 * width + spacing) if is_differential else width
+    text = (f"No stackup declared, so no impedance pass runs. On a NOMINAL "
+            f"{n_cu}-layer {board_thickness:g}mm FR4 stack (er "
+            f"{NOMINAL_EPSILON_R:g}, {NOMINAL_COPPER_THICKNESS_MM * 1000:.0f}um "
+            f"Cu) {target_z0:g} ohm on {layer_name} would need a "
+            f"{width:.3f}mm {kind}"
+            + (f" ({channel:.3f}mm for the pair)" if is_differential else ""))
+    detail = {'assumed': 'nominal', 'copper_layers': n_cu,
+              'board_thickness_mm': board_thickness,
+              'epsilon_r': NOMINAL_EPSILON_R, 'target_ohms': float(target_z0),
+              'layer': layer_name, 'width_mm': round(float(width), 4),
+              'channel_mm': round(float(channel), 4),
+              'differential': bool(is_differential)}
+    if min_pitch_gap and min_pitch_gap > 0:
+        ratio = channel / min_pitch_gap
+        detail['pin_gap_mm'] = round(float(min_pitch_gap), 4)
+        detail['channel_over_pin_gap'] = round(ratio, 2)
+        text += (f", against a {min_pitch_gap:.3f}mm gap between the pins it "
+                 f"leaves from -- {ratio:.1f}x. Not achievable here")
+    text += ". Author a stackup (/recommend-stackup) if you need it graded."
+    return text, detail
+
+
 def get_layer_ps_per_mm(pcb: PCBData, layer_name: str) -> float:
     """
     Get propagation delay in picoseconds per millimeter for a layer.

--- a/py_router/kicad_exact_fill.py
+++ b/py_router/kicad_exact_fill.py
@@ -616,6 +616,80 @@ def refill_islands_ex(board_file: str, timeout: int = EXACT_FILL_TIMEOUT,
     return _out, _ok_status(_out, time.monotonic() - _t0)
 
 
+def write_filled_board(board_file: str, dst_file: str,
+                       timeout: int = EXACT_FILL_TIMEOUT,
+                       verbose: bool = False,
+                       project_from: str = None) -> RefillStatus:
+    """Write a FILLED copy of `board_file` to `dst_file` (#910).
+
+    The routed deliverable carries zone OUTLINES with no `(filled_polygon ...)`
+    -- `kicad_writer` writes the `(fill yes ...)` properties and nothing in the
+    plane path ever writes a fill. Opened in KiCad before a refill, or graded
+    by `kicad-cli pcb drc` WITHOUT `--refill-zones`, such a board reports
+    plane-net opens that are not real: measured on run 25's routed.kicad_pcb,
+    5 unconnected (all GND) without the flag and 0 with it.
+
+    Same machinery as `refill_islands_ex` -- KiCad's own ZONE_FILLER through
+    its bundled python -- except that the filled board is the PRODUCT rather
+    than a temp file the reader is parsed out of and deleted. The save is
+    `aSkipSettings=True`, which is what keeps the sibling `.kicad_pro` intact:
+    a plain `pcbnew.SaveBoard` rewrites the project from KiCad's in-memory
+    (pre-stamp, possibly pre-migration) view and silently deletes every
+    non-Default net class, and on pre-KiCad-10 projects aborts the process
+    outright. `headless_plan` documents that trap; this must not re-open it.
+
+    The caller is responsible for the sibling files at `dst_file` (use
+    `copy_board.copy_board` first); this writes ONLY the board.
+
+    Returns a `RefillStatus`; `dst_file` is untouched unless `.ok`.
+    """
+    kpy = find_kicad_python()
+    if kpy is None:
+        return RefillStatus('no_kicad_python')
+    tmpdir = tempfile.mkdtemp(prefix='fill_delivery_')
+    _t0 = time.monotonic()
+    try:
+        stem = os.path.splitext(os.path.basename(board_file))[0]
+        staged = os.path.join(tmpdir, stem + '.kicad_pcb')
+        shutil.copyfile(board_file, staged)
+        sib_pro = os.path.splitext(board_file)[0] + '.kicad_pro'
+        if not os.path.isfile(sib_pro) and project_from:
+            sib_pro = os.path.splitext(project_from)[0] + '.kicad_pro'
+        if os.path.isfile(sib_pro):
+            shutil.copyfile(sib_pro, os.path.join(tmpdir,
+                                                  stem + '.kicad_pro'))
+        script = os.path.join(tmpdir, 'refill.py')
+        with open(script, 'w') as f:
+            f.write(_REFILL_SCRIPT)
+        filled = os.path.join(tmpdir, stem + '_filled.kicad_pcb')
+        r = subprocess.run([kpy, script, staged, filled,
+                            os.path.dirname(os.path.abspath(__file__))],
+                           capture_output=True, text=True, timeout=timeout)
+        if 'REFILL_OK' not in (r.stdout or '') or not os.path.isfile(filled):
+            _why = (r.stderr or '').strip()[-200:]
+            if verbose:
+                print(f"  (fill-for-delivery failed: rc={r.returncode} {_why})")
+            return RefillStatus('refill_failed',
+                                f'rc={r.returncode} {_why}'.strip(),
+                                time.monotonic() - _t0)
+        # Written only once the refill succeeded, so a failure never leaves a
+        # half-written deliverable behind.
+        shutil.copyfile(filled, dst_file)
+    except subprocess.TimeoutExpired:
+        _dt = time.monotonic() - _t0
+        if verbose:
+            print(f"  (fill-for-delivery timed out after {_dt:.0f}s)")
+        return RefillStatus('timeout', f'limit {timeout}s', _dt)
+    except Exception as e:
+        if verbose:
+            print(f"  (fill-for-delivery unavailable: {e})")
+        return RefillStatus('error', f'{type(e).__name__}: {e}',
+                            time.monotonic() - _t0)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+    return RefillStatus('ok', '', time.monotonic() - _t0)
+
+
 def parse_filled_islands(text: str
                          ) -> Dict[Tuple[str, str],
                                    List[List[Tuple[float, float]]]]:

--- a/py_router/kicad_exact_fill.py
+++ b/py_router/kicad_exact_fill.py
@@ -631,12 +631,16 @@ def write_filled_board(board_file: str, dst_file: str,
 
     Same machinery as `refill_islands_ex` -- KiCad's own ZONE_FILLER through
     its bundled python -- except that the filled board is the PRODUCT rather
-    than a temp file the reader is parsed out of and deleted. The save is
-    `aSkipSettings=True`, which is what keeps the sibling `.kicad_pro` intact:
+    than a temp file the reader is parsed out of and deleted.
+
+    The save is `aSkipSettings=True`, for the reason `headless_plan` documents:
     a plain `pcbnew.SaveBoard` rewrites the project from KiCad's in-memory
-    (pre-stamp, possibly pre-migration) view and silently deletes every
-    non-Default net class, and on pre-KiCad-10 projects aborts the process
-    outright. `headless_plan` documents that trap; this must not re-open it.
+    (pre-stamp, possibly pre-migration) view -- deleting every non-Default net
+    class -- and aborts the process outright on a pre-KiCad-10 project. Note
+    what that does NOT do here: the fill runs in a temp dir on a STAGED copy,
+    so the caller's destination `.kicad_pro` is never in reach either way.
+    The caller's own net-class audit is the check that this stayed true, not a
+    restatement of it.
 
     The caller is responsible for the sibling files at `dst_file` (use
     `copy_board.copy_board` first); this writes ONLY the board.

--- a/py_router/kicad_parser.py
+++ b/py_router/kicad_parser.py
@@ -343,6 +343,12 @@ class Segment:
     # net's copper when any of it is locked (#521 follow-up); locked copper was
     # already an obstacle (#150). Set by BOTH parse paths (text + pcbnew).
     locked: bool = False
+    # #908: for copper drawn INSIDE a footprint, the DISAMBIGUATED footprint
+    # key that owns it ('U2', 'TP4~2'); '' for board-level graphics and for
+    # every routed track. It is what lets a DRC report name the object the way
+    # KiCad does ("Polygon of U2 on F.Cu") instead of the anonymous `net_0`,
+    # and what scopes the own-pad obstacle lift to the owning part.
+    owner_ref: str = ""
 
 
 @dataclass
@@ -1504,7 +1510,35 @@ def _mask_pad_primitives(content: str) -> str:
     return ''.join(out)
 
 
+@functools.lru_cache(maxsize=2)
+def _footprint_blocks_by_key_cached(content: str):
+    return _footprint_blocks_by_key_uncached(content)
+
+
 def _footprint_blocks_by_key(content: str):
+    """Memoised wrapper. See `_footprint_blocks_by_key_uncached`.
+
+    ONE parse now asks this question four times -- `extract_board_bounds`,
+    `footprint_outline_owners` (#829), `_collect_footprint_edge_segments_by_ref`
+    (#550) and the #908 footprint-copper pass -- and each call is a
+    `find_matching_paren` walk over every footprint block on the board, i.e.
+    over the whole file. Uncached, the #908 pass alone cost +41% on ulx3s,
+    +47% on glasgow_revC (which carries NO footprint copper at all: the walk,
+    not the work) and +74% on watchy. Memoised, the #908 pass is free AND the
+    three older callers stop paying for their own repeats.
+
+    The returned list is treated as READ-ONLY by every caller; do not mutate
+    it. `maxsize=2` for the same reason `_footprint_edge_points_by_ref` uses
+    it: the only repeat caller is one parse, and caching board texts is not
+    worth the memory.
+    """
+    try:
+        return _footprint_blocks_by_key_cached(content)
+    except TypeError:                                            # unhashable
+        return _footprint_blocks_by_key_uncached(content)
+
+
+def _footprint_blocks_by_key_uncached(content: str):
     """Ordered `(start, end, key)` for every `(footprint ...)` block, keyed the
     way `extract_footprints_and_pads` keys the footprints dict (#829).
 
@@ -1522,6 +1556,101 @@ def _footprint_blocks_by_key(content: str):
         raws.append(footprint_raw_reference(content[m.start():end]))
     return [(a, b, k) for (a, b), k in
             zip(spans, disambiguate_references(raws))]
+
+
+#: The footprint-embedded drawing primitives. `fp_curve` is deliberately absent
+#: from the COPPER scan (see `iter_footprint_shapes`): the Edge.Cuts scans
+#: linearize it for bounds, but no corpus board draws copper with one, and a
+#: bezier needs its own linearizer rather than a shared block reader.
+_FP_SHAPE_TAGS = ('fp_line', 'fp_arc', 'fp_poly', 'fp_rect', 'fp_circle')
+_FP_SHAPE_RE = re.compile(r'\(fp_(?:line|arc|poly|rect|circle)\b')
+
+
+def iter_footprint_shapes(fp_text: str, tags=_FP_SHAPE_TAGS):
+    """Yield `(tag, block)` for each `(fp_* ...)` shape in ONE footprint block,
+    every block read as a BALANCED sub-expression (#908).
+
+    Balanced, not regex-sliced, for the same reason the board-level `gr_*` scan
+    in `extract_segments` is block-based: an `fp_poly`'s vertices live in a
+    nested `(pts ...)` and its `(layer ...)` may sit on either side of them, so
+    a flat field-ordered pattern either misses the layer or runs out of one
+    shape into the next.
+
+    Custom-pad `(primitives ...)` are excluded FOR FREE because KiCad spells
+    those shapes `gr_*`, not `fp_*` -- do not widen this to "any shape inside a
+    footprint block", or urchin's 136 pad primitives arrive as phantom copper
+    at PAD-LOCAL coordinates.
+    """
+    for tag in tags:
+        needle = '(' + tag
+        pos = 0
+        while True:
+            i = fp_text.find(needle, pos)
+            if i < 0:
+                break
+            nxt = fp_text[i + len(needle): i + len(needle) + 1]
+            if nxt and (nxt.isalnum() or nxt == '_'):
+                pos = i + len(needle)      # token boundary: '(fp_linex'
+                continue
+            j = find_matching_paren(fp_text, i)
+            yield tag, fp_text[i:j]
+            pos = j
+
+
+def footprint_pose(fp_text: str):
+    """`(x, y, rotation_deg)` of one footprint block, or None.
+
+    The FIRST `(at ...)` in a footprint block is the footprint's own pose in
+    every KiCad dialect this parser reads; `_footprint_edge_points_by_ref` has
+    always resolved it this way and both callers must agree, or the Edge.Cuts
+    and copper scans would place the same shape differently.
+    """
+    m = re.search(r'\(at\s+([\d.-]+)\s+([\d.-]+)(?:\s+([\d.-]+))?\)', fp_text)
+    if not m:
+        return None
+    return (float(m.group(1)), float(m.group(2)),
+            float(m.group(3)) if m.group(3) else 0.0)
+
+
+_FP_PAD_RE = re.compile(r'\(pad\s')
+
+
+def footprint_pad_count(fp_text: str) -> int:
+    """Number of `(pad ...)` entries in one footprint block's TEXT."""
+    return len(_FP_PAD_RE.findall(fp_text))
+
+
+def footprint_copper_is_functional(pad_count: int) -> bool:
+    """Is copper drawn inside a footprint the PART's copper, or decoration?
+
+    #908. A footprint shape cannot carry a `(net ...)` in KiCad, so the #337
+    net guard -- "net-tied copper is functional, net-less copper is a logo" --
+    is a NO-OP for `fp_*` and cannot separate the two. The owning footprint's
+    PAD COUNT can, and does so exactly on the corpus:
+
+    | board              | ref                        | pads | copper polys | what it is          |
+    |--------------------|----------------------------|------|--------------|---------------------|
+    | esp_prog           | U2                         | 3    | 1            | SOT89 drawn tab     |
+    | watchy             | AE1                        | 2    | 12           | PCB meander antenna |
+    | tigard             | JP1                        | 2    | 1            | bridged jumper      |
+    | ulx3s              | RP1-3, D9, D51, D52        | 2    | 1 each       | NC jumpers          |
+    | orangecrab_ext_pll | `G***`, `G***~2`           | 0    | 1 + 3        | OSHW / LOGO art     |
+
+    kicad-cli 10.0.0 agrees independently: the pad-BEARING footprints produce
+    17 pad-vs-polygon `shorting_items` between them, the pad-LESS logo
+    footprints produce zero.
+
+    A part's land-pattern copper is therefore MODELLED (obstacle + DRC) and
+    never relocated to silkscreen; a logo footprint keeps #146's treatment
+    unchanged -- moved to silk by the writer, and for that reason not modelled
+    either, since modelling copper the writer is about to move off copper
+    would cost routing area for nothing.
+
+    Takes a scalar, not a footprint, precisely so the four fronts that ask it
+    (text parser, pcbnew parser, CLI writer, GUI writer) cannot drift: each
+    counts pads in its own idiom and there is nothing else to disagree about.
+    """
+    return pad_count > 0
 
 
 def _footprint_edge_points(content: str) -> List[Tuple[float, float]]:
@@ -3998,6 +4127,98 @@ def extract_segments(content: str, name_to_id: Dict[str, int] = None) -> List[Se
                         _emit_outline([(c[0] + r * math.cos(k * math.pi / 8),
                                         c[1] + r * math.sin(k * math.pi / 8))
                                        for k in range(16)], w, layer, nid, uuid)
+
+    # #908: the same model for copper drawn INSIDE a footprint -- the drawn tab
+    # of a SOT89/DPAK, a PCB antenna, a solder-jumper bridge. The scan above
+    # walks `gr_*` only, so this copper was invisible to the obstacle builders
+    # and to check_drc, which reads this same parser: kicad-cli 10.0.0 reports
+    # a real short on esp_prog (U2 pad 2 against its own tab polygon) that
+    # check_drc graded clean, and a foreign track laid across the tab would
+    # have routed and graded clean here and shorted on the fab.
+    #
+    # Same emission as the board-level pass -- net-0 `graphic=True` outline
+    # Segments, sharing `_blk_fields`/`_xy`/`_emit_outline` so the two cannot
+    # describe the same primitive differently -- plus the ONE thing footprint
+    # shapes need: the owning footprint's pose. Points go through
+    # `local_to_global`, never a hand-rolled transform, because its
+    # integer-nanometre snap is what keeps the text and pcbnew parse paths
+    # bit-identical.
+    #
+    # B-side needs no mirror term: footprint child coordinates are stored
+    # already side-resolved and the shape carries its own `(layer "B.Cu")`
+    # (verified against pcbnew GraphicalItems on a flipped rot-180 part, see
+    # the #304 note in `_collect_footprint_edge_segments_by_ref`).
+    if '(fp_' in content:
+        for _fstart, _fend, _fkey in _footprint_blocks_by_key(content):
+            fp_text = content[_fstart:_fend]
+            if not _FP_SHAPE_RE.search(fp_text):
+                continue
+            # A pad-LESS footprint is a logo the writer relocates to silk
+            # (#146); modelling copper that is about to leave copper would
+            # cost routing area for nothing. See footprint_copper_is_functional.
+            if not footprint_copper_is_functional(footprint_pad_count(fp_text)):
+                continue
+            _pose = footprint_pose(fp_text)
+            if _pose is None:
+                continue
+            _fx, _fy, _frot = _pose
+
+            def _g(_x, _y, _ox=_fx, _oy=_fy, _or=_frot):
+                return local_to_global(_ox, _oy, _or, _x, _y)
+
+            _mark_from = len(segments)
+            for tag, blk in iter_footprint_shapes(fp_text):
+                layers, w, nid, uuid = _blk_fields(blk)
+                if not layers:
+                    continue
+                if tag in ('fp_line', 'fp_arc') and w <= 0:
+                    continue    # unstroked line/arc: no copper to model
+                for layer in layers:
+                    if tag == 'fp_line':
+                        a, b = _xy(blk, 'start'), _xy(blk, 'end')
+                        if a and b:
+                            ga, gb = _g(*a), _g(*b)
+                            segments.append(Segment(
+                                start_x=ga[0], start_y=ga[1],
+                                end_x=gb[0], end_y=gb[1],
+                                width=w, layer=layer, net_id=nid,
+                                uuid=uuid, graphic=True))
+                    elif tag == 'fp_arc':
+                        a, mid, b = (_xy(blk, 'start'), _xy(blk, 'mid'),
+                                     _xy(blk, 'end'))
+                        if a and mid and b:
+                            for p0, p1 in _arc_to_segments(a, mid, b):
+                                g0, g1 = _g(*p0), _g(*p1)
+                                segments.append(Segment(
+                                    start_x=g0[0], start_y=g0[1],
+                                    end_x=g1[0], end_y=g1[1],
+                                    width=w, layer=layer, net_id=nid,
+                                    uuid=uuid, graphic=True))
+                    elif tag == 'fp_poly':
+                        pts = [_g(float(x), float(y)) for x, y in
+                               re.findall(r'\(xy\s+([-\d.]+)\s+([-\d.]+)\)',
+                                          blk)]
+                        _emit_outline(pts, w, layer, nid, uuid)
+                    elif tag == 'fp_rect':
+                        a, b = _xy(blk, 'start'), _xy(blk, 'end')
+                        if a and b:
+                            # all four corners transformed: under rotation the
+                            # rect tilts, so start/end alone do not bound it
+                            _emit_outline([_g(a[0], a[1]), _g(b[0], a[1]),
+                                           _g(b[0], b[1]), _g(a[0], b[1])],
+                                          w, layer, nid, uuid)
+                    elif tag == 'fp_circle':
+                        c, e = _xy(blk, 'center'), _xy(blk, 'end')
+                        if c and e:
+                            r = math.hypot(e[0] - c[0], e[1] - c[1])
+                            _emit_outline(
+                                [_g(c[0] + r * math.cos(k * math.pi / 8),
+                                    c[1] + r * math.sin(k * math.pi / 8))
+                                 for k in range(16)], w, layer, nid, uuid)
+            # Tag afterwards rather than threading an owner through
+            # `_emit_outline`, whose signature the board-level pass shares.
+            for _s in segments[_mark_from:]:
+                _s.owner_ref = _fkey
 
     warn_net_tagged_graphics(segments, name_to_id)
     return segments

--- a/py_router/kicad_parser.py
+++ b/py_router/kicad_parser.py
@@ -4037,6 +4037,14 @@ def extract_segments(content: str, name_to_id: Dict[str, int] = None) -> List[Se
         ew = w if w > 0 else defaults.TRACK_WIDTH
         seq = pts + [pts[0]] if closed else pts
         for a, b in zip(seq, seq[1:]):
+            if a == b:
+                # A poly whose vertex list already REPEATS its first point --
+                # KiCad writes many that way (every one of watchy's twelve
+                # antenna polys) -- would close onto itself and yield a
+                # zero-length "segment". That models no copper and each one
+                # becomes a duplicate DRC row a human has to dismiss: watchy
+                # graded 12 board-edge violations where the truth is 9.
+                continue
             segments.append(Segment(
                 start_x=a[0], start_y=a[1], end_x=b[0], end_y=b[1],
                 width=ew, layer=layer, net_id=nid, uuid=uuid, graphic=True))
@@ -4078,19 +4086,27 @@ def extract_segments(content: str, name_to_id: Dict[str, int] = None) -> List[Se
         m = re.search(r'\(' + name + r'\s+([-\d.]+)\s+([-\d.]+)\)', blk)
         return (float(m.group(1)), float(m.group(2))) if m else None
 
+    # A custom pad draws its copper with gr_* PRIMITIVES, in PAD-LOCAL
+    # coordinates. Real KiCad writes those without a `(layer ...)`, so
+    # `_blk_fields` drops them -- but that immunity is INCIDENTAL, and a
+    # primitive that does carry a copper layer lands as phantom copper
+    # hundreds of millimetres from the pad. Mask them, which is the structural
+    # answer the other board-level gr_* scans already use. Length-preserving,
+    # so the footprint spans below still line up.
+    _gcontent = _mask_pad_primitives(content)
     for tag in ('gr_line', 'gr_arc', 'gr_poly', 'gr_rect', 'gr_circle'):
         needle = '(' + tag
         pos = 0
         while True:
-            i = content.find(needle, pos)
+            i = _gcontent.find(needle, pos)
             if i < 0:
                 break
-            nxt = content[i + len(needle): i + len(needle) + 1]
+            nxt = _gcontent[i + len(needle): i + len(needle) + 1]
             if nxt and (nxt.isalnum() or nxt == '_'):
                 pos = i + len(needle)
                 continue
-            j = find_matching_paren(content, i)
-            blk = content[i:j]
+            j = find_matching_paren(_gcontent, i)
+            blk = _gcontent[i:j]
             pos = j
             layers, w, nid, uuid = _blk_fields(blk)
             if not layers:
@@ -4149,8 +4165,12 @@ def extract_segments(content: str, name_to_id: Dict[str, int] = None) -> List[Se
     # (verified against pcbnew GraphicalItems on a flipped rot-180 part, see
     # the #304 note in `_collect_footprint_edge_segments_by_ref`).
     if '(fp_' in content:
+        # Spans come from the UNMASKED text so the memo is shared with the
+        # other three callers; the slice comes from the masked text, which is
+        # the same length, so a layered pad primitive cannot leak in here
+        # either.
         for _fstart, _fend, _fkey in _footprint_blocks_by_key(content):
-            fp_text = content[_fstart:_fend]
+            fp_text = _gcontent[_fstart:_fend]
             if not _FP_SHAPE_RE.search(fp_text):
                 continue
             # A pad-LESS footprint is a logo the writer relocates to silk
@@ -5602,6 +5622,8 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
                 def _emit_outline_b(pts, ew):
                     seq = list(pts) + [pts[0]]
                     for _a, _b in zip(seq, seq[1:]):
+                        if _a == _b:
+                            continue        # see _emit_outline (text path)
                         segments.append(Segment(
                             start_x=_a[0], start_y=_a[1], end_x=_b[0], end_y=_b[1],
                             width=ew, layer=_ln, net_id=_nid, graphic=True,

--- a/py_router/kicad_parser.py
+++ b/py_router/kicad_parser.py
@@ -5543,10 +5543,29 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
     # Parity with the text parser's gr_line/gr_arc pass: PCB_SHAPE lines/arcs
     # on copper layers render as real copper (obstacles + DRC), tagged
     # graphic=True (immutable input art -- never ripped/pruned/stripped).
+    # #908: and the same for copper drawn INSIDE a footprint. `GetDrawings()`
+    # excludes footprint children, so this path was blind to an SOT89 tab or a
+    # PCB antenna exactly as the text path was. One emitter, two feeders --
+    # board drawings and `fp.GraphicalItems()` -- because the alternative is a
+    # second hand-written copy that drifts (the tree already carries four
+    # disagreeing answers to the same question for Edge.Cuts).
     try:
         import pcbnew as _pcbnew_g
-        for _d in board.GetDrawings():
-            if _d.GetClass() not in ("PCB_SHAPE", "DRAWSEGMENT"):
+        _fp_shapes = []
+        try:
+            for _ofp, _okey in zip(_live_fps, _live_keys):
+                if not footprint_copper_is_functional(len(_ofp.Pads())):
+                    continue        # pad-less logo footprint: see the text path
+                for _g in _ofp.GraphicalItems():
+                    _fp_shapes.append((_g, _okey))
+        except Exception:
+            pass                    # older pcbnew: no GraphicalItems()
+        for _d, _owner in ([(_x, "") for _x in board.GetDrawings()]
+                           + _fp_shapes):
+            # FP_SHAPE is KiCad 6/7's class for a footprint-embedded shape;
+            # KiCad 8+ unified them onto PCB_SHAPE. `GraphicalItems()` also
+            # yields text, which this pass must not touch.
+            if _d.GetClass() not in ("PCB_SHAPE", "DRAWSEGMENT", "FP_SHAPE"):
                 continue
             # EVERY copper layer of the shape, not just GetLayer() (#659
             # follow-up): KiCad writes a multi-layer graphic as the plural
@@ -5585,7 +5604,8 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
                     for _a, _b in zip(seq, seq[1:]):
                         segments.append(Segment(
                             start_x=_a[0], start_y=_a[1], end_x=_b[0], end_y=_b[1],
-                            width=ew, layer=_ln, net_id=_nid, graphic=True))
+                            width=ew, layer=_ln, net_id=_nid, graphic=True,
+                            owner_ref=_owner))
 
                 if _shape == getattr(_pcbnew_g, 'SHAPE_T_SEGMENT', 0):
                     if _w <= 0:
@@ -5593,7 +5613,8 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
                     segments.append(Segment(
                         start_x=to_mm(_d.GetStart().x), start_y=to_mm(_d.GetStart().y),
                         end_x=to_mm(_d.GetEnd().x), end_y=to_mm(_d.GetEnd().y),
-                        width=_w, layer=_ln, net_id=_nid, graphic=True))
+                        width=_w, layer=_ln, net_id=_nid, graphic=True,
+                        owner_ref=_owner))
                 elif _shape == getattr(_pcbnew_g, 'SHAPE_T_ARC', 2):
                     if _w <= 0:
                         continue
@@ -5606,7 +5627,8 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
                     for _p0, _p1 in _arc_to_segments(_s0, _m0, _e0):
                         segments.append(Segment(
                             start_x=_p0[0], start_y=_p0[1], end_x=_p1[0], end_y=_p1[1],
-                            width=_w, layer=_ln, net_id=_nid, graphic=True))
+                            width=_w, layer=_ln, net_id=_nid, graphic=True,
+                            owner_ref=_owner))
                 elif _shape in (_POLY, _RECT, _CIRC):
                     # FILLED copper areas (#337): outline as graphic segments (parity
                     # with the text parser). Filled shapes may have 0 stroke width.

--- a/py_router/kicad_parser.py
+++ b/py_router/kicad_parser.py
@@ -1533,9 +1533,13 @@ def _footprint_blocks_by_key(content: str):
     worth the memory.
     """
     try:
-        return _footprint_blocks_by_key_cached(content)
-    except TypeError:                                            # unhashable
+        hash(content)
+    except TypeError:              # not a str: cannot be memoised
         return _footprint_blocks_by_key_uncached(content)
+    # Deliberately NOT a try/except around the cached call: that would also
+    # catch a TypeError raised INSIDE the scan, re-run the whole whole-file
+    # walk, and hide the real bug behind a slow success.
+    return _footprint_blocks_by_key_cached(content)
 
 
 def _footprint_blocks_by_key_uncached(content: str):
@@ -1576,10 +1580,14 @@ def iter_footprint_shapes(fp_text: str, tags=_FP_SHAPE_TAGS):
     a flat field-ordered pattern either misses the layer or runs out of one
     shape into the next.
 
-    Custom-pad `(primitives ...)` are excluded FOR FREE because KiCad spells
-    those shapes `gr_*`, not `fp_*` -- do not widen this to "any shape inside a
-    footprint block", or urchin's 136 pad primitives arrive as phantom copper
-    at PAD-LOCAL coordinates.
+    Custom-pad `(primitives ...)` must never reach this. KiCad spells those
+    shapes `gr_*`, so the tag list alone happens to exclude them -- but that
+    is a spelling coincidence, not a guarantee, and the caller therefore feeds
+    this the `_mask_pad_primitives` text. A primitive that leaks in is not
+    merely phantom copper: its coordinates are PAD-local, so the footprint
+    pose places it millimetres from where it belongs (measured: 3.5mm off on
+    a synthetic 45-degree part) -- a false obstacle AND missing copper at
+    once. Do not widen this to "any shape inside a footprint block".
     """
     for tag in tags:
         needle = '(' + tag
@@ -1600,24 +1608,66 @@ def iter_footprint_shapes(fp_text: str, tags=_FP_SHAPE_TAGS):
 def footprint_pose(fp_text: str):
     """`(x, y, rotation_deg)` of one footprint block, or None.
 
-    The FIRST `(at ...)` in a footprint block is the footprint's own pose in
-    every KiCad dialect this parser reads; `_footprint_edge_points_by_ref` has
-    always resolved it this way and both callers must agree, or the Edge.Cuts
-    and copper scans would place the same shape differently.
+    The footprint's own `(at ...)` is the one at the block's TOP LEVEL. Taking
+    the textually first one instead is wrong twice over, and #908 raised the
+    stakes from a bounds point to a copper obstacle at the wrong place:
+
+      * a child's `(at ...)` -- a property's, a pad's -- can precede it, and
+        the shape then lands relative to the child instead of the part;
+      * an `(at ...)` inside a QUOTED STRING (a `(descr "trap (at 99 99 45)")`)
+        is not markup at all. `find_matching_paren` was taught to skip quoted
+        strings for exactly this class of bug (#113, the footprint named
+        `"TCR2EF115,LM(CT"`); a regex here would re-introduce it on the same
+        file.
+
+    Neither shape is what KiCad writes today -- this agrees with pcbnew's
+    `GetPosition()`/`GetOrientationDegrees()` on all 1349 corpus footprints --
+    so both are latent. They are also free to rule out.
     """
-    m = re.search(r'\(at\s+([\d.-]+)\s+([\d.-]+)(?:\s+([\d.-]+))?\)', fp_text)
-    if not m:
-        return None
-    return (float(m.group(1)), float(m.group(2)),
-            float(m.group(3)) if m.group(3) else 0.0)
+    depth = 0
+    i, n = 0, len(fp_text)
+    while i < n:
+        c = fp_text[i]
+        if c == '"':                        # skip the whole string literal
+            i += 1
+            while i < n:
+                if fp_text[i] == '\\':
+                    i += 2
+                    continue
+                if fp_text[i] == '"':
+                    break
+                i += 1
+            i += 1
+            continue
+        if c == '(':
+            depth += 1
+            if depth == 2 and fp_text.startswith('(at', i):
+                m = re.match(r'\(at\s+([\d.-]+)\s+([\d.-]+)'
+                             r'(?:\s+([\d.-]+))?\s*\)', fp_text[i:])
+                if m:
+                    return (float(m.group(1)), float(m.group(2)),
+                            float(m.group(3)) if m.group(3) else 0.0)
+        elif c == ')':
+            depth -= 1
+        i += 1
+    return None
 
 
-_FP_PAD_RE = re.compile(r'\(pad\s')
+_FP_PAD_RE = re.compile(r'\(pad\s+("(?:[^"\\]|\\.)*"|\S+)\s+(\w+)')
 
 
 def footprint_pad_count(fp_text: str) -> int:
-    """Number of `(pad ...)` entries in one footprint block's TEXT."""
-    return len(_FP_PAD_RE.findall(fp_text))
+    """Number of pads with COPPER in one footprint block's TEXT.
+
+    NPTH pads are excluded: CLAUDE.md's own rule is that they have no copper
+    even when `layers` lists `*.Cu` (the size is the mask opening), so a
+    footprint whose only "pad" is a net-tied mounting hole owns no land
+    pattern and its copper artwork is decoration like any other logo's.
+    Without this a decorative footprint carrying one mounting hole would be
+    modelled AND kept on copper by the writer.
+    """
+    return sum(1 for _num, _type in _FP_PAD_RE.findall(fp_text)
+               if _type != 'np_thru_hole')
 
 
 def footprint_copper_is_functional(pad_count: int) -> bool:
@@ -5571,17 +5621,49 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
     # disagreeing answers to the same question for Edge.Cuts).
     try:
         import pcbnew as _pcbnew_g
-        _fp_shapes = []
+        # The CAPABILITY probe is what may legitimately fail on an older
+        # pcbnew; wrapping the whole walk instead would turn a real bug at
+        # footprint #5 into "this board has no footprint copper", silently, on
+        # the GUI's parse path -- copper vanishing from the obstacle model
+        # with no diagnostic is the one failure this pass must not have.
+        _fp_graphics_ok = True
         try:
+            if _live_fps:
+                _live_fps[0].GraphicalItems()
+                _live_fps[0].Pads()
+        except Exception:
+            _fp_graphics_ok = False     # older pcbnew: no GraphicalItems()
+        # A generator, not a list: on a big board this walk visits every
+        # graphical item of every pad-bearing footprint, and materialising the
+        # pairs first only adds allocation on top of the SWIG enumeration that
+        # is the real cost. That cost is inherent -- copper graphics cannot be
+        # found without looking at them -- and it is MEASURED, not waved away:
+        # +16..24% on watchy/esp_prog, within noise on glasgow_revC and ulx3s
+        # (11 reps, two paired passes, KiCad 10.0.0 python). The text path had
+        # a duplicate whole-file walk to reclaim with a memo; this path has
+        # none, so the cost stands.
+        def _fp_shapes():
+            if not _fp_graphics_ok:
+                return
             for _ofp, _okey in zip(_live_fps, _live_keys):
-                if not footprint_copper_is_functional(len(_ofp.Pads())):
+                # NPTH pads are not copper (see footprint_pad_count), so the
+                # two parse paths must count pads the same way or a mounting
+                # hole would make a logo "functional" on one side only.
+                _npads = 0
+                for _pd in _ofp.Pads():
+                    try:
+                        if _pd.GetAttribute() == _pcbnew_g.PAD_ATTRIB_NPTH:
+                            continue
+                    except Exception:
+                        pass
+                    _npads += 1
+                if not footprint_copper_is_functional(_npads):
                     continue        # pad-less logo footprint: see the text path
                 for _g in _ofp.GraphicalItems():
-                    _fp_shapes.append((_g, _okey))
-        except Exception:
-            pass                    # older pcbnew: no GraphicalItems()
-        for _d, _owner in ([(_x, "") for _x in board.GetDrawings()]
-                           + _fp_shapes):
+                    yield _g, _okey
+        import itertools as _it
+        for _d, _owner in _it.chain(((_x, "") for _x in board.GetDrawings()),
+                                    _fp_shapes()):
             # FP_SHAPE is KiCad 6/7's class for a footprint-embedded shape;
             # KiCad 8+ unified them onto PCB_SHAPE. `GraphicalItems()` also
             # yields text, which this pass must not touch.
@@ -6549,7 +6631,13 @@ def compare_pcb_data(from_board: 'PCBData', from_file: 'PCBData', tolerance: flo
                 # KiCad RECOMPUTES a copper graphic's net from connectivity on
                 # load (openstint: file attribute /A-, pcbnew says GND for the
                 # same art). Same copper either way -- compare geometry only.
-                return (ends, _q(s.width), s.layer, '<graphic>')
+                # `owner_ref` IS compared (#908): it is not recomputed by
+                # KiCad, both paths derive it from the same disambiguator, and
+                # it is what scopes the own-pad obstacle lift -- so the two
+                # fronts disagreeing about it is exactly the drift this
+                # comparator exists to catch.
+                return (ends, _q(s.width), s.layer, '<graphic>',
+                        getattr(s, 'owner_ref', ''))
             return (ends, _q(s.width), s.layer, _net_label(pcb, s.net_id))
         return _seg_sig
 

--- a/py_router/kicad_parser.py
+++ b/py_router/kicad_parser.py
@@ -5638,10 +5638,13 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
         # pairs first only adds allocation on top of the SWIG enumeration that
         # is the real cost. That cost is inherent -- copper graphics cannot be
         # found without looking at them -- and it is MEASURED, not waved away:
-        # +16..24% on watchy/esp_prog, within noise on glasgow_revC and ulx3s
-        # (11 reps, two paired passes, KiCad 10.0.0 python). The text path had
-        # a duplicate whole-file walk to reclaim with a memo; this path has
-        # none, so the cost stands.
+        # +14.5..57% median across esp_prog / splitflap_driver / tigard /
+        # watchy, two independent paired passes with a fresh process per
+        # parse and the arms alternated (KiCad 10.0.0 python). The direction
+        # is robust; the magnitude is not tight, and the biggest number is on
+        # the smallest board, where the fixed cost dominates. The text path
+        # had a duplicate whole-file walk to reclaim with a memo; this path
+        # has none, so the cost stands.
         def _fp_shapes():
             if not _fp_graphics_ok:
                 return

--- a/py_router/kicad_parser.py
+++ b/py_router/kicad_parser.py
@@ -4230,6 +4230,11 @@ def extract_segments(content: str, name_to_id: Dict[str, int] = None) -> List[Se
                 continue
             _pose = footprint_pose(fp_text)
             if _pose is None:
+                # Copper dropped in silence is the failure mode this whole
+                # pass exists to end, so say it rather than `continue`.
+                print(f"  WARNING: footprint {_fkey} draws copper but has no "
+                      f"readable (at x y) pose; its copper is NOT modelled "
+                      f"(#908)")
                 continue
             _fx, _fy, _frot = _pose
 
@@ -5621,11 +5626,14 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
     # disagreeing answers to the same question for Edge.Cuts).
     try:
         import pcbnew as _pcbnew_g
-        # The CAPABILITY probe is what may legitimately fail on an older
-        # pcbnew; wrapping the whole walk instead would turn a real bug at
-        # footprint #5 into "this board has no footprint copper", silently, on
-        # the GUI's parse path -- copper vanishing from the obstacle model
-        # with no diagnostic is the one failure this pass must not have.
+        # The CAPABILITY probe is scoped to itself, so a real bug in the walk
+        # is not mistaken for "older pcbnew". Note the honest limit: the
+        # board-level #337 pass this shares still has its own
+        # `except Exception: pass` at the end (best-effort on old APIs), so a
+        # raise inside the walk is caught THERE and the board comes back with
+        # no graphic copper. Narrowing that outer guard is a #337 change, not
+        # a #908 one; what is fixed here is the guard that was three lines
+        # wide and swallowed the footprint walk on its own.
         _fp_graphics_ok = True
         try:
             if _live_fps:

--- a/py_router/kicad_writer.py
+++ b/py_router/kicad_writer.py
@@ -104,6 +104,13 @@ def move_copper_text_to_silkscreen(content: str) -> str:
 # cannot see that, because a footprint shape cannot carry a `(net ...)` in
 # KiCad at all. The tags stay listed -- they are still handled -- but the
 # DECISION is now owner-aware: see `footprint_copper_is_functional`.
+#: The footprint tags the PARSER models as copper (kicad_parser._FP_SHAPE_TAGS).
+#: The keep decision below is scoped to exactly these: `fp_curve` is in the tag
+#: list above but the parser emits nothing for it, so keeping one on copper
+#: would leave it UNMODELLED there -- strictly worse than #146's relocation,
+#: and reported to the user as successfully "kept". Keep the two lists in step.
+_FP_MODELLED_TAGS = ('fp_poly', 'fp_line', 'fp_arc', 'fp_rect', 'fp_circle')
+
 _COPPER_GRAPHIC_TAGS = (
     'fp_poly', 'gr_poly', 'fp_line', 'gr_line', 'fp_circle', 'gr_circle',
     'fp_arc', 'gr_arc', 'fp_rect', 'gr_rect', 'fp_curve', 'gr_curve',
@@ -230,10 +237,18 @@ def move_copper_graphics_to_silkscreen(content: str) -> str:
     parser; a footprint with NO pads is a logo, which keeps #146's treatment
     exactly. Board-level `gr_*` is untouched by this change.
     """
-    _keep_spans = _functional_footprint_spans(content)
     kept = 0
     count = 0
     for tag in _COPPER_GRAPHIC_TAGS:
+        # RECOMPUTED per tag pass, not hoisted: this loop rewrites `content`
+        # at the end of every iteration and each relocation grows the text by
+        # 3 bytes (F.Cu -> F.SilkS), so spans taken once from the original
+        # text drift out of alignment from the second tag onward. Measured:
+        # past ~33 relocated board-level logos a pad-bearing footprint's own
+        # land-pattern copper was relocated anyway -- the exact deletion this
+        # gate exists to stop, and silently, because the "Kept ..." line
+        # drifts away with it.
+        _keep_spans = _functional_footprint_spans(content)
         token = '(' + tag
         tlen = len(token)
         result_parts = []
@@ -275,7 +290,7 @@ def move_copper_graphics_to_silkscreen(content: str) -> str:
             if not net_tied:
                 name_match = re.search(r'\(net\s+"((?:[^"\\]|\\.)*)"\)', block)
                 net_tied = bool(name_match and name_match.group(1) != '')
-            if (layer_match and not net_tied and tag.startswith('fp_')
+            if (layer_match and not net_tied and tag in _FP_MODELLED_TAGS
                     and _in_any_span(start, _keep_spans)):
                 # #908: this footprint has pads, so its copper is the part's
                 # own land pattern, not decoration. Leave it on copper -- the

--- a/py_router/kicad_writer.py
+++ b/py_router/kicad_writer.py
@@ -98,6 +98,12 @@ def move_copper_text_to_silkscreen(content: str) -> str:
 # Graphic primitives that make up copper logos/artwork (no net). Functional copper
 # is zones / segments / vias / pads — never standalone graphics — so moving these
 # off copper is safe and only affects decoration.
+#
+# ...with ONE exception, #908: a footprint's own `fp_*` copper (a SOT89 tab, a
+# PCB antenna, a solder-jumper bridge) IS functional, and the net guard below
+# cannot see that, because a footprint shape cannot carry a `(net ...)` in
+# KiCad at all. The tags stay listed -- they are still handled -- but the
+# DECISION is now owner-aware: see `footprint_copper_is_functional`.
 _COPPER_GRAPHIC_TAGS = (
     'fp_poly', 'gr_poly', 'fp_line', 'gr_line', 'fp_circle', 'gr_circle',
     'fp_arc', 'gr_arc', 'fp_rect', 'gr_rect', 'fp_curve', 'gr_curve',
@@ -169,6 +175,35 @@ def strip_zero_length_edge_cuts(content: str) -> str:
     return ''.join(out)
 
 
+def _functional_footprint_spans(content: str):
+    """`[(start, end)]` of every footprint block whose copper this tool must
+    not relocate -- i.e. every footprint that has pads (#908).
+
+    Byte spans rather than references, because the caller works on raw text
+    offsets and a reference cannot say WHICH block on a board that spells one
+    reference twice.
+    """
+    if '(fp_' not in content:
+        return []
+    from kicad_parser import (_footprint_blocks_by_key, footprint_pad_count,
+                              footprint_copper_is_functional)
+    spans = []
+    for start, end, _key in _footprint_blocks_by_key(content):
+        if footprint_copper_is_functional(
+                footprint_pad_count(content[start:end])):
+            spans.append((start, end))
+    return spans
+
+
+def _in_any_span(pos: int, spans) -> bool:
+    """Is `pos` inside one of `spans`? Linear; the list is one entry per
+    pad-bearing footprint and the caller asks once per graphic primitive."""
+    for a, b in spans:
+        if a <= pos < b:
+            return True
+    return False
+
+
 def move_copper_graphics_to_silkscreen(content: str) -> str:
     """Move graphic primitives (logos / artwork drawn as polys, lines, arcs, ...)
     from copper layers to silkscreen, mirroring move_copper_text_to_silkscreen:
@@ -181,7 +216,22 @@ def move_copper_graphics_to_silkscreen(content: str) -> str:
     copper. A NET-TIED copper graphic is real functional copper (#337 models it
     as an immutable obstacle and DRC treats it as copper) and is LEFT IN PLACE --
     moving it would delete a real connection.
+
+    #908: that net guard is a NO-OP for footprint shapes, because a footprint
+    shape cannot carry a `(net ...)` in KiCad -- so until now EVERY `fp_*`
+    copper shape was relocated, and the corpus says what that costs: esp_prog
+    1, watchy 12, tigard 1, ulx3s 6, orangecrab_ext_pll 4 shapes moved off
+    copper on every single write. watchy's is a PCB antenna; esp_prog's is the
+    SOT89 tab under U2. Deleting a component's own land-pattern copper from a
+    board this tool was asked to route is not a routing decision to make.
+
+    The owner decides instead (`footprint_copper_is_functional`): a footprint
+    WITH pads owns functional copper, which stays and is now modelled by the
+    parser; a footprint with NO pads is a logo, which keeps #146's treatment
+    exactly. Board-level `gr_*` is untouched by this change.
     """
+    _keep_spans = _functional_footprint_spans(content)
+    kept = 0
     count = 0
     for tag in _COPPER_GRAPHIC_TAGS:
         token = '(' + tag
@@ -225,6 +275,13 @@ def move_copper_graphics_to_silkscreen(content: str) -> str:
             if not net_tied:
                 name_match = re.search(r'\(net\s+"((?:[^"\\]|\\.)*)"\)', block)
                 net_tied = bool(name_match and name_match.group(1) != '')
+            if (layer_match and not net_tied and tag.startswith('fp_')
+                    and _in_any_span(start, _keep_spans)):
+                # #908: this footprint has pads, so its copper is the part's
+                # own land pattern, not decoration. Leave it on copper -- the
+                # parser models it, so nothing routes over it any more.
+                kept += 1
+                layer_match = None
             if layer_match and not net_tied:
                 layer = layer_match.group(1)
                 new_layer = 'F.SilkS' if layer == 'F.Cu' else 'B.SilkS'
@@ -239,6 +296,11 @@ def move_copper_graphics_to_silkscreen(content: str) -> str:
 
     if count > 0:
         print(f"  Moved {count} copper graphic(s)/logo(s) to silkscreen")
+    if kept > 0:
+        # Disclose what was KEPT, not only what was moved: this copper used to
+        # disappear from the deliverable silently (#908).
+        print(f"  Kept {kept} footprint copper shape(s) on copper "
+              f"(a part's own land pattern, not decoration)")
 
     return content
 

--- a/py_router/obstacle_map.py
+++ b/py_router/obstacle_map.py
@@ -405,6 +405,12 @@ def build_base_obstacle_map(pcb_data: PCBData, config: GridRouteConfig,
     pcb_data._net_tie_price = {
         nid: sorted(e['cells'] - e.get('safe_cells', set()))
         for nid, e in _tie_corridors.items()}
+    # NOTE (#908): this bake has NO `_baked` marker, unlike the own-pad lift
+    # below, so `prepare_obstacles_inplace` lifts the same rows a second time
+    # when a base built for ONE net is then prepared for that net. Left as it
+    # is deliberately -- fixing it changes routing on net-tie boards and is
+    # owed its own measurement -- but do NOT copy this shape onto a new lift,
+    # and do not "restore symmetry" by deleting the marker below.
     if len(nets_to_route_set) == 1:
         for _arr in pcb_data._net_tie_lift.get(next(iter(nets_to_route_set)), []):
             if len(_arr):
@@ -417,11 +423,36 @@ def build_base_obstacle_map(pcb_data: PCBData, config: GridRouteConfig,
     pcb_data._graphic_own_pad_lift = {
         _nid: np.ascontiguousarray(np.concatenate(_rws))
         for _nid, _rws in _own_pad_rows.items() if _rws}
+    # WHICH net this build BAKED into the map it is about to return, so
+    # `prepare_obstacles_inplace` does not lift the same rows a SECOND time.
+    #
+    # It has to be recorded, because both consumers of this base map live in
+    # ONE loop and are chosen per net: `single_ended_loop` uses
+    # prepare/restore when it has a working map and a net cache, and falls
+    # back to `build_single_ended_obstacles` (a clone, no prepare) when it
+    # does not. So the bake cannot simply be dropped in favour of prepare --
+    # the fallback clone would then seal the pad -- and prepare cannot
+    # unconditionally lift either. Measured on esp_prog before this marker
+    # existed, via `route.py --nets 'Net-(C1-Pad1)'` (one net, so the bake
+    # fires AND prepare runs): the second removal took 28 cells that a pad
+    # also blocked from refcount 2 straight to 0, and the restore put them
+    # back at 1 -- copper unchanged on that board, but the map's refcounts no
+    # longer matched the copper they stood for, which is the desync the
+    # remove/re-add pairing exists to make impossible.
+    #
+    # Written UNCONDITIONALLY and immediately beside the dict it guards: the
+    # two are the same build's answer, so they can never describe different
+    # builds. That matters because a nested single-net build on this same
+    # pcb_data (`net_rescue._pristine_rescue_map` passes the run's own
+    # pcb_data) replaces the dict; the marker is replaced with it rather than
+    # surviving as a stale claim about rows that are gone.
+    pcb_data._graphic_own_pad_lift_baked = None
     if len(nets_to_route_set) == 1:
-        _arr = pcb_data._graphic_own_pad_lift.get(
-            next(iter(nets_to_route_set)))
+        _nid = next(iter(nets_to_route_set))
+        _arr = pcb_data._graphic_own_pad_lift.get(_nid)
         if _arr is not None and len(_arr):
             obstacles.remove_blocked_cell_spans_batch(_arr)
+            pcb_data._graphic_own_pad_lift_baked = _nid
 
     # Add board edge clearance
     _report("board edge", 0, 0, force=True)

--- a/py_router/obstacle_map.py
+++ b/py_router/obstacle_map.py
@@ -2677,14 +2677,20 @@ def remove_vias_list_from_obstacles(obstacles: GridObstacleMap, vias: list,
 
 
 def same_net_pad_via_keepout_cells(pcb_data: PCBData, net_id: int,
-                                   config: GridRouteConfig) -> "np.ndarray":
+                                   config: GridRouteConfig,
+                                   pads=None) -> "np.ndarray":
     """#581: (N, 2) via-block cells over the net's own SMD pads when an active
     (> 0) same_net_pad_clearance is on the config; empty otherwise.
 
     Blocks VIA placement only (never tracks) at pad-edge + via/2 + clearance,
     mirroring plane_obstacle_builder._add_pad_via_obstacle's geometry.
     Through-hole pads are exempt (their barrel is the layer transition, and
-    the #581 concern is SMD reflow)."""
+    the #581 concern is SMD reflow).
+
+    `pads` restricts the answer to those pads (#907): the seal diagnosis needs
+    to know which cells around ONE pad this flag is responsible for, without
+    rebuilding or mutating the map. Defaults to every pad of the net, which is
+    what the stampers ask for."""
     snpc = getattr(config, 'same_net_pad_clearance', -1.0)
     if snpc is None or snpc <= 0:
         return np.empty((0, 2), dtype=np.int32)
@@ -2692,7 +2698,7 @@ def same_net_pad_via_keepout_cells(pcb_data: PCBData, net_id: int,
     coord = GridCoord(config.grid_step)
     margin = config.via_size / 2 + snpc + config.grid_step / 2
     chunks = []
-    for pad in pcb_data.pads_by_net.get(net_id, []):
+    for pad in (pcb_data.pads_by_net.get(net_id, []) if pads is None else pads):
         if getattr(pad, 'drill', 0):
             continue
         gx, gy = coord.to_grid(pad.global_x, pad.global_y)

--- a/py_router/obstacle_map.py
+++ b/py_router/obstacle_map.py
@@ -76,6 +76,10 @@ class _StaticStampProxy:
         return getattr(self._real, name)
 
 
+#: Shared empty set for the #908 own-pad lift lookup, so the hot segment
+#: loop allocates nothing per row.
+_EMPTY_NETS = frozenset()
+
 def _obstacle_progress_reporter(progress_callback):
     """Throttled sub-phase progress for the base obstacle build (#556).
 
@@ -210,11 +214,30 @@ def build_base_obstacle_map(pcb_data: PCBData, config: GridRouteConfig,
     # Use actual segment width for obstacle, and layer-specific width for routing track
     _seg_cell_batch: Dict[int, list] = {}
     _seg_via_batch: list = []
+    # #908: copper a FOOTPRINT draws (an SOT89 tab, a solder-jumper bridge, a
+    # PCB antenna) carries no net, so it is foreign copper to every net --
+    # including the net of the pad it was drawn around. Stamped whole, U2's tab
+    # SEALS esp_prog pad 2, which is #907's failure mode manufactured by #908's
+    # fix. The lift is per SEGMENT and own-footprint only: the edges that
+    # actually touch the pad stop blocking that pad's net, the rest of the
+    # shape keeps blocking everything. Never the whole cluster -- see
+    # check_drc.graphic_own_pad_nets for why (watchy's antenna).
+    _own_pad_nets = {}
+    if any(getattr(s, 'graphic', False) and getattr(s, 'owner_ref', '')
+           for s in pcb_data.segments):
+        try:
+            from check_drc import graphic_own_pad_nets
+            _own_pad_nets = graphic_own_pad_nets(pcb_data)
+        except Exception:
+            _own_pad_nets = {}      # never let a diagnosis break a build
     _n_segs = len(pcb_data.segments)
     for _seg_i, seg in enumerate(pcb_data.segments):
         if (_seg_i & 511) == 0:
             _report("copper", _seg_i, _n_segs)
         if seg.net_id in nets_to_route_set:
+            continue
+        if _own_pad_nets and (nets_to_route_set
+                              & _own_pad_nets.get(id(seg), _EMPTY_NETS)):
             continue
         layer_idx = layer_map.get(seg.layer)
         if layer_idx is None:

--- a/py_router/obstacle_map.py
+++ b/py_router/obstacle_map.py
@@ -222,23 +222,31 @@ def build_base_obstacle_map(pcb_data: PCBData, config: GridRouteConfig,
     # actually touch the pad stop blocking that pad's net, the rest of the
     # shape keeps blocking everything. Never the whole cluster -- see
     # check_drc.graphic_own_pad_nets for why (watchy's antenna).
+    #
+    # It is PER NET, and the base map is built for a whole BATCH: skipping the
+    # stamp when the lift net is anywhere in `nets_to_route_set` would drop the
+    # copper for EVERY net in the run -- measured, on `route.py`'s default
+    # all-nets call: tigard 4/4 and ulx3s 24/24 footprint-copper edges
+    # unmodelled, i.e. #908 nullified on the shipping path. So the segment is
+    # always stamped and its rows are RECORDED per net, for the single-net
+    # shortcut below and for `prepare_obstacles_inplace` to lift and restore
+    # exactly the way the net-tie corridor lift already does.
     _own_pad_nets = {}
     if any(getattr(s, 'graphic', False) and getattr(s, 'owner_ref', '')
            for s in pcb_data.segments):
-        try:
-            from check_drc import graphic_own_pad_nets
-            _own_pad_nets = graphic_own_pad_nets(pcb_data)
-        except Exception:
-            _own_pad_nets = {}      # never let a diagnosis break a build
+        from check_drc import graphic_own_pad_nets
+        # NOT wrapped: this decides whether a pad is REACHABLE, not what gets
+        # printed. Losing it silently reinstates the seal it exists to prevent,
+        # indistinguishable from a routing failure.
+        _own_pad_nets = graphic_own_pad_nets(pcb_data)
+    _own_pad_rows: Dict[int, list] = {}
     _n_segs = len(pcb_data.segments)
     for _seg_i, seg in enumerate(pcb_data.segments):
         if (_seg_i & 511) == 0:
             _report("copper", _seg_i, _n_segs)
         if seg.net_id in nets_to_route_set:
             continue
-        if _own_pad_nets and (nets_to_route_set
-                              & _own_pad_nets.get(id(seg), _EMPTY_NETS)):
-            continue
+        _lift_nets = _own_pad_nets.get(id(seg)) if _own_pad_nets else None
         layer_idx = layer_map.get(seg.layer)
         if layer_idx is None:
             # Copper on a layer OUTSIDE config.layers (a 6/8-layer board routed
@@ -289,6 +297,16 @@ def build_base_obstacle_map(pcb_data: PCBData, config: GridRouteConfig,
             expansion_mm, coord.grid_step)
         if len(cells_arr):
             _seg_cell_batch.setdefault(layer_idx, []).append(cells_arr)
+            if _lift_nets:
+                # The exact rows this segment contributes, in the 4-column
+                # (span + layer) form the flush below uses, so the lift is a
+                # balanced remove/re-add of THIS copper's own stamp and can
+                # never desync a refcount.
+                _rows = np.empty((len(cells_arr), 4), dtype=np.int32)
+                _rows[:, :3] = cells_arr
+                _rows[:, 3] = layer_idx
+                for _ln in _lift_nets:
+                    _own_pad_rows.setdefault(_ln, []).append(_rows)
         vias_arr = segment_blocked_spans(
             seg.start_x, seg.start_y, seg.end_x, seg.end_y,
             via_block_mm, coord.grid_step)
@@ -391,6 +409,19 @@ def build_base_obstacle_map(pcb_data: PCBData, config: GridRouteConfig,
         for _arr in pcb_data._net_tie_lift.get(next(iter(nets_to_route_set)), []):
             if len(_arr):
                 obstacles.remove_blocked_cells_batch(_arr)
+
+    # #908 own-pad lift, same shape as the net-tie one above: per net, applied
+    # here when the map IS this net's map, and left to
+    # `prepare_obstacles_inplace` (which removes and restores it around each
+    # net's own route) when the map serves a whole batch.
+    pcb_data._graphic_own_pad_lift = {
+        _nid: np.ascontiguousarray(np.concatenate(_rws))
+        for _nid, _rws in _own_pad_rows.items() if _rws}
+    if len(nets_to_route_set) == 1:
+        _arr = pcb_data._graphic_own_pad_lift.get(
+            next(iter(nets_to_route_set)))
+        if _arr is not None and len(_arr):
+            obstacles.remove_blocked_cell_spans_batch(_arr)
 
     # Add board edge clearance
     _report("board edge", 0, 0, force=True)

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -7184,7 +7184,8 @@ For differential pair routing, use route_diff.py:
         try:
             from kicad_exact_fill import write_filled_board
             _fst = write_filled_board(args.output_file, args.output_file,
-                                      verbose=True)
+                                      verbose=True,
+                                      project_from=args.input_file)
             if _fst.ok:
                 with open(args.output_file, encoding='utf-8',
                           errors='replace') as _fh:

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -6522,6 +6522,15 @@ For differential pair routing, use route_diff.py:
                         help="Print memory usage statistics at key points during routing")
     parser.add_argument("--add-teardrops", action="store_true",
                         help="Add teardrop settings to all pads and vias in output file")
+    parser.add_argument("--write-fill", action="store_true",
+                        help="After writing the board, fill its zones with "
+                             "KiCad's own ZONE_FILLER so the deliverable "
+                             "carries (filled_polygon ...) blocks (#910). "
+                             "Without it the board ships zone OUTLINES only, "
+                             "and a grade without --refill-zones reports "
+                             "plane opens that are not real. Needs KiCad's "
+                             "bundled python; the sibling .kicad_pro and its "
+                             "net classes are preserved.")
     parser.add_argument("--stats", action="store_true",
                         help="Collect and print A* search statistics for debugging heuristic efficiency")
 
@@ -7166,6 +7175,30 @@ For differential pair routing, use route_diff.py:
                 persist_same_net_pad_clearance(_pro, args.same_net_pad_clearance)
         except Exception as e:
             print(f"  (skipped protected-nets record: {e})")
+    # #910: OPT-IN delivery fill. Last, because it is the only step that wants
+    # the board AND its .kicad_pro already final -- the fill is graded against
+    # the project's real netclasses, and the floor writeback above is what
+    # puts them there. Guarded like the castellated-retract pass: nothing to
+    # fill if the run reverted, skipped routing, or wrote nothing.
+    if getattr(args, 'write_fill', False) and args.output_file             and not args.skip_routing and not _gate_reverted             and os.path.isfile(args.output_file):
+        try:
+            from kicad_exact_fill import write_filled_board
+            _fst = write_filled_board(args.output_file, args.output_file,
+                                      verbose=True)
+            if _fst.ok:
+                with open(args.output_file, encoding='utf-8',
+                          errors='replace') as _fh:
+                    _nfp = _fh.read().count('(filled_polygon')
+                print(f"  --write-fill: wrote {_nfp} filled_polygon block(s); "
+                      f"the deliverable no longer reads phantom plane opens "
+                      f"until refilled")
+            else:
+                print(f"  (--write-fill did not run: {_fst.reason}"
+                      + (f" ({_fst.detail})" if _fst.detail else '')
+                      + "; the board ships unfilled -- grade it with "
+                        "`kicad-cli pcb drc --refill-zones`)")
+        except Exception as _e:
+            print(f"  (--write-fill skipped: {_e})")
     # #857: --strict-sizes turns any delivery below a requested size, or any
     # fab-tier escalation, into a non-zero exit so a harness needs no grep.
     if getattr(args, 'strict_sizes', False):

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -3907,6 +3907,7 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
     blockers_report = []
     boxed_in_report = []
     fanout_dropped_report = []
+    sealed_by_snpc_report = []
     try:
         _final_failed_ids = list(dict.fromkeys(
             failed_single_ids + [m['net_id'] for m in failed_multipoint]))
@@ -3962,12 +3963,25 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                     _fd = _ev.get('details') or _fd
             if _fd:
                 fanout_dropped_report.append(dict(_fd, net=_name))
+            # #907: and the fourth cause -- a FLAG THIS RUN SET closed the
+            # last legal via site. Its own key for the same reason as the
+            # three above: it answers a different question, and it is the only
+            # one whose remedy is a command-line change the caller already
+            # controls. Nothing else in the summary names the flag.
+            _sn = None
+            for _ev in (state.net_history.get(_nid) or []):
+                if _ev.get('event') == 'sealed_by_snpc':
+                    _sn = _ev.get('details') or _sn
+            if _sn:
+                sealed_by_snpc_report.append(dict(_sn, net=_name))
         if blockers_report:
             summary['blockers'] = blockers_report
         if boxed_in_report:
             summary['boxed_in'] = boxed_in_report
         if fanout_dropped_report:
             summary['fanout_dropped'] = fanout_dropped_report
+        if sealed_by_snpc_report:
+            summary['sealed_by_snpc'] = sealed_by_snpc_report
     except Exception:
         blockers_report = []
     # #409 follow-up: pad-pair routability tallies (PRR ingredients: connected

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -1028,7 +1028,25 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
               "--impedance <ohms> to route as a coplanar waveguide.")
     if impedance is not None:
         if not pcb_data.board_info.stackup:
+            # #909: "no stackup" is true and tells the reader nothing about
+            # whether authoring one would have helped. The repo's own solvers
+            # answer that against a NOMINAL stack, in one call, with numbers.
             print("WARNING: No stackup found in PCB file. Using fixed track width.")
+            try:
+                from impedance import (achievability_note, tightest_pin_gap,
+                                       _impedance_scope_net_ids)
+                _ly = (layers[0] if layers else 'F.Cu')
+                _note, _ = achievability_note(
+                    pcb_data, _ly, impedance,
+                    is_differential=False,
+                    spacing=0.0,
+                    min_pitch_gap=tightest_pin_gap(
+                        pcb_data, _impedance_scope_net_ids(pcb_data,
+                                                           net_names)))
+                if _note:
+                    print("  " + _note)
+            except Exception:
+                pass
         else:
             # #486: which nets run through a ground pour on their own layer?
             # An empty coplanar_nets with a gap set means "all of them", so the

--- a/py_router/route_diff.py
+++ b/py_router/route_diff.py
@@ -456,7 +456,25 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
               "--impedance <ohms> to route as a coplanar waveguide.")
     if impedance is not None:
         if not pcb_data.board_info.stackup:
+            # #909: "no stackup" is true and tells the reader nothing about
+            # whether authoring one would have helped. The repo's own solvers
+            # answer that against a NOMINAL stack, in one call, with numbers.
             print("WARNING: No stackup found in PCB file. Using fixed track width.")
+            try:
+                from impedance import (achievability_note, tightest_pin_gap,
+                                       _impedance_scope_net_ids)
+                _ly = (layers[0] if layers else 'F.Cu')
+                _note, _ = achievability_note(
+                    pcb_data, _ly, impedance,
+                    is_differential=True,
+                    spacing=diff_pair_gap or 0.0,
+                    min_pitch_gap=tightest_pin_gap(
+                        pcb_data, _impedance_scope_net_ids(pcb_data,
+                                                           net_names)))
+                if _note:
+                    print("  " + _note)
+            except Exception:
+                pass
         else:
             print(f"\nCalculating trace widths for {impedance}Ω differential impedance...")
             print(f"Using diff pair spacing: {diff_pair_gap}mm ({diff_pair_gap * 39.3701:.2f} mil)")

--- a/py_router/routing_context.py
+++ b/py_router/routing_context.py
@@ -490,6 +490,18 @@ def prepare_obstacles_inplace(
     # sibling routes and third nets stays intact; pads are never ripped and
     # the partner trunk's base stamps are only mutated by this balanced
     # remove / restore re-add pair. Via blocking is not recorded, not lifted.
+    # #908: a footprint's own copper must not seal the pad it was drawn
+    # around. The base map stamps it for everyone (it IS foreign copper to
+    # every other net); here the rows it contributed are lifted for the ONE
+    # net whose pad it touches, and restore_obstacles_inplace puts them back.
+    # Recorded rows, not recomputed geometry, so the remove/re-add is exactly
+    # balanced and cannot desync a refcount.
+    _op_lift = (getattr(pcb_data, '_graphic_own_pad_lift', None)
+                or {}).get(net_id)
+    if _op_lift is not None and len(_op_lift):
+        working_obstacles.remove_blocked_cell_spans_batch(_op_lift)
+        _OWNPAD_LIFTED[(id(working_obstacles), net_id)] = _op_lift
+
     _tie_lift = getattr(pcb_data, '_net_tie_lift', None)
     if _tie_lift:
         _lifted = [a for a in _tie_lift.get(net_id, []) if len(a)]
@@ -661,6 +673,8 @@ def prepare_obstacles_inplace(
 # strictly paired per net route on one thread, so entries live only across
 # that window; keying by map id keeps cloned maps independent.
 _TIE_LIFTED: Dict[tuple, list] = {}
+#: #908 own-pad lift, same lifetime and keying as _TIE_LIFTED.
+_OWNPAD_LIFTED: Dict[tuple, object] = {}
 
 
 def restore_obstacles_inplace(
@@ -704,6 +718,11 @@ def restore_obstacles_inplace(
     if _lifted:
         for _arr in _lifted:
             working_obstacles.add_blocked_cells_batch(_arr)
+
+    # #908: and the own-pad graphic lift, the same balanced way.
+    _op = _OWNPAD_LIFTED.pop((id(working_obstacles), net_id), None)
+    if _op is not None and len(_op):
+        working_obstacles.add_blocked_cell_spans_batch(_op)
 
     # Restore current net's obstacles (from cache - original stubs)
     # Note: If routing succeeded, caller should update cache first with new route data

--- a/py_router/routing_context.py
+++ b/py_router/routing_context.py
@@ -496,9 +496,17 @@ def prepare_obstacles_inplace(
     # net whose pad it touches, and restore_obstacles_inplace puts them back.
     # Recorded rows, not recomputed geometry, so the remove/re-add is exactly
     # balanced and cannot desync a refcount.
+    # ... UNLESS the base build already baked this net's lift into the map
+    # this one was cloned from (it does that when it was built for a single
+    # net -- see obstacle_map's `_graphic_own_pad_lift_baked`). Lifting again
+    # is not a no-op: a cell two obstacles blocked goes 2 -> 0 instead of
+    # 2 -> 1, and the restore below returns it at 1, so the map stops
+    # matching the copper it stands for.
     _op_lift = (getattr(pcb_data, '_graphic_own_pad_lift', None)
                 or {}).get(net_id)
-    if _op_lift is not None and len(_op_lift):
+    if (_op_lift is not None and len(_op_lift)
+            and net_id != getattr(pcb_data,
+                                  '_graphic_own_pad_lift_baked', None)):
         working_obstacles.remove_blocked_cell_spans_batch(_op_lift)
         _OWNPAD_LIFTED[(id(working_obstacles), net_id)] = _op_lift
 

--- a/py_router/routing_diagnostics.py
+++ b/py_router/routing_diagnostics.py
@@ -45,6 +45,21 @@ def suggest_route_adjustments(failed: int, total: int,
     via_size = _g(config, 'via_size')
     layers = _g(config, 'layers') or []
 
+    # #907: an ACTIVE same-net pad via clearance is the one suggestion whose
+    # cause is a control the user set on this very dialog, and it can make a
+    # boxed-in SMD pad unroutable outright rather than merely harder. It goes
+    # FIRST for that reason -- the others ask for a knob to be turned, this
+    # one names a rule that may have closed the last via site.
+    snpc = _g(config, 'same_net_pad_clearance')
+    if snpc is not None and snpc > 0:
+        suggestions.append(
+            f"Untick 'via-in-pad forbidden' / set Same-net pad clearance "
+            f"(currently {snpc:g} mm) to 0 - it bans every via within "
+            f"{snpc:g} mm of the net's OWN SMD pads, and an SMD pad boxed in "
+            f"closer than that on every side has no legal via site at all. "
+            f"The run log names any pad this actually sealed."
+        )
+
     # Rip-up is the single highest-leverage fix for "blocker" failures.
     if max_ripup is not None and max_ripup < 3:
         suggestions.append(
@@ -603,6 +618,129 @@ def fanout_dropped_ball_hint(pcb_data, config, net_id, net_name=None, *,
     return _ret(hint, {'verdict': 'fanout_dropped', 'pad': where,
                        'component': ref, 'plane_like': plane_like,
                        'pads': [f"{r}.{p.pad_number}" for p, r in bare[:6]]})
+
+
+def same_net_pad_seal_hint(pcb_data, config, net_id, net_name=None,
+                           obstacles=None, layer_count=None, *,
+                           return_verdict=False):
+    """`--same-net-pad-clearance` can make an SMD pad unroutable, silently (#907).
+
+    The flag bans VIA placement within pad-edge + via/2 + clearance + grid/2 of
+    the net's own SMD pads (`obstacle_map.same_net_pad_via_keepout_cells`). On
+    a pad boxed in on every side closer than that, the ban closes the last
+    legal via site and the net simply fails -- and NOTHING in the failure
+    report names the flag. The router's own diagnostic inspects the target
+    CELL ("backward cell ... ok, 0/8 neighbors blocked"), which is about TRACK
+    blocking and stays green while the via map is what is closed. Measured on
+    run 25's esp_prog: U2's tab pad became unroutable in the quality lap and
+    the cause was found by hand geometry, not by the tool.
+
+    The test is the A/B the router itself cannot do: for each of the net's
+    SMD pads, take the cells THIS FLAG contributes around that pad alone,
+    remove them from the via map, and ask again whether any site that could
+    serve the pad is legal. If one appears only with the flag's cells gone,
+    the flag is what closed it. The map is REFCOUNTED, so the removal and the
+    re-add are exactly balanced and the map is byte-for-byte what it was --
+    and the restore runs in a `finally`, because a diagnosis that corrupts the
+    obstacle map would be far worse than no diagnosis.
+
+    "A site that could serve the pad" is the pad's own cells plus the off-pad
+    escape-stub radius (`KICAD_ESCAPE_STUB_RADIUS`, 1.0 mm by default), which
+    is the actual fallback rung `_place_shrunk_via_in_pad` uses when this flag
+    forbids the in-pad arm -- so the question asked is the one the router
+    really answers.
+
+    Returns '' (or `('', None)`) whenever the flag is off, the net has no SMD
+    pad, or a legal site exists either way -- the common case, in which the
+    caller should print whatever it was going to print.
+    """
+    def _ret(hint, verdict=None):
+        return (hint, verdict) if return_verdict else hint
+
+    snpc = getattr(config, 'same_net_pad_clearance', -1.0)
+    if obstacles is None or pcb_data is None or not net_id             or snpc is None or snpc <= 0:
+        return _ret('')
+    try:
+        from obstacle_map import (same_net_pad_via_keepout_cells, GridCoord,
+                                  _mirror_rungs_add, _mirror_rungs_remove,
+                                  _rung_small_armed)
+        import numpy as _np
+        import env_knobs
+    except Exception:
+        return _ret('')
+    pads = [p for p in pcb_data.pads_by_net.get(net_id, [])
+            if not getattr(p, 'drill', 0)]
+    if not pads:
+        return _ret('')            # through-hole only: the flag exempts those
+    coord = GridCoord(config.grid_step)
+    rung = int(getattr(config, 'via_rung', 0) or 0)
+    reach_mm = max(0.0, env_knobs.ESCAPE_STUB_RADIUS)
+
+    def _free_site(pad):
+        """Is any via site that could serve `pad` legal right now?"""
+        pgx, pgy = coord.to_grid(pad.global_x, pad.global_y)
+        span = int(round((max(pad.size_x, pad.size_y) / 2 + reach_mm)
+                         / config.grid_step))
+        for gx in range(pgx - span, pgx + span + 1):
+            for gy in range(pgy - span, pgy + span + 1):
+                try:
+                    blocked = obstacles.is_via_blocked_rung(gx, gy, rung)
+                except Exception:
+                    blocked = obstacles.is_via_blocked(gx, gy)
+                if not blocked:
+                    return True
+        return False
+
+    for pad in pads:
+        try:
+            cells = same_net_pad_via_keepout_cells(pcb_data, net_id, config,
+                                                   pads=[pad])
+        except Exception:
+            continue
+        if not len(cells):
+            continue
+        if _free_site(pad):
+            continue               # a legal site exists: the flag sealed nothing
+        arr = _np.asarray(cells, dtype=_np.int32)
+        try:
+            obstacles.remove_blocked_vias_batch(arr)
+            if _rung_small_armed():
+                obstacles.remove_blocked_vias_small_batch(arr)
+            _mirror_rungs_remove(obstacles, arr)
+            freed = _free_site(pad)
+        except Exception:
+            continue
+        finally:
+            # Exactly balanced on a refcounted map -- a cell blocked by this
+            # flag AND by something else keeps its other reference and stays
+            # blocked, which is the right answer.
+            try:
+                obstacles.add_blocked_vias_batch(arr)
+                if _rung_small_armed():
+                    obstacles.add_blocked_vias_small_batch(arr)
+                _mirror_rungs_add(obstacles, arr)
+            except Exception:
+                pass
+        if not freed:
+            continue               # something else seals it; not this flag
+        where = f"{pad.component_ref}.{pad.pad_number}"
+        name = net_name or pad.net_name or f"net{net_id}"
+        need = config.via_size / 2 + snpc + config.grid_step / 2
+        hint = (f"Hint: pad {where} is sealed by --same-net-pad-clearance "
+                f"{snpc:g} -- with that flag's keep-out removed a legal via "
+                f"site appears, and with it there is none within the "
+                f"{reach_mm:g}mm escape-stub reach. It needs {need:.3f}mm of "
+                f"clear pad surround (via/2 {config.via_size / 2:.3f} + "
+                f"clearance {snpc:g} + grid/2 {config.grid_step / 2:.3f}), so "
+                f"{name} cannot change layer here. Re-run with "
+                f"--same-net-pad-clearance 0 to allow via-in-pad on this "
+                f"board, or widen the channel around {where} in placement.")
+        return _ret(hint, {'verdict': 'sealed_by_snpc', 'pad': where,
+                           'same_net_pad_clearance': float(snpc),
+                           'required_surround_mm': round(need, 4),
+                           'escape_reach_mm': round(reach_mm, 3),
+                           'net': name})
+    return _ret('')
 
 
 def static_boxin_hint(result, config, pcb_data=None, *, return_verdict=False):

--- a/py_router/routing_diagnostics.py
+++ b/py_router/routing_diagnostics.py
@@ -52,12 +52,16 @@ def suggest_route_adjustments(failed: int, total: int,
     # one names a rule that may have closed the last via site.
     snpc = _g(config, 'same_net_pad_clearance')
     if snpc is not None and snpc > 0:
+        # The control is the 'Allow via-in-pad' CHECKBOX, ticked by default;
+        # UNticking it is what arms this clearance. Name it as the user sees
+        # it, and in the direction they must move it.
         suggestions.append(
-            f"Untick 'via-in-pad forbidden' / set Same-net pad clearance "
-            f"(currently {snpc:g} mm) to 0 - it bans every via within "
+            f"Tick 'Allow via-in-pad' (or set Same-net pad clearance, "
+            f"currently {snpc:g} mm, to 0) - it bans every via within "
             f"{snpc:g} mm of the net's OWN SMD pads, and an SMD pad boxed in "
             f"closer than that on every side has no legal via site at all. "
-            f"The run log names any pad this actually sealed."
+            f"When a net fails with no rippable blockers, the run log names "
+            f"any pad this actually sealed."
         )
 
     # Rip-up is the single highest-leverage fix for "blocker" failures.
@@ -662,7 +666,6 @@ def same_net_pad_seal_hint(pcb_data, config, net_id, net_name=None,
         return _ret('')
     try:
         from obstacle_map import (same_net_pad_via_keepout_cells, GridCoord,
-                                  _mirror_rungs_add, _mirror_rungs_remove,
                                   _rung_small_armed)
         import numpy as _np
         import env_knobs
@@ -702,25 +705,37 @@ def same_net_pad_seal_hint(pcb_data, config, net_id, net_name=None,
         if _free_site(pad):
             continue               # a legal site exists: the flag sealed nothing
         arr = _np.asarray(cells, dtype=_np.int32)
+        # REMOVE EXACTLY WHAT THE STAMP ADDED, and nothing else. The snpc
+        # keep-out is stamped by routing_context as `add_blocked_vias_batch`
+        # plus the #568 SMALL mirror -- never into the per-net RUNG maps. And
+        # `remove_blocked_vias_rung_batch` SATURATES at zero (an absent key is
+        # a no-op), so touching the rungs here would remove nothing and then
+        # STAMP them on the way back: measured, a rung count of 1 became 4 and
+        # the cell stayed blocked for the rest of the run, silently
+        # over-blocking rung via placement on the failure path -- exactly when
+        # the router is already struggling.
+        _small = _rung_small_armed()
+        _removed = False
         try:
             obstacles.remove_blocked_vias_batch(arr)
-            if _rung_small_armed():
+            if _small:
                 obstacles.remove_blocked_vias_small_batch(arr)
-            _mirror_rungs_remove(obstacles, arr)
+            _removed = True
             freed = _free_site(pad)
         except Exception:
             continue
         finally:
-            # Exactly balanced on a refcounted map -- a cell blocked by this
-            # flag AND by something else keeps its other reference and stays
-            # blocked, which is the right answer.
-            try:
-                obstacles.add_blocked_vias_batch(arr)
-                if _rung_small_armed():
-                    obstacles.add_blocked_vias_small_batch(arr)
-                _mirror_rungs_add(obstacles, arr)
-            except Exception:
-                pass
+            # Balanced on a refcounted map -- a cell blocked by this flag AND
+            # by something else keeps its other reference and stays blocked,
+            # which is the right answer. Re-added ONLY if the removal actually
+            # happened, so a throw part-way through cannot leak a stamp.
+            if _removed:
+                try:
+                    obstacles.add_blocked_vias_batch(arr)
+                    if _small:
+                        obstacles.add_blocked_vias_small_batch(arr)
+                except Exception:
+                    pass
         if not freed:
             continue               # something else seals it; not this flag
         where = f"{pad.component_ref}.{pad.pad_number}"

--- a/py_router/routing_state.py
+++ b/py_router/routing_state.py
@@ -440,7 +440,7 @@ def get_net_history_summary(state: RoutingState, net_id: int, pcb_data: 'PCBData
                 f"[{seq}] Pad {details.get('pad', '?')} sealed by "
                 f"--same-net-pad-clearance "
                 f"{details.get('same_net_pad_clearance', '?')}: every via "
-                f"site within {details.get('searched_mm', '?')}mm is banned "
+                f"site within {details.get('escape_reach_mm', '?')}mm is banned "
                 f"by that flag alone (needs "
                 f"{details.get('required_surround_mm', '?')}mm of clear pad "
                 f"surround)")

--- a/py_router/routing_state.py
+++ b/py_router/routing_state.py
@@ -432,6 +432,19 @@ def get_net_history_summary(state: RoutingState, net_id: int, pcb_data: 'PCBData
                          f"{iters} iteration(s)"
                          + (f" ({', '.join(bits)} mm)" if bits else ""))
 
+        elif event == "sealed_by_snpc":
+            # #907. The remedy is a FLAG, so name the flag and its value --
+            # an event with no arm here prints bare and loses its details,
+            # which is exactly how this cause stayed invisible.
+            lines.append(
+                f"[{seq}] Pad {details.get('pad', '?')} sealed by "
+                f"--same-net-pad-clearance "
+                f"{details.get('same_net_pad_clearance', '?')}: every via "
+                f"site within {details.get('searched_mm', '?')}mm is banned "
+                f"by that flag alone (needs "
+                f"{details.get('required_surround_mm', '?')}mm of clear pad "
+                f"surround)")
+
         elif event == "fanout_dropped":
             # The fix for this one is UPSTREAM (re-run the fanout), which is
             # the point of naming it apart from the two above.

--- a/py_router/single_ended_loop.py
+++ b/py_router/single_ended_loop.py
@@ -1556,10 +1556,12 @@ def route_single_ended_nets(
                 if not _cells301:
                     _cells301 = list(locals().get('blocked_cells') or [])
                 # #907: say WHY nothing is rippable when the answer is "a
-                # FLAG THIS RUN SET closed the last via site". First in the
-                # cascade because it is the only one whose remedy is a
-                # command-line change the caller already controls -- and
-                # because nothing else in the report names the flag at all.
+                # FLAG THIS RUN SET closed the last via site". Ahead of the
+                # #652 and #301 hints (the static-boxin verdict above is
+                # printed by the `no rippable blockers` line itself) because
+                # it is the only cause whose remedy is a command-line change
+                # the caller already controls -- and because nothing else in
+                # the report names the flag at all.
                 try:
                     from routing_diagnostics import same_net_pad_seal_hint
                     _h907, _v907 = same_net_pad_seal_hint(

--- a/py_router/single_ended_loop.py
+++ b/py_router/single_ended_loop.py
@@ -1555,6 +1555,25 @@ def route_single_ended_nets(
                                  (result.get('blocked_cells_backward') or []))
                 if not _cells301:
                     _cells301 = list(locals().get('blocked_cells') or [])
+                # #907: say WHY nothing is rippable when the answer is "a
+                # FLAG THIS RUN SET closed the last via site". First in the
+                # cascade because it is the only one whose remedy is a
+                # command-line change the caller already controls -- and
+                # because nothing else in the report names the flag at all.
+                try:
+                    from routing_diagnostics import same_net_pad_seal_hint
+                    _h907, _v907 = same_net_pad_seal_hint(
+                        pcb_data, config, net_id, net_name,
+                        obstacles=state.working_obstacles,
+                        return_verdict=True)
+                    if _h907:
+                        _c907 = condense_hint(_h907)
+                        if _c907:
+                            print(f"  {_c907}")
+                        record_net_event(state, net_id, "sealed_by_snpc",
+                                         _v907)
+                except Exception:
+                    pass
                 # #652: say WHY nothing is rippable when the answer is
                 # "this ball never got an escape". Placed before the #301 hint
                 # because it is the actionable one -- #301 names copper to rip,

--- a/py_router/single_ended_routing.py
+++ b/py_router/single_ended_routing.py
@@ -2463,6 +2463,15 @@ def _place_shrunk_via_in_pad_impl(pad_obj, obstacles, config, pcb_data, net_id, 
     _allow_in_pad = getattr(config, 'same_net_pad_clearance', -1.0) <= 0
     _escape_radius = max(0.0, env_knobs.ESCAPE_STUB_RADIUS)
     if not _allow_in_pad and _escape_radius <= 0:
+        # #907 filed this as "no fallback by design". There IS a fallback --
+        # the off-pad escape-stub rung below -- and this is the one
+        # configuration that has none: the flag forbids the in-pad arm and
+        # KICAD_ESCAPE_STUB_RADIUS=0 turns off the compliant replacement. Say
+        # so; a bare `return None` here reads as "no site fits", which sends
+        # the reader looking at geometry instead of at two settings.
+        print("    (no via-in-pad rescue: --same-net-pad-clearance forbids "
+              "the in-pad arm and KICAD_ESCAPE_STUB_RADIUS=0 disables the "
+              "off-pad escape stub that replaces it)")
         return None
     if hasattr(pad_obj, 'layers') and '*.Cu' in pad_obj.layers:
         return None

--- a/py_tools/fill_for_delivery.py
+++ b/py_tools/fill_for_delivery.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Write a FILLED copy of a routed board, for delivery (#910).
+
+The routed deliverable carries zone OUTLINES with no `(filled_polygon ...)`:
+`kicad_writer` writes the `(fill yes ...)` properties, and nothing in the plane
+path ever writes a fill. Opened in KiCad before a refill -- or graded by
+`kicad-cli pcb drc` WITHOUT `--refill-zones` -- such a board reports plane-net
+opens that are not real. Measured on run 25's `routed.kicad_pcb`: 5 unconnected
+(all GND) without the flag, 0 with it.
+
+This is the opt-in delivery step. It runs KiCad's own ZONE_FILLER through the
+bundled interpreter and saves with `aSkipSettings=True`, so the sibling
+`.kicad_pro` -- and every non-Default net class in it -- survives.
+
+Usage:
+    python3 py_tools/fill_for_delivery.py routed.kicad_pcb -o delivered.kicad_pcb
+
+Exit codes:
+    0  filled, net classes intact
+    1  the fill did not run, or a net class went missing (nothing shipped)
+"""
+from __future__ import annotations
+
+import _path  # noqa: F401  (#522: puts ../py_router on sys.path)
+
+import argparse
+import json
+import os
+import sys
+
+
+def _netclass_names(pcb_path):
+    """The net-class names in the sibling .kicad_pro, or None if there is none."""
+    pro = os.path.splitext(pcb_path)[0] + '.kicad_pro'
+    if not os.path.isfile(pro):
+        return None
+    try:
+        with open(pro, encoding='utf-8') as fh:
+            doc = json.load(fh)
+    except Exception:
+        return None
+    nc = (doc.get('net_settings') or {}).get('classes') or []
+    return {c.get('name') for c in nc if isinstance(c, dict)}
+
+
+def _unconnected(pcb_path):
+    """kicad-cli's unconnected count WITHOUT `--refill-zones`, or None.
+
+    Deliberately without the flag: that is the number a reviewer sees when
+    they open or grade the deliverable as shipped, and the whole point of
+    this step is to make it agree with the refilled one.
+    """
+    import subprocess
+    import tempfile
+    try:
+        from kicad_unconnected import find_kicad_cli
+    except Exception:
+        return None
+    cli = find_kicad_cli()
+    if cli is None:
+        return None
+    out = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as fh:
+            out = fh.name
+        subprocess.run([cli, 'pcb', 'drc', '--format', 'json',
+                        '--severity-error', '-o', out, pcb_path],
+                       capture_output=True, text=True, timeout=600)
+        with open(out, encoding='utf-8') as fh:
+            return len(json.load(fh).get('unconnected_items') or [])
+    except Exception:
+        return None
+    finally:
+        if out:
+            try:
+                os.unlink(out)
+            except OSError:
+                pass
+
+
+def main() -> int:
+    from redo_record import record_invocation
+    record_invocation()
+
+    ap = argparse.ArgumentParser(
+        description=__doc__.split('\n')[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__)
+    ap.add_argument('input_file', help='routed .kicad_pcb')
+    ap.add_argument('-o', '--output', required=True,
+                    help='destination .kicad_pcb (siblings are copied too)')
+    ap.add_argument('--timeout', type=int, default=None,
+                    help='seconds to allow the KiCad fill (default: the '
+                         'exact-fill budget)')
+    ap.add_argument('--exit-zero', action='store_true',
+                    help='report problems but exit 0')
+    args = ap.parse_args()
+
+    if not os.path.isfile(args.input_file):
+        print(f"error: no such board: {args.input_file}")
+        return 0 if args.exit_zero else 1
+
+    from copy_board import copy_board
+    from kicad_exact_fill import write_filled_board, EXACT_FILL_TIMEOUT
+
+    want = _netclass_names(args.input_file)
+    before = _unconnected(args.input_file)
+
+    # Siblings FIRST (.kicad_pro / .kicad_prl / .kicad_dru / design brief):
+    # the fill is graded against the project's real netclasses, and #441 is
+    # what happens when a board travels without them.
+    copy_board(args.input_file, args.output)
+
+    st = write_filled_board(args.input_file, args.output, verbose=True,
+                            timeout=args.timeout or EXACT_FILL_TIMEOUT)
+    if not st.ok:
+        print(f"FILL NOT WRITTEN: {st.reason}"
+              + (f" ({st.detail})" if st.detail else ''))
+        print("  The copied board is unfilled; grade it with "
+              "`kicad-cli pcb drc --refill-zones` or press B in KiCad.")
+        return 0 if args.exit_zero else 1
+
+    # The trap this step exists to avoid, checked rather than assumed: a save
+    # that rewrites the project deletes every non-Default class.
+    got = _netclass_names(args.output)
+    if want is not None and got is not None and not want.issubset(got):
+        lost = sorted(want - got)
+        print(f"REFUSING: net class(es) lost in the filled output: "
+              f"{', '.join(lost)}")
+        try:
+            os.unlink(args.output)
+        except OSError:
+            pass
+        return 0 if args.exit_zero else 1
+
+    after = _unconnected(args.output)
+    n_fill = 0
+    try:
+        with open(args.output, encoding='utf-8', errors='replace') as fh:
+            n_fill = fh.read().count('(filled_polygon')
+    except OSError:
+        pass
+    print(f"Filled: {args.output}")
+    print(f"  filled_polygon blocks: {n_fill}")
+    if want is not None:
+        print(f"  net classes preserved: {len(want)}")
+    if before is not None and after is not None:
+        # The record that the fill did not CHANGE connectivity, only revealed
+        # it -- the number a reviewer would otherwise have to take on trust.
+        print(f"  unconnected (no --refill-zones): {before} -> {after}")
+    return 0
+
+
+if __name__ == '__main__':
+    import cli_banner
+    cli_banner.install()
+    sys.exit(main())

--- a/py_tools/fill_for_delivery.py
+++ b/py_tools/fill_for_delivery.py
@@ -9,15 +9,25 @@ opens that are not real. Measured on run 25's `routed.kicad_pcb`: 5 unconnected
 (all GND) without the flag, 0 with it.
 
 This is the opt-in delivery step. It runs KiCad's own ZONE_FILLER through the
-bundled interpreter and saves with `aSkipSettings=True`, so the sibling
-`.kicad_pro` -- and every non-Default net class in it -- survives.
+bundled interpreter, on a STAGED copy in a temp dir, and saves with
+`aSkipSettings=True` (a plain `SaveBoard` rewrites the project from KiCad's
+in-memory view, deleting every non-Default net class, and aborts outright on a
+pre-KiCad-10 project). The destination's `.kicad_pro` is written here by
+`copy_board` and is never in the fill's reach -- and this tool AUDITS that
+afterwards rather than asserting it, refusing if a class went missing.
 
 Usage:
     python3 py_tools/fill_for_delivery.py routed.kicad_pcb -o delivered.kicad_pcb
 
 Exit codes:
     0  filled, net classes intact
-    1  the fill did not run, or a net class went missing (nothing shipped)
+    1  the fill did not run, or a net class went missing
+
+On exit 1 the destination holds the board and its siblings COPIED but not
+filled -- that copy is useful (grade it with `kicad-cli pcb drc
+--refill-zones`, or press B in KiCad) and the run says so -- except on the
+net-class refusal, where the destination is removed entirely, because a board
+graded against rules it no longer carries is worse than no board.
 """
 from __future__ import annotations
 
@@ -99,6 +109,12 @@ def main() -> int:
     if not os.path.isfile(args.input_file):
         print(f"error: no such board: {args.input_file}")
         return 0 if args.exit_zero else 1
+    if os.path.abspath(args.input_file) == os.path.abspath(args.output):
+        # A natural thing to try, and copy_board would raise SameFileError at
+        # the user. `route.py --write-fill` is the in-place form.
+        print("error: -o names the input file. Use `route.py --write-fill` to "
+              "fill a board in place, or give a different -o.")
+        return 0 if args.exit_zero else 1
 
     from copy_board import copy_board
     from kicad_exact_fill import write_filled_board, EXACT_FILL_TIMEOUT
@@ -112,7 +128,8 @@ def main() -> int:
     copy_board(args.input_file, args.output)
 
     st = write_filled_board(args.input_file, args.output, verbose=True,
-                            timeout=args.timeout or EXACT_FILL_TIMEOUT)
+                            timeout=args.timeout or EXACT_FILL_TIMEOUT,
+                            project_from=args.input_file)
     if not st.ok:
         print(f"FILL NOT WRITTEN: {st.reason}"
               + (f" ({st.detail})" if st.detail else ''))
@@ -127,10 +144,15 @@ def main() -> int:
         lost = sorted(want - got)
         print(f"REFUSING: net class(es) lost in the filled output: "
               f"{', '.join(lost)}")
-        try:
-            os.unlink(args.output)
-        except OSError:
-            pass
+        # The SIBLINGS go too: a `.kicad_pro` / `.kicad_dru` left behind with
+        # no board is debris a later step can pick up as a DRC floor.
+        from copy_board import SIBLING_EXTS
+        _stem = os.path.splitext(args.output)[0]
+        for _ext in ('.kicad_pcb',) + tuple(SIBLING_EXTS):
+            try:
+                os.unlink(_stem + _ext)
+            except OSError:
+                pass
         return 0 if args.exit_zero else 1
 
     after = _unconnected(args.output)

--- a/tests/gui_parity/test_cli_postpass_coverage.py
+++ b/tests/gui_parity/test_cli_postpass_coverage.py
@@ -167,6 +167,14 @@ DISCOVERY_EXEMPT = {'add_drc_fix_args', 'drc_fix_kwargs', 'find_kicad_cli',
 KNOWN_CLI_ONLY = {
     'run_drc': 'bga/qfn fanout post-engine DRC graze audit -> JSON_SUMMARY '
                'drc_grazes (report-only, no board mutation)',
+    # #910. OPT-IN (--write-fill) and CLI-only ON PURPOSE: it writes
+    # `filled_polygon` blocks into the DELIVERED FILE, and the GUI has no
+    # delivered file -- it applies copper to the user's open board, where
+    # KiCad fills live and pressing B is the same operation. A GUI twin would
+    # be a button that does what the application already does.
+    'write_filled_board': 'route.py --write-fill: fills the WRITTEN board for '
+                          'delivery; the GUI mutates a live board KiCad fills '
+                          'itself, so there is no file to fill',
 }
 
 

--- a/tests/gui_parity/test_cli_postpass_coverage.py
+++ b/tests/gui_parity/test_cli_postpass_coverage.py
@@ -107,6 +107,12 @@ REGISTRY = {
 # gui_utils.move_copper_graphics_to_silkscreen_board. Any new writer-level pass
 # needs the same treatment.
 #
+# #908 made that twin pair carry a DECISION as well as a walk (a footprint with
+# pads owns functional copper and is exempt from the move). Both fronts read the
+# one predicate kicad_parser.footprint_copper_is_functional rather than each
+# counting pads its own way, and tests/test_908_writer_owner_gate.py measures
+# the two fronts against each other on real boards.
+#
 # OPEN GAP (2026-07-28): kicad_writer.strip_zero_length_edge_cuts sits in exactly
 # that position -- wired into output_writer / plane_io / kicad_writer beside the
 # silkscreen movers -- and has NO GUI twin yet. Consequence: a board routed

--- a/tests/stress/manifest_to_plan.py
+++ b/tests/stress/manifest_to_plan.py
@@ -193,6 +193,14 @@ BOOL_FLAGS = {
     # #489 section 9: now on every step that writes pad/via copper (route,
     # route_diff, route_planes, route_disconnected_planes, bga/qfn fanout).
     '--add-teardrops': 'add_teardrops',
+    # #910: route.py's opt-in delivery fill. Registered not because the GUI
+    # has a control for it (it does not -- the GUI mutates a live board KiCad
+    # fills itself), but because an UNREGISTERED bare flag falls through to
+    # the unknown-flag branch, whose value loop does not stop at a
+    # `.kicad_pcb` -- so `route.py in.kicad_pcb --write-fill out.kicad_pcb`
+    # would swallow the OUTPUT path out of the step's `_files`, which pruning
+    # reads. Mapping it to a param keeps the file list intact.
+    '--write-fill': 'write_fill',
     # #487: route_planes' default-on thermal-via arrays; the NEGATIVE flag
     # must survive conversion or a replay re-enables what the run disabled
     # (ai_plan's no_thermal_vias alias unchecks the planes checkbox).

--- a/tests/test_581_same_net_pad_via_clearance.py
+++ b/tests/test_581_same_net_pad_via_clearance.py
@@ -15,6 +15,11 @@ Invariants:
      caller leaves the parameter unset (repair/finalize path), and an explicit
      caller 0 keeps its legacy meaning.
   6. add_same_net_via_clearance stamps the pad keep-out (Phase 3 path).
+  7. #907: the flag DISCLOSES itself. `same_net_pad_seal_hint` names the flag
+     and the pad when this flag alone closed every via site around it, stays
+     silent when a legal site exists or when something ELSE is also in the
+     way, and `same_net_pad_via_keepout_cells(pads=[one])` answers for a
+     single pad without rebuilding or mutating the map.
 
 Run:
     python3 tests/test_581_same_net_pad_via_clearance.py
@@ -172,6 +177,73 @@ def main():
     obs2 = GridObstacleMap(2)
     add_same_net_via_clearance(obs2, pcb, 1, cfg_off)
     check("inactive: pad centre open", not obs2.is_via_blocked(gx, gy))
+
+    # -- 7: #907 disclosure ---------------------------------------------------
+    print("7: the flag names itself when it seals a pad")
+    from routing_diagnostics import same_net_pad_seal_hint
+
+    # per-pad scoping: two pads, one asked about
+    pcb2 = _pcb([_pad(5, 5), _pad(12, 12)])
+    both = same_net_pad_via_keepout_cells(pcb2, 1, cfg_on)
+    one = same_net_pad_via_keepout_cells(pcb2, 1, cfg_on,
+                                         pads=[pcb2.pads_by_net[1][0]])
+    check("pads= scopes the keep-out to one pad",
+          len(one) and len(one) < len(both))
+
+    # A map carrying ONLY this flag's cells: every site around the pad is
+    # banned, and nothing else is in the way -> the hint must fire and name it.
+    # The real shape of the failure (run 25's esp_prog): OTHER copper boxes
+    # the pad in beyond the flag's own ring, and the flag takes the last
+    # sites -- the ones ON the pad. Removing the flag's cells must free one.
+    obs7 = GridObstacleMap(2)
+    add_same_net_via_clearance(obs7, pcb, 1, cfg_on)
+    _co = GridCoord(cfg_on.grid_step)
+    _pgx, _pgy = _co.to_grid(10.0, 10.0)
+    _keep = {(int(a), int(b)) for a, b in
+             same_net_pad_via_keepout_cells(pcb, 1, cfg_on)}
+    _sp = int(round((0.5 + 1.0) / cfg_on.grid_step)) + 2
+    for _dx in range(-_sp, _sp + 1):
+        for _dy in range(-_sp, _sp + 1):
+            _c2 = (_pgx + _dx, _pgy + _dy)
+            if _c2 not in _keep:
+                obs7.add_blocked_via(*_c2)
+    hint, verdict = same_net_pad_seal_hint(pcb, cfg_on, 1, 'N1',
+                                           obstacles=obs7,
+                                           return_verdict=True)
+    check("sealed pad: the hint fires", bool(hint))
+    check("sealed pad: the hint NAMES the flag",
+          'same-net-pad-clearance' in (hint or ''))
+    check("sealed pad: a structured verdict comes with it",
+          bool(verdict) and verdict.get('verdict') == 'sealed_by_snpc'
+          and verdict.get('pad') == 'U1.1')
+
+    # Same map, flag OFF on the config -> nothing to disclose.
+    hint_off = same_net_pad_seal_hint(pcb, cfg_off, 1, 'N1', obstacles=obs7)
+    check("flag inactive: silent", hint_off == '')
+
+    # An EMPTY map: a legal site exists, so the flag sealed nothing.
+    hint_free = same_net_pad_seal_hint(pcb, cfg_on, 1, 'N1',
+                                       obstacles=GridObstacleMap(2))
+    check("a legal via site exists: silent", hint_free == '')
+
+    # Sealed by something ELSE as well -> removing the flag's cells frees
+    # nothing, so this is not the flag's doing and it must stay silent.
+    obs7b = GridObstacleMap(2)
+    add_same_net_via_clearance(obs7b, pcb, 1, cfg_on)
+    _c = GridCoord(cfg_on.grid_step)
+    _gx, _gy = _c.to_grid(10.0, 10.0)
+    _span = int(round((0.5 + 1.0) / cfg_on.grid_step)) + 2
+    for _dx in range(-_span, _span + 1):
+        for _dy in range(-_span, _span + 1):
+            obs7b.add_blocked_via(_gx + _dx, _gy + _dy)
+    check("sealed by something else too: silent",
+          same_net_pad_seal_hint(pcb, cfg_on, 1, 'N1',
+                                 obstacles=obs7b) == '')
+    # ...and the probe RESTORED the map it borrowed: the pad centre is still
+    # blocked afterwards. A diagnosis that desyncs a refcounted via map would
+    # be far worse than no diagnosis.
+    check("the probe restores the map exactly",
+          obs7.is_via_blocked(gx, gy) and obs7b.is_via_blocked(_gx, _gy))
 
     print()
     if fails:

--- a/tests/test_581_same_net_pad_via_clearance.py
+++ b/tests/test_581_same_net_pad_via_clearance.py
@@ -26,6 +26,7 @@ Run:
 """
 
 import json
+import numpy as np
 import os
 import sys
 import tempfile
@@ -244,6 +245,39 @@ def main():
     # be far worse than no diagnosis.
     check("the probe restores the map exactly",
           obs7.is_via_blocked(gx, gy) and obs7b.is_via_blocked(_gx, _gy))
+
+    # ...and restores means restores: nothing may BECOME blocked either, in
+    # any per-net RUNG map. `remove_blocked_vias_rung_batch` saturates at zero
+    # (an absent key is a no-op), so a probe that removed from the rungs would
+    # remove nothing and then STAMP them on the way back -- silently
+    # over-blocking rung via placement for the rest of the run. A bare
+    # GridObstacleMap has no rungs, so this arm builds one that does.
+    obs7c = GridObstacleMap(2)
+    add_same_net_via_clearance(obs7c, pcb, 1, cfg_on)
+    _keep2 = {(int(a), int(b)) for a, b in
+              same_net_pad_via_keepout_cells(pcb, 1, cfg_on)}
+    _sp2 = int(round((0.5 + 1.0) / cfg_on.grid_step)) + 2
+    for _dx in range(-_sp2, _sp2 + 1):
+        for _dy in range(-_sp2, _sp2 + 1):
+            _c3 = (_gx + _dx, _gy + _dy)
+            if _c3 not in _keep2:
+                obs7c.add_blocked_via(*_c3)
+    # Rungs are created on first use, and rung 1 is the #568 SMALL map's own
+    # slot -- per-net rungs start at 2. Touch rung 3 so rung_count becomes 4
+    # and _per_net_rungs is [2, 3], i.e. the helpers are live rather than
+    # no-ops on a bare map (which carries rung_count 1 and no per-net rungs
+    # at all, so an earlier version of this row could not fail).
+    obs7c.add_blocked_vias_rung_batch(3, np.array([[_gx + 500, _gy + 500]],
+                                                  dtype=np.int32))
+    from obstacle_map import _per_net_rungs
+    _rungs = list(_per_net_rungs(obs7c))
+    check(f"the rung fixture is live (per-net rungs {_rungs})",
+          len(_rungs) >= 1)
+    _len_before = {r: obs7c.rung_len(r) for r in _rungs}
+    same_net_pad_seal_hint(pcb, cfg_on, 1, 'N1', obstacles=obs7c)
+    _len_after = {r: obs7c.rung_len(r) for r in _rungs}
+    check(f"the probe stamps nothing into a per-net rung map "
+          f"({_len_before} -> {_len_after})", _len_before == _len_after)
 
     print()
     if fails:

--- a/tests/test_619_underpad_stub_vs_erased_copper.py
+++ b/tests/test_619_underpad_stub_vs_erased_copper.py
@@ -240,10 +240,19 @@ def test_erasure_injection_and_control():
           "(tigard U3, QFN-64)")
     _gate('all')
     pcb = parse_kicad_pcb(TIGARD)
-    check("tigard carries ZERO vias and ZERO segments -- an injected obstacle "
-          "is the only one, so the baseline cannot be contaminated",
-          len(pcb.vias) == 0 and len(pcb.segments) == 0,
-          f"{len(pcb.vias)} vias, {len(pcb.segments)} segments")
+    # ROUTED copper, which is what "cannot be contaminated" is about. Since
+    # #908 the board also carries 4 `graphic=True` segments -- JP1's own
+    # solder-jumper bridge, drawn in the footprint, on B.Cu and nowhere near
+    # U3. They are part of the board's fixed geometry, identical in every arm
+    # of this test, so they cannot contaminate a baseline; counting them here
+    # would only make the premise unstateable.
+    _routed = [s for s in pcb.segments if not getattr(s, 'graphic', False)]
+    _art = len(pcb.segments) - len(_routed)
+    check("tigard carries ZERO vias and ZERO ROUTED segments -- an injected "
+          "obstacle is the only one, so the baseline cannot be contaminated",
+          len(pcb.vias) == 0 and len(_routed) == 0,
+          f"{len(pcb.vias)} vias, {len(_routed)} routed segments "
+          f"({_art} footprint-art segments, #908)")
 
     a, b = "/BD0", "/BD1"
     nid_a = next(n for n, net in pcb.nets.items() if net.name == a)

--- a/tests/test_703_predictor_regen.py
+++ b/tests/test_703_predictor_regen.py
@@ -141,15 +141,37 @@ sys.path.insert(0, os.path.join(ROOT, 'tests', 'stress'))
 #:     holds for the blocking half, and is left standing above with this
 #:     correction rather than quietly edited.
 #:
+#: RE-RECORDED 2026-09-10 (#908). Footprint copper -- `fp_poly` on a copper
+#: layer inside a `(footprint ...)` block -- is now parsed, modelled as an
+#: obstacle and graded by check_drc; before this it was invisible to all
+#: three, AND the writer relocated it to silkscreen on every write. esp_prog
+#: carries one: the drawn tab of U2's SOT89. All three esp_prog rows move, and
+#: the two kinds of movement are worth separating:
+#:
+#:   * `truth.quality` on all three -- the router now has an obstacle it did
+#:     not have, so it lays different copper past U2. authored
+#:     39/353.93/256 -> 34/344.06/286; perturb-scatter-d1
+#:     32/327.31/282 -> 37/363.0/311; portfolio-1 31/341.99/263 ->
+#:     30/350.67/304. Stable across repeated runs.
+#:   * `esp_prog:portfolio-1` -- `truth.headline` 0 -> 1, and it is NOT a
+#:     routing failure: `blocking_by` reads unrouted 0, broken 0, **drc 1**.
+#:     The quench candidate moves U2 so its tab lands ON Q1's pads, and
+#:     check_drc now says so: "Pad:/DTR (Q1.2) <-> Seg:net_0 [Polygon(U2)],
+#:     overlap 0.101mm". kicad-cli 10.0.0 independently reports the same
+#:     candidate as `shorting_items` against Q1 pad 2 AND pad 3. So the row
+#:     did not get worse -- a real defect in that placement stopped being
+#:     invisible. The header's "this row is the study's headline in miniature"
+#:     commentary is left standing above, with this as its second correction.
+#:
 EXPECTED = {
     'esp_prog:authored': dict(
         poses_sha256='67a9712d200814442b4a25cf1fa8ccd075c1968d5b08c0ad58c4662f0a479da7',
         argv_sha='52aaeed47e14fea796be12c36db09c605a4b8ec588da12bded6a2573b1c7f0b0',
-        seconds=8.2,
+        seconds=8.3,
         truth={'headline': 0,
-               # re-recorded 2026-09-03 with the #530 defaults --fab-tier auto /
-               # --escalation fab (the pre-#857 ladder): 33/345.52/373 -> 39/353.93/256
-               'quality': {'vias': 39, 'copper_mm': 353.93, 'segments': 256}},
+               # 2026-09-03 (#530 auto/fab defaults): 33/345.52/373 -> 39/353.93/256
+               # 2026-09-10 (#908 footprint copper): 39/353.93/256 -> 34/344.06/286
+               'quality': {'vias': 34, 'copper_mm': 344.06, 'segments': 286}},
         predictors={
             'crossings': 53, 'hpwl': 253.98092000000003,
             'halo': 127.48707486477095, 'overlap_area': 1.1400451712000104,
@@ -160,10 +182,11 @@ EXPECTED = {
     'esp_prog:perturb-scatter-d1': dict(
         poses_sha256='ce4d5a3803cfcf56d4ab3cfbf4f1be3ffd61242a1be78ef4ce2cae110dc96eca',
         argv_sha='52aaeed47e14fea796be12c36db09c605a4b8ec588da12bded6a2573b1c7f0b0',
-        seconds=11.2,
+        seconds=12.6,
         truth={'headline': 0,
-               # re-recorded 2026-09-03 (auto/fab defaults): 29/341.07/288 -> 32/327.31/282
-               'quality': {'vias': 32, 'copper_mm': 327.31, 'segments': 282}},
+               # 2026-09-03 (auto/fab defaults): 29/341.07/288 -> 32/327.31/282
+               # 2026-09-10 (#908 footprint copper): 32/327.31/282 -> 37/363.0/311
+               'quality': {'vias': 37, 'copper_mm': 363.0, 'segments': 311}},
         predictors={
             'crossings': 50, 'hpwl': 252.34828000000005,
             'halo': 130.46454030971682, 'overlap_area': 1.1400451712000104,
@@ -210,10 +233,14 @@ EXPECTED = {
     'esp_prog:portfolio-1': dict(
         poses_sha256='d1290d938a770bb17f2c6a4869b8224eb30aeba6bb37e11c2ae2f3c6c042695b',
         argv_sha='52aaeed47e14fea796be12c36db09c605a4b8ec588da12bded6a2573b1c7f0b0',
-        seconds=9.5,
-        truth={'headline': 0,
-               # re-recorded 2026-09-03 (auto/fab defaults): 32/347.03/270 -> 31/341.99/263
-               'quality': {'vias': 31, 'copper_mm': 341.99, 'segments': 263}},
+        seconds=12.0,
+        # headline 3 -> 0 (2026-09-03) -> 1 (2026-09-10). The 1 is `drc`, NOT
+        # `unrouted`/`broken`: this candidate lands U2's SOT89 tab on Q1's
+        # pads, and #908 is what makes that visible. See the header note.
+        truth={'headline': 1,
+               # 2026-09-03 (auto/fab defaults): 32/347.03/270 -> 31/341.99/263
+               # 2026-09-10 (#908 footprint copper): 31/341.99/263 -> 30/350.67/304
+               'quality': {'vias': 30, 'copper_mm': 350.67, 'segments': 304}},
         predictors={
             'crossings': 23, 'hpwl': 260.0687799999999,
             'halo': 101.01900525631262, 'overlap_area': 1.0,

--- a/tests/test_713_wallclock_census.py
+++ b/tests/test_713_wallclock_census.py
@@ -66,6 +66,15 @@ REGISTRY = {
         'hang_detector',
         'kicad-cli DRC child. Expiry returns an explicit error string and the '
         'CLI exits 3 -- a refusal, never a clean verdict.'),
+    'py_tools/fill_for_delivery.py': (
+        'hang_detector',
+        'Two external children (#910): the kicad-cli DRC used for the '
+        'before/after unconnected line, and EXACT_FILL_TIMEOUT forwarded to '
+        "kicad_exact_fill's ZONE_FILLER child (`--timeout` overrides it). "
+        'Neither expiry can change the deliverable: the DRC one returns None '
+        'and the before/after line is simply not printed, and the fill one '
+        'returns RefillStatus(timeout), which is a REFUSAL -- the board is '
+        'not written and the run says so.'),
     'kicad_routing_plugin/deps_check.py': (
         'hang_detector',
         'pip/import probes of an external toolchain, plus a worker join.'),

--- a/tests/test_908_drc_report.py
+++ b/tests/test_908_drc_report.py
@@ -92,10 +92,20 @@ def main():
           bool(hits) and any('Polygon(U1)' in str(h.get('item1', ''))
                              + str(h.get('item2', '')) for h in hits),
           f'{[ (h.get("item1"), h.get("item2")) for h in hits ]}')
+    # NOT filtered to a type list: the fixture produces `segment-crossing`,
+    # so a filter naming only segment-segment/pad-segment made this `all([])`
+    # -- vacuous, and it SURVIVED replacing every no_net computation with the
+    # constant False. Assert over the hits themselves, and assert the printed
+    # note too, so the key cannot go back to being written and read by nothing.
     check('the netless side is marked no_net (a clearance issue, not a short)',
-          bool(hits) and all(h.get('no_net') for h in hits
-                             if h['type'] in ('segment-segment',
-                                              'pad-segment')))
+          bool(hits) and all(h.get('no_net') for h in hits),
+          f'{[(h["type"], h.get("no_net")) for h in hits]}')
+    import contextlib as _cl, io as _io
+    _buf = _io.StringIO()
+    with _cl.redirect_stdout(_buf):
+        _run(TRACK % ('F.Cu', 2))
+    check('and the report SAYS so',
+          'no net: a clearance issue, not a short' in _buf.getvalue())
 
     # --- 2: the same track on the other side is NOT caught -----------------
     vs_b = _run(TRACK % ('B.Cu', 2))

--- a/tests/test_908_drc_report.py
+++ b/tests/test_908_drc_report.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""#908: check_drc must see FOREIGN copper against a footprint's own copper.
+
+The point of modelling `fp_*` copper is that a foreign track laid across a
+SOT89 tab is caught here instead of on the fab. The mirror-image requirement
+is that the footprint's OWN pad under its OWN copper is NOT reported: that is
+fixed library geometry, never pipeline-introduced, and the repo already holds
+that doctrine for pad-vs-pad (`tests/test_drc_pad_pad.py:7-11`). KiCad's own
+connectivity unification says the same thing -- it derives a graphic's net
+from what touches it (#337) -- so the exemption is KiCad's rule, not a waiver
+invented here.
+
+Invariants gated here:
+  1. A foreign-net track crossing a footprint's F.Cu poly IS reported, and
+     the report NAMES the polygon (`Polygon(U1)`), the way KiCad does.
+  2. The same track on B.Cu is NOT reported (the layer is respected).
+  3. The footprint's own pad under its own poly is NOT reported.
+  4. A track on the same net as the touched pad is NOT reported.
+  5. `no_net` is set on a violation involving netless copper: a pad with no
+     net cannot electrically SHORT a net (the existing pad-pad idiom).
+
+Run:
+    python3 tests/test_908_drc_report.py
+"""
+
+import os
+import sys
+import tempfile
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(TESTS_DIR)
+sys.path.insert(0, ROOT_DIR)
+sys.path.insert(0, os.path.join(ROOT_DIR, 'py_router'))  # #522
+sys.path.insert(0, os.path.join(ROOT_DIR, 'py_tools'))  # #522
+
+from check_drc import run_drc
+
+RUN_ALL_FAST_OK = True
+
+#: U1 sits at (10,10) with pad 1 at its origin and a 3x1 mm F.Cu poly running
+#: east from the pad. A track at y=10 crosses that poly.
+BOARD = '''(kicad_pcb
+ (version 20221018)
+ (net 0 "")
+ (net 1 "/A")
+ (net 2 "/B")
+ (footprint "L:P" (layer "F.Cu") (at 10 10)
+   (property "Reference" "U1")
+   (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "/A"))
+   (fp_poly (pts (xy 0.4 -0.5) (xy 3.4 -0.5) (xy 3.4 0.5) (xy 0.4 0.5))
+     (stroke (width 0) (type solid)) (fill yes)
+     (layer "F.Cu") (uuid "poly1")))
+%s
+)'''
+
+#: crosses the poly's northern edge at x=12
+TRACK = ('(segment (start 12 8) (end 12 12) (width 0.15) (layer "%s")'
+         ' (net %d) (uuid "t1"))')
+
+
+def _run(body):
+    with tempfile.NamedTemporaryFile('w', suffix='.kicad_pcb',
+                                     delete=False, encoding='utf-8') as fh:
+        fh.write(BOARD % body)
+        path = fh.name
+    try:
+        return run_drc(path, clearance=0.2, quiet=True)
+    finally:
+        os.unlink(path)
+
+
+def main():
+    fails = []
+
+    def check(name, cond, detail=''):
+        print(f"  {'PASS' if cond else 'FAIL'}: {name}"
+              + (f"   [{detail}]" if detail and not cond else ''))
+        if not cond:
+            fails.append(name)
+
+    def involving_poly(vs):
+        return [v for v in vs
+                if 'Polygon' in str(v.get('item1', ''))
+                or 'Polygon' in str(v.get('item2', ''))]
+
+    # --- 1: foreign copper across the tab IS caught, and NAMED -------------
+    vs = _run(TRACK % ('F.Cu', 2))
+    hits = involving_poly(vs)
+    check('a foreign track across a footprint poly is reported',
+          len(hits) >= 1, f'{len(hits)} of {len(vs)} violations')
+    check('the report names the polygon by its owner',
+          bool(hits) and any('Polygon(U1)' in str(h.get('item1', ''))
+                             + str(h.get('item2', '')) for h in hits),
+          f'{[ (h.get("item1"), h.get("item2")) for h in hits ]}')
+    check('the netless side is marked no_net (a clearance issue, not a short)',
+          bool(hits) and all(h.get('no_net') for h in hits
+                             if h['type'] in ('segment-segment',
+                                              'pad-segment')))
+
+    # --- 2: the same track on the other side is NOT caught -----------------
+    vs_b = _run(TRACK % ('B.Cu', 2))
+    check('the same track on B.Cu is not reported against an F.Cu poly',
+          involving_poly(vs_b) == [],
+          f'{involving_poly(vs_b)}')
+
+    # --- 3: the footprint's own pad under its own copper -------------------
+    vs_none = _run('')
+    check('the footprint\'s own pad under its own poly is not reported',
+          involving_poly(vs_none) == [], f'{involving_poly(vs_none)}')
+
+    # --- 4: same-net copper is not reported --------------------------------
+    vs_same = _run(TRACK % ('F.Cu', 1))
+    check('a track on the touched pad\'s own net is not reported',
+          involving_poly(vs_same) == [], f'{involving_poly(vs_same)}')
+
+    # Anti-vacuity: arm 1 must genuinely differ from arms 2-4, otherwise the
+    # whole file would pass with a check_drc that reports nothing at all.
+    check('the positive arm really differs from the negative arms',
+          len(involving_poly(vs)) > 0
+          and len(involving_poly(vs_b)) == 0
+          and len(involving_poly(vs_same)) == 0)
+
+    print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'ALL PASS'}")
+    return 1 if fails else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_908_footprint_copper.py
+++ b/tests/test_908_footprint_copper.py
@@ -24,9 +24,11 @@ is the sibling this is modelled on, including its anti-vacuity idiom):
   7. The plural `(layers "F.Cu" "F.Mask")` form is read, and `F&B.Cu`
      emits on both copper sides -- the same answers the `gr_*` table gives.
   8. A vertex list that already repeats its first point emits N-1 segments,
-     not N with a zero-length one (every watchy antenna poly is written that
-     way, and the duplicates graded as 12 board-edge violations where the
-     truth is 9).
+     not N with a zero-length one. Every watchy antenna poly is written that
+     way, so the duplicates doubled three of its board-edge findings (12
+     reported where the geometry gives 9; those nine are now published as the
+     `immutable-graphic` accepted class rather than counted, but a degenerate
+     segment would still double them there).
   9. `owner_ref` names the DISAMBIGUATED footprint key, so a board that
      spells one reference twice attributes copper to the right block.
  10. The real corpus: esp_prog 8, tigard 4, ulx3s 24, watchy 48 graphic

--- a/tests/test_908_footprint_copper.py
+++ b/tests/test_908_footprint_copper.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""#908: copper drawn INSIDE a footprint must reach the copper model.
+
+The #337 scan walks board-level `gr_*` only, so a footprint's own copper -- the
+drawn tab of a SOT89/DPAK, a PCB antenna, a solder-jumper bridge -- was
+invisible to every obstacle builder and to check_drc, which reads this same
+parser. Measured on esp_prog before the fix: kicad-cli 10.0.0 reports "Pad 2
+[Net-(C1-Pad1)] of U2 on F.Cu" shorting "Polygon [<no net>] of U2 on F.Cu",
+and `check_drc.py` on the same file says NO DRC VIOLATIONS FOUND.
+
+Invariants gated here (the `gr_*` table in test_copper_graphics_layers_plural.py
+is the sibling this is modelled on, including its anti-vacuity idiom):
+
+  1. `fp_poly` on F.Cu in a pad-bearing footprint -> graphic Segments at the
+     GLOBAL coordinates `local_to_global` gives, rotation included.
+  2. B.Cu is read from the SHAPE's own layer; no mirror term is applied.
+  3. A pad-LESS (logo) footprint emits nothing -- the writer relocates it.
+  4. Silk/mask-only `fp_poly` emits nothing.
+  5. A custom pad's `(primitives (gr_poly ...))` emits nothing, even on a
+     copper layer -- those coordinates are PAD-local and would land as
+     phantom copper (urchin carries 136 of them).
+  6. `(stroke (width 0))` on a filled poly -> the TRACK_WIDTH fallback;
+     an `fp_line` with width 0 -> nothing.
+  7. The plural `(layers "F.Cu" "F.Mask")` form is read, and `F&B.Cu`
+     emits on both copper sides -- the same answers the `gr_*` table gives.
+  8. A vertex list that already repeats its first point emits N-1 segments,
+     not N with a zero-length one (every watchy antenna poly is written that
+     way, and the duplicates graded as 12 board-edge violations where the
+     truth is 9).
+  9. `owner_ref` names the DISAMBIGUATED footprint key, so a board that
+     spells one reference twice attributes copper to the right block.
+ 10. The real corpus: esp_prog 8, tigard 4, ulx3s 24, watchy 48 graphic
+     segments; orangecrab_ext_pll, splitflap_driver and glasgow_revC zero.
+
+Run:
+    python3 tests/test_908_footprint_copper.py
+"""
+
+import os
+import sys
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(TESTS_DIR)
+sys.path.insert(0, ROOT_DIR)
+sys.path.insert(0, os.path.join(ROOT_DIR, 'py_router'))  # #522
+sys.path.insert(0, os.path.join(ROOT_DIR, 'py_tools'))  # #522
+
+from kicad_parser import extract_segments, local_to_global, parse_kicad_pcb
+import routing_defaults as defaults
+
+RUN_ALL_FAST_OK = True
+
+NAME_TO_ID = {'/A': 1, '/B': 2}
+
+
+def _board(body):
+    return ('(kicad_pcb (version 20221018)\n (net 0 "")\n (net 1 "/A")\n'
+            ' (net 2 "/B")\n%s\n)' % body)
+
+
+def _fp(inner, at='10 20 -90', pads=1, ref='U1'):
+    pad_txt = '\n'.join(
+        '   (pad "%d" smd rect (at %d 0) (size 0.6 0.6) (layers "F.Cu") '
+        '(net 1 "/A"))' % (i + 1, i) for i in range(pads))
+    return ('(footprint "L:P" (layer "F.Cu") (at %s)\n'
+            '   (property "Reference" "%s")\n%s\n%s)' % (at, ref, pad_txt, inner))
+
+
+def _poly(layer='F.Cu', pts='(xy 0 0) (xy 1 0) (xy 1 1) (xy 0 1)',
+          stroke='(stroke (width 0) (type solid)) (fill yes)'):
+    return ('   (fp_poly (pts %s)\n     %s\n     (layer "%s") (uuid "p1"))'
+            % (pts, stroke, layer))
+
+
+def _graphics(content):
+    return [s for s in extract_segments(content, NAME_TO_ID)
+            if getattr(s, 'graphic', False)]
+
+
+def main():
+    fails = []
+
+    def check(name, cond, detail=''):
+        print(f"  {'PASS' if cond else 'FAIL'}: {name}"
+              + (f"   [{detail}]" if detail and not cond else ''))
+        if not cond:
+            fails.append(name)
+
+    # --- 1: geometry, with rotation ---------------------------------------
+    segs = _graphics(_board(_fp(_poly())))
+    want = [local_to_global(10, 20, -90, x, y)
+            for x, y in ((0, 0), (1, 0), (1, 1), (0, 1))]
+    got_pts = {(round(s.start_x, 6), round(s.start_y, 6)) for s in segs}
+    check('rotated fp_poly emits its transformed outline',
+          len(segs) == 4
+          and got_pts == {(round(x, 6), round(y, 6)) for x, y in want},
+          f'{len(segs)} segs, pts={sorted(got_pts)}')
+    check('emitted copper is graphic, net 0, owned by U1',
+          bool(segs) and all(s.graphic and s.net_id == 0
+                             and s.owner_ref == 'U1' for s in segs))
+    check('the transform is NOT the identity (rotation really applied)',
+          bool(segs) and got_pts != {(0.0, 0.0), (1.0, 0.0),
+                                     (1.0, 1.0), (0.0, 1.0)})
+
+    # --- 2: B.Cu comes from the shape, not the footprint ------------------
+    segs = _graphics(_board(_fp(_poly(layer='B.Cu'))))
+    check('a B.Cu fp_poly lands on B.Cu',
+          bool(segs) and all(s.layer == 'B.Cu' for s in segs))
+    b_pts = {(round(s.start_x, 6), round(s.start_y, 6)) for s in segs}
+    check('no extra mirror term is applied to a B.Cu shape',
+          b_pts == got_pts, f'{sorted(b_pts)}')
+
+    # --- 3/4/5: the three negative controls -------------------------------
+    check('a pad-LESS logo footprint emits nothing',
+          _graphics(_board(_fp(_poly(), pads=0))) == [])
+    check('a silk-only fp_poly emits nothing',
+          _graphics(_board(_fp(_poly(layer='F.SilkS')))) == [])
+    prim = ('   (pad "9" smd custom (at 3 0) (size 0.4 0.4) (layers "F.Cu")\n'
+            '     (net 2 "/B")\n'
+            '     (primitives (gr_poly (pts (xy 0 0) (xy 9 0) (xy 9 9))\n'
+            '       (stroke (width 0.1) (type solid)) (fill yes)\n'
+            '       (layer "F.Cu"))))')
+    check('a custom pad\'s gr_poly primitive emits nothing',
+          _graphics(_board(_fp(prim))) == [])
+
+    # --- 6: widths ---------------------------------------------------------
+    segs = _graphics(_board(_fp(_poly())))
+    check('a 0-stroke filled poly falls back to TRACK_WIDTH',
+          bool(segs) and all(s.width == defaults.TRACK_WIDTH for s in segs),
+          f'{sorted({s.width for s in segs})}')
+    line0 = ('   (fp_line (start 0 0) (end 1 0)\n'
+             '     (stroke (width 0) (type solid)) (layer "F.Cu") (uuid "l0"))')
+    check('an fp_line with width 0 emits nothing',
+          _graphics(_board(_fp(line0))) == [])
+    line1 = ('   (fp_line (start 0 0) (end 1 0)\n'
+             '     (stroke (width 0.2) (type solid)) (layer "F.Cu") (uuid "l1"))')
+    lsegs = _graphics(_board(_fp(line1)))
+    check('a stroked fp_line emits one segment at its own width',
+          len(lsegs) == 1 and lsegs[0].width == 0.2)
+
+    # --- 7: the layer-token forms -----------------------------------------
+    plural = ('   (fp_poly (pts (xy 0 0) (xy 1 0) (xy 1 1))\n'
+              '     (stroke (width 0.1) (type solid)) (fill yes)\n'
+              '     (layers "F.Cu" "F.Mask") (uuid "p2"))')
+    psegs = _graphics(_board(_fp(plural)))
+    check('the plural (layers ...) form is read, mask member dropped',
+          len(psegs) == 3 and all(s.layer == 'F.Cu' for s in psegs),
+          f'{len(psegs)} segs, layers={sorted({s.layer for s in psegs})}')
+    two = plural.replace('(layers "F.Cu" "F.Mask")', '(layer "F&B.Cu")')
+    tsegs = _graphics(_board(_fp(two)))
+    check('F&B.Cu emits on both copper sides',
+          {s.layer for s in tsegs} == {'F.Cu', 'B.Cu'} and len(tsegs) == 6,
+          f'{len(tsegs)} segs, {sorted({s.layer for s in tsegs})}')
+
+    # --- 8: a repeated closing vertex is not a zero-length segment --------
+    closed = _poly(pts='(xy 0 0) (xy 1 0) (xy 1 1) (xy 0 1) (xy 0 0)')
+    csegs = _graphics(_board(_fp(closed)))
+    check('a poly repeating its first point emits 4 edges, not 5',
+          len(csegs) == 4, f'{len(csegs)}')
+    check('no zero-length graphic segment is ever emitted',
+          bool(csegs) and all((s.start_x, s.start_y) != (s.end_x, s.end_y)
+                              for s in csegs))
+
+    # --- 9: owner_ref uses the DISAMBIGUATED key --------------------------
+    dup = _board(_fp(_poly(), ref='TP4') + '\n'
+                 + _fp(_poly(), at='30 40 0', ref='TP4'))
+    dsegs = _graphics(dup)
+    check('two blocks sharing a reference get distinct owner keys',
+          {s.owner_ref for s in dsegs} == {'TP4', 'TP4~2'},
+          f'{sorted({s.owner_ref for s in dsegs})}')
+
+    # --- 10: the real corpus ----------------------------------------------
+    expect = {'esp_prog': 8, 'tigard': 4, 'ulx3s': 24, 'watchy': 48,
+              'orangecrab_ext_pll': 0, 'splitflap_driver': 0,
+              'glasgow_revC': 0}
+    seen = 0
+    for board, want_n in sorted(expect.items()):
+        path = os.path.join(ROOT_DIR, 'kicad_files', f'{board}.kicad_pcb')
+        if not os.path.isfile(path):
+            check(f'{board}: corpus board present', False, path)
+            continue
+        pcb = parse_kicad_pcb(path)
+        got = [s for s in pcb.segments if getattr(s, 'graphic', False)]
+        seen += 1
+        check(f'{board}: {want_n} graphic segments', len(got) == want_n,
+              f'got {len(got)}')
+        check(f'{board}: every graphic names an owner',
+              all(s.owner_ref for s in got) if got else True)
+    check('the corpus section actually ran', seen == len(expect),
+          f'{seen}/{len(expect)}')
+
+    print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'ALL PASS'}")
+    return 1 if fails else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_908_own_pad_lift.py
+++ b/tests/test_908_own_pad_lift.py
@@ -222,6 +222,76 @@ def main():
               f'after={sum(1 for x, y in corridor if obs.is_blocked(x, y, 0))} '
               f'before={blocked_before}')
 
+    # --- 7: the bake and prepare must not BOTH lift the same rows ---------
+    # `build_base_obstacle_map` BAKES the lift straight into the map when it
+    # was built for a single net, because the caller may use that map (or a
+    # clone of it) without ever calling prepare -- `net_rescue`'s pristine
+    # map, and `single_ended_loop`'s `build_single_ended_obstacles` fallback,
+    # both do. `prepare_obstacles_inplace` lifts it too. When BOTH happen --
+    # `route.py --nets '<one net>'`, where the base's net set is that one net
+    # and the loop then prepares it -- the same rows came off twice.
+    #
+    # Removing twice is NOT a no-op, because the map is refcounted: a cell
+    # that a pad also blocks goes 2 -> 0 instead of 2 -> 1, and the restore
+    # returns it at 1. Measured on esp_prog before the fix: 28 such cells.
+    # The routed copper did not change on that board, which is exactly why
+    # this needs a gate rather than a corpus A/B -- the damage is in the map,
+    # and the next thing to consult it is the one that pays.
+    #
+    # Asserted at the precise point of harm: no row the BAKE left blocked may
+    # be unblocked by prepare. A refcount-total comparison would not do --
+    # prepare legitimately blocks and unblocks plenty besides this.
+    if pcb2 is not None and pad is not None:
+        from routing_context import prepare_obstacles_inplace
+        from obstacle_map import build_layer_map
+
+        def _lift_cells(pcbx, net):
+            rows = (getattr(pcbx, '_graphic_own_pad_lift', None) or {}).get(net)
+            out = []
+            for r in (rows if rows is not None else []):
+                gx, lo, hi, layer = int(r[0]), int(r[1]), int(r[2]), int(r[3])
+                out.extend((gx, gy, layer) for gy in range(lo, hi + 1))
+            return out
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            solo = build_base_obstacle_map(pcb2, cfg, [pad.net_id])
+        baked = getattr(pcb2, '_graphic_own_pad_lift_baked', None)
+        check('a base built for ONE net records which net it baked',
+              baked == pad.net_id, f'baked={baked} want={pad.net_id}')
+
+        cells = _lift_cells(pcb2, pad.net_id)
+        check('the bake has rows to bake (otherwise this row proves nothing)',
+              len(cells) > 0, f'{len(cells)} cell(s)')
+        still = [c for c in cells if solo.is_blocked(*c)]
+        with contextlib.redirect_stdout(io.StringIO()):
+            prepare_obstacles_inplace(
+                solo, pcb2, cfg, pad.net_id, [pad.net_id], [], {},
+                build_layer_map(cfg.layers), {})
+        lost = [c for c in still if not solo.is_blocked(*c)]
+        check('prepare does not lift rows the base already baked',
+              not lost,
+              f'{len(lost)} of {len(still)} baked-and-still-blocked cell(s) '
+              f'were unblocked a second time')
+
+        # The other direction, so the fix cannot be "never lift": a base built
+        # for a BATCH bakes nothing, and prepare must still deliver the lift.
+        with contextlib.redirect_stdout(io.StringIO()):
+            grp = build_base_obstacle_map(pcb2, cfg,
+                                          [pad.net_id] + (foreign or []))
+        check('a base built for a BATCH bakes nothing',
+              getattr(pcb2, '_graphic_own_pad_lift_baked', None) is None,
+              f'baked={getattr(pcb2, "_graphic_own_pad_lift_baked", None)}')
+        gcells = _lift_cells(pcb2, pad.net_id)
+        gblocked = [c for c in gcells if grp.is_blocked(*c)]
+        with contextlib.redirect_stdout(io.StringIO()):
+            prepare_obstacles_inplace(
+                grp, pcb2, cfg, pad.net_id, [pad.net_id] + (foreign or []),
+                [], {}, build_layer_map(cfg.layers), {})
+        freed = [c for c in gblocked if not grp.is_blocked(*c)]
+        check('...and prepare still lifts when the base did not bake',
+              len(freed) > 0,
+              f'{len(freed)} of {len(gblocked)} freed')
+
     # --- 6: naming ---------------------------------------------------------
     check('a graphic with an owner is named Polygon(owner)',
           graphic_item_label(art) == 'Polygon(U1)')

--- a/tests/test_908_own_pad_lift.py
+++ b/tests/test_908_own_pad_lift.py
@@ -167,6 +167,61 @@ def main():
                   free_count(foreign) < len(corridor),
                   f'{free_count(foreign)}/{len(corridor)} free')
 
+            # ...INCLUDING when both nets are in the same batch. The base map
+            # is built for a whole call, so a lift keyed on "is the own net
+            # anywhere in nets_to_route" drops the copper for EVERY net in the
+            # run: measured on route.py's default all-nets call, tigard 4/4
+            # and ulx3s 24/24 footprint-copper edges went unmodelled. Routing
+            # the two nets SEPARATELY cannot see that, which is why this row
+            # exists.
+            # Compared against the SAME batch with the lift disabled, not
+            # against a foreign-only run: routing the own net also stops its
+            # PADS being stamped, which moves the corridor for reasons that
+            # have nothing to do with this feature.
+            batch = [pad.net_id] + foreign
+            both = free_count(batch)
+            try:
+                _cd.graphic_own_pad_nets = lambda _p: {}
+                both_nolift = free_count(batch)
+            finally:
+                _cd.graphic_own_pad_nets = real
+            check('a batch containing the own net does NOT lift it in the '
+                  'base map',
+                  both == both_nolift,
+                  f'batch={both} same-batch-without-the-lift={both_nolift}')
+
+        # ...and the per-net lift still reaches the own net inside a batch,
+        # through prepare_obstacles_inplace rather than the base map. This is
+        # the arm that proves the batch fix actually delivers the lift; a
+        # skipped version of it would assert nothing.
+        from routing_context import (prepare_obstacles_inplace,
+                                     restore_obstacles_inplace)
+        from obstacle_map import build_layer_map
+        import numpy as _np
+        batch = [pad.net_id] + (foreign or [])
+        with contextlib.redirect_stdout(io.StringIO()):
+            obs = build_base_obstacle_map(pcb2, cfg, batch)
+        blocked_before = sum(1 for x, y in corridor if obs.is_blocked(x, y, 0))
+        cache = {}
+        with contextlib.redirect_stdout(io.StringIO()):
+            _snv, _ = prepare_obstacles_inplace(
+                obs, pcb2, cfg, pad.net_id, batch, [], {},
+                build_layer_map(cfg.layers), cache)
+        prepared = sum(0 if obs.is_blocked(x, y, 0) else 1
+                       for x, y in corridor)
+        check('inside a batch, prepare lifts it for the OWN net',
+              prepared == len(corridor), f'{prepared}/{len(corridor)}')
+        with contextlib.redirect_stdout(io.StringIO()):
+            restore_obstacles_inplace(
+                obs, pad.net_id, cache,
+                _snv if isinstance(_snv, _np.ndarray)
+                else _np.empty((0, 2), dtype=_np.int32))
+        check('and restore puts every lifted row back',
+              sum(1 for x, y in corridor
+                  if obs.is_blocked(x, y, 0)) == blocked_before,
+              f'after={sum(1 for x, y in corridor if obs.is_blocked(x, y, 0))} '
+              f'before={blocked_before}')
+
     # --- 6: naming ---------------------------------------------------------
     check('a graphic with an owner is named Polygon(owner)',
           graphic_item_label(art) == 'Polygon(U1)')

--- a/tests/test_908_own_pad_lift.py
+++ b/tests/test_908_own_pad_lift.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""#908: modelling a footprint's own copper must not SEAL its own pad.
+
+A footprint's copper carries no net, so it is foreign copper to every net --
+including the net of the pad it was drawn around. esp_prog's U2 tab notches
+around pad 2 (`Net-(C1-Pad1)`) with its west edge exactly coincident with the
+pad's, so stamping the shape whole pinches the pad's approach: the failure
+mode of sibling #907, manufactured by the fix for #908.
+
+The lift is per SEGMENT and own-footprint only. The whole-CLUSTER answer
+(`graphic_effective_nets`, which is what the CHECKER uses) is much wider:
+watchy's twelve antenna polys form ONE cluster touching both the feed pad and
+a GND pad, so a cluster-wide lift would let a GND route cross the whole
+antenna -- graded clean by that same reasoning, and a destroyed part.
+
+Invariants gated here:
+  1. The subset chain own-pad <= pads-only <= checker, on synthetic data and
+     on every affected corpus board. This is the safety direction: a
+     GENERATOR that is never more permissive than the CHECKER cannot lay
+     copper the checker will flag.
+  2. `include_mutable=False` really does drop the track/via arms (a track
+     touching a graphic grants its net in the checker's answer and NOT in the
+     obstacle map's -- because a rip can delete that track later).
+  3. The lift is LOCAL: on watchy only a handful of the antenna's 48 edges
+     lift, not all of them.
+  4. It works: esp_prog U2 pad 2's approach corridor is free with the lift
+     and pinched without it.
+  5. A FOREIGN net is still blocked by the same copper.
+  6. Reporting: a graphic is named `Polygon(<owner>)`, matching KiCad's own
+     "Polygon [<no net>] of U2 on F.Cu"; a routed track gets no label.
+
+Run:
+    python3 tests/test_908_own_pad_lift.py
+"""
+
+import contextlib
+import io
+import os
+import sys
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(TESTS_DIR)
+sys.path.insert(0, ROOT_DIR)
+sys.path.insert(0, os.path.join(ROOT_DIR, 'py_router'))  # #522
+sys.path.insert(0, os.path.join(ROOT_DIR, 'py_tools'))  # #522
+
+from kicad_parser import parse_kicad_pcb, Segment, Pad, Net, PCBData, Footprint
+from check_drc import (graphic_effective_nets, graphic_own_pad_nets,
+                       graphic_item_label)
+
+RUN_ALL_TIMEOUT = 900
+
+
+def _synthetic():
+    """A 2-pad part whose own graphic touches pad 1, plus a foreign track that
+    also touches the graphic (the track arm is what `include_mutable` gates)."""
+    pad1 = Pad(pad_number='1', net_id=1, net_name='/A',
+               global_x=0.0, global_y=0.0, local_x=0, local_y=0,
+               size_x=1.0, size_y=1.0, shape='rect', layers=['F.Cu'],
+               drill=0, pad_type='smd', component_ref='U1')
+    pad2 = Pad(pad_number='2', net_id=2, net_name='/B',
+               global_x=8.0, global_y=0.0, local_x=8, local_y=0,
+               size_x=1.0, size_y=1.0, shape='rect', layers=['F.Cu'],
+               drill=0, pad_type='smd', component_ref='U1')
+    art = Segment(start_x=0.5, start_y=0.0, end_x=3.0, end_y=0.0,
+                  width=0.3, layer='F.Cu', net_id=0, graphic=True,
+                  owner_ref='U1')
+    trk = Segment(start_x=3.0, start_y=0.0, end_x=5.0, end_y=0.0,
+                  width=0.3, layer='F.Cu', net_id=3)
+    fp = Footprint(reference='U1', footprint_name='L:P', x=0.0, y=0.0,
+                   rotation=0.0, layer='F.Cu', pads=[pad1, pad2])
+    return PCBData(board_info=None,
+                   nets={1: Net(1, '/A'), 2: Net(2, '/B'), 3: Net(3, '/C')},
+                   footprints={'U1': fp}, vias=[], segments=[art, trk],
+                   pads_by_net={1: [pad1], 2: [pad2]}), art
+
+
+def main():
+    fails = []
+
+    def check(name, cond, detail=''):
+        print(f"  {'PASS' if cond else 'FAIL'}: {name}"
+              + (f"   [{detail}]" if detail and not cond else ''))
+        if not cond:
+            fails.append(name)
+
+    # --- 1/2 on synthetic data --------------------------------------------
+    pcb, art = _synthetic()
+    own = graphic_own_pad_nets(pcb)
+    pads_only = graphic_effective_nets(pcb, include_mutable=False)
+    checker = graphic_effective_nets(pcb, include_mutable=True)
+    check('own-pad lift names the touched pad\'s net',
+          own.get(id(art)) == frozenset({1}), f'{own.get(id(art))}')
+    check('pads-only answer has the pad net and NOT the track net',
+          pads_only.get(id(art)) == frozenset({0, 1}),
+          f'{pads_only.get(id(art))}')
+    check('the checker\'s answer DOES include the touching track\'s net',
+          3 in (checker.get(id(art)) or set()), f'{checker.get(id(art))}')
+    check('subset chain holds: own <= pads-only <= checker',
+          own[id(art)] <= pads_only[id(art)] <= checker[id(art)])
+
+    # --- 1 again, on the real boards --------------------------------------
+    boards = ['esp_prog', 'tigard', 'watchy', 'ulx3s']
+    seen = 0
+    for b in boards:
+        path = os.path.join(ROOT_DIR, 'kicad_files', f'{b}.kicad_pcb')
+        if not os.path.isfile(path):
+            check(f'{b}: board present', False, path)
+            continue
+        with contextlib.redirect_stdout(io.StringIO()):
+            rp = parse_kicad_pcb(path)
+        o = graphic_own_pad_nets(rp)
+        po = graphic_effective_nets(rp, include_mutable=False)
+        ck = graphic_effective_nets(rp, include_mutable=True)
+        seen += 1
+        check(f'{b}: subset chain holds for every lifted segment',
+              bool(o) and all(o[k] <= po[k] <= ck[k] for k in o),
+              f'{len(o)} lifted')
+        # 3: the lift is LOCAL, not the whole shape
+        n_graphic = len([s for s in rp.segments
+                         if getattr(s, 'graphic', False)])
+        if b == 'watchy':
+            check('watchy: only a few antenna edges lift, not all 48',
+                  0 < len(o) < n_graphic / 2, f'{len(o)}/{n_graphic}')
+    check('the corpus section actually ran', seen == len(boards),
+          f'{seen}/{len(boards)}')
+
+    # --- 4/5: the obstacle map ---------------------------------------------
+    from routing_config import GridRouteConfig
+    from obstacle_map import build_base_obstacle_map, GridCoord
+    import check_drc as _cd
+
+    path = os.path.join(ROOT_DIR, 'kicad_files', 'esp_prog.kicad_pcb')
+    if not os.path.isfile(path):
+        check('esp_prog present for the obstacle probe', False, path)
+    else:
+        with contextlib.redirect_stdout(io.StringIO()):
+            pcb2 = parse_kicad_pcb(path)
+        pad = [p for p in pcb2.footprints['U2'].pads if p.pad_number == '2'][0]
+        cfg = GridRouteConfig(layers=['F.Cu', 'B.Cu'])
+        coord = GridCoord(cfg.grid_step)
+        gx, gy = coord.to_grid(pad.global_x, pad.global_y)
+        corridor = [(gx - k, gy) for k in range(1, 9)]
+
+        def free_count(nets):
+            with contextlib.redirect_stdout(io.StringIO()):
+                obs = build_base_obstacle_map(pcb2, cfg, nets)
+            return sum(0 if obs.is_blocked(x, y, 0) else 1
+                       for x, y in corridor)
+
+        with_lift = free_count([pad.net_id])
+        real = _cd.graphic_own_pad_nets
+        try:
+            _cd.graphic_own_pad_nets = lambda _p: {}
+            without_lift = free_count([pad.net_id])
+        finally:
+            _cd.graphic_own_pad_nets = real
+        check('esp_prog U2.2: the lift frees the west approach corridor',
+              with_lift == len(corridor) and without_lift < with_lift,
+              f'with={with_lift} without={without_lift} of {len(corridor)}')
+
+        # 5: a FOREIGN net must still be blocked by that same copper
+        foreign = [n for n in pcb2.nets
+                   if n and n != pad.net_id][:1]
+        if foreign:
+            check('a foreign net is still blocked by the same tab copper',
+                  free_count(foreign) < len(corridor),
+                  f'{free_count(foreign)}/{len(corridor)} free')
+
+    # --- 6: naming ---------------------------------------------------------
+    check('a graphic with an owner is named Polygon(owner)',
+          graphic_item_label(art) == 'Polygon(U1)')
+    check('an ownerless graphic is named Graphic',
+          graphic_item_label(Segment(0, 0, 1, 1, 0.2, 'F.Cu', 0,
+                                     graphic=True)) == 'Graphic')
+    check('a routed track gets no label',
+          graphic_item_label(Segment(0, 0, 1, 1, 0.2, 'F.Cu', 5)) == '')
+
+    print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'ALL PASS'}")
+    return 1 if fails else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_908_writer_owner_gate.py
+++ b/tests/test_908_writer_owner_gate.py
@@ -48,21 +48,24 @@ from kicad_writer import move_copper_graphics_to_silkscreen
 RUN_ALL_FAST_OK = True
 
 
-def _fp(pads, shape_layer='F.Cu', ref='U1'):
-    """One footprint block with `pads` pads and one fp_poly on `shape_layer`."""
+def _fp(pads, shape_layer='F.Cu', ref='U1', inner=None):
+    """One footprint block with `pads` pads and one fp_poly on `shape_layer`
+    -- or `inner` verbatim in the copper shape's place."""
     pad_txt = '\n'.join(
         '   (pad "%d" smd rect (at %d 0) (size 0.6 0.6) (layers "F.Cu") '
         '(net %d "/N%d"))' % (i + 1, i, i + 1, i + 1) for i in range(pads))
+    shape = inner if inner is not None else (
+        '   (fp_poly (pts (xy 0 0) (xy 1 0) (xy 1 1) (xy 0 1))\n'
+        '     (stroke (width 0) (type solid)) (fill yes)\n'
+        '     (layer "%s") (uuid "aaa"))' % shape_layer)
     return ('(footprint "L:P" (layer "F.Cu") (at 10 10)\n'
             '   (property "Reference" "%s")\n'
             '%s\n'
-            '   (fp_poly (pts (xy 0 0) (xy 1 0) (xy 1 1) (xy 0 1))\n'
-            '     (stroke (width 0) (type solid)) (fill yes)\n'
-            '     (layer "%s") (uuid "aaa"))\n'
+            '%s\n'
             '   (fp_poly (pts (xy 2 0) (xy 3 0) (xy 3 1))\n'
             '     (stroke (width 0.1) (type solid))\n'
             '     (layer "F.SilkS") (uuid "bbb")))'
-            % (ref, pad_txt, shape_layer))
+            % (ref, pad_txt, shape))
 
 
 def _board(body):
@@ -126,7 +129,46 @@ def main():
     check('board-level net-TIED gr_poly is still left (#337)',
           out == gr_tied and moved == 0, f'moved={moved}')
 
-    # --- 7: the real corpus ----------------------------------------------
+    # --- 7: byte spans must survive the pass's OWN rewrites ---------------
+    # Every relocation grows the text by 3 bytes (F.Cu -> F.SilkS), and the
+    # pass rewrites `content` once per TAG. Spans taken once from the original
+    # text drift, and past enough relocations a pad-bearing footprint's copper
+    # is relocated anyway -- silently, because the "Kept" line drifts with it.
+    # The kept shape is an fp_LINE on purpose: `_COPPER_GRAPHIC_TAGS` runs
+    # fp_poly FIRST, so a poly is always decided against un-rewritten text and
+    # could never show the drift. fp_line is reached only after gr_poly has
+    # already rewritten `content`, which is where a hoisted span goes stale.
+    kept_line = ('   (fp_line (start 0 0) (end 1 0)\n'
+                 '     (stroke (width 0.2) (type solid))\n'
+                 '     (layer "F.Cu") (uuid "aaa"))')
+    for n_logos in (0, 20, 40, 80):
+        logos = '\n'.join(
+            '(gr_poly (pts (xy %d 0) (xy %d 0) (xy %d 1))'
+            ' (stroke (width 0.1) (type solid)) (fill yes)'
+            ' (layer "F.Cu") (uuid "g%d"))' % (i, i + 1, i + 1, i)
+            for i in range(n_logos))
+        src = _board(logos + ('\n' if logos else '')
+                     + _fp(2, inner=kept_line))
+        out, moved, kept = _move(src)
+        check(f'{n_logos} board logos: the footprint copper is still kept',
+              kept == 1 and moved == n_logos
+              and '(layer "F.Cu") (uuid "aaa")' in out,
+              f'moved={moved} kept={kept}')
+
+    # --- 8: fp_curve is NOT modelled, so it must NOT be kept ---------------
+    # Keeping unmodelled copper ON copper is strictly worse than #146's
+    # relocation: pours and routed copper run over it and short, and the run
+    # reports it as successfully "kept".
+    curve = ('   (fp_curve (pts (xy 0 0) (xy 1 0) (xy 1 1) (xy 0 1))\n'
+             '     (stroke (width 0.1) (type solid))\n'
+             '     (layer "F.Cu") (uuid "cv1"))')
+    out, moved, kept = _move(_board(_fp(2, inner=curve)))
+    check('an fp_curve on copper is still relocated (nothing models it)',
+          moved == 1 and kept == 0
+          and '(layer "F.SilkS") (uuid "cv1")' in out,
+          f'moved={moved} kept={kept}')
+
+    # --- 9: the real corpus ----------------------------------------------
     # (moved, kept) per board. The `kept` figures are the shapes that used to
     # be deleted from copper on every write.
     expect = {

--- a/tests/test_908_writer_owner_gate.py
+++ b/tests/test_908_writer_owner_gate.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""#908: the writer must not delete a component's own copper.
+
+`move_copper_graphics_to_silkscreen` relocates NET-LESS copper graphics off
+copper (#146: an unmodelled copper logo shorted ~30 orangecrab plane
+traces/vias). Its "net-tied copper is functional, leave it" guard (#337/#369)
+is a NO-OP for footprint shapes, because a footprint shape cannot carry a
+`(net ...)` in KiCad at all -- so EVERY `fp_*` copper shape was relocated,
+including watchy's PCB antenna and the SOT89 tab under esp_prog's U2.
+
+The owner decides instead: a footprint WITH pads owns functional land-pattern
+copper (kept on copper, and modelled by the parser); a footprint with NO pads
+is a logo (moved, exactly as #146 does).
+
+Invariants gated here:
+  1. `fp_poly` on F.Cu in a 2-pad footprint  -> UNCHANGED.
+  2. The same `fp_poly` in a 0-pad footprint -> moved to F.SilkS.
+  3. B.Cu behaves the same way on both arms (the layer is not the decision).
+  4. Board-level net-less `gr_poly`          -> still moved (#146 intact).
+  5. Board-level net-tied `gr_poly`          -> still left  (#337 intact).
+  6. A pad-bearing footprint's SILKSCREEN art is untouched by either arm
+     (the gate must not become "never touch a footprint").
+  7. Real corpus boards: esp_prog / tigard / ulx3s / watchy move 0 and keep
+     1 / 1 / 6 / 12; orangecrab_ext_pll still moves its 4 logo shapes;
+     splitflap_driver (no footprint copper) is unchanged either way.
+
+Run:
+    python3 tests/test_908_writer_owner_gate.py
+"""
+
+import io
+import contextlib
+import os
+import re
+import sys
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(TESTS_DIR)
+sys.path.insert(0, ROOT_DIR)
+sys.path.insert(0, os.path.join(ROOT_DIR, 'py_router'))  # #522
+sys.path.insert(0, os.path.join(ROOT_DIR, 'py_tools'))  # #522
+
+from run_utils import evidence
+from kicad_writer import move_copper_graphics_to_silkscreen
+
+#: This test imports run_utils (for `evidence`) but never shells out and never
+#: routes; it is pure text in and text out. Measured well under a second.
+RUN_ALL_FAST_OK = True
+
+
+def _fp(pads, shape_layer='F.Cu', ref='U1'):
+    """One footprint block with `pads` pads and one fp_poly on `shape_layer`."""
+    pad_txt = '\n'.join(
+        '   (pad "%d" smd rect (at %d 0) (size 0.6 0.6) (layers "F.Cu") '
+        '(net %d "/N%d"))' % (i + 1, i, i + 1, i + 1) for i in range(pads))
+    return ('(footprint "L:P" (layer "F.Cu") (at 10 10)\n'
+            '   (property "Reference" "%s")\n'
+            '%s\n'
+            '   (fp_poly (pts (xy 0 0) (xy 1 0) (xy 1 1) (xy 0 1))\n'
+            '     (stroke (width 0) (type solid)) (fill yes)\n'
+            '     (layer "%s") (uuid "aaa"))\n'
+            '   (fp_poly (pts (xy 2 0) (xy 3 0) (xy 3 1))\n'
+            '     (stroke (width 0.1) (type solid))\n'
+            '     (layer "F.SilkS") (uuid "bbb")))'
+            % (ref, pad_txt, shape_layer))
+
+
+def _board(body):
+    return ('(kicad_pcb (version 20221018)\n (net 0 "")\n (net 1 "/N1")\n'
+            ' (net 2 "/N2")\n%s\n)' % body)
+
+
+def _move(text):
+    """Run the pass, returning (new_text, moved_count, kept_count)."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        out = move_copper_graphics_to_silkscreen(text)
+    log = buf.getvalue()
+    m = re.search(r'Moved (\d+) copper graphic', log)
+    k = re.search(r'Kept (\d+) footprint copper shape', log)
+    return out, int(m.group(1)) if m else 0, int(k.group(1)) if k else 0
+
+
+def main():
+    fails = []
+
+    def check(name, cond, detail=''):
+        print(f"  {'PASS' if cond else 'FAIL'}: {name}"
+              + (f"   [{detail}]" if detail and not cond else ''))
+        if not cond:
+            fails.append(name)
+
+    # --- 1/2/3: the owner decides, on both copper sides -------------------
+    for layer, silk in (('F.Cu', 'F.SilkS'), ('B.Cu', 'B.SilkS')):
+        src = _board(_fp(2, layer))
+        out, moved, kept = _move(src)
+        check(f'2-pad footprint keeps its {layer} copper',
+              out == src and moved == 0 and kept == 1,
+              f'moved={moved} kept={kept} changed={out != src}')
+
+        src0 = _board(_fp(0, layer))
+        out0, moved0, kept0 = _move(src0)
+        check(f'0-pad logo footprint still moves off {layer}',
+              moved0 == 1 and kept0 == 0
+              and f'(layer "{silk}") (uuid "aaa")' in out0,
+              f'moved={moved0} kept={kept0}')
+
+        # 6: silkscreen art inside the kept footprint is untouched either way
+        check(f'{layer} arm leaves the footprint\'s own silk art alone',
+              out.count('(layer "F.SilkS") (uuid "bbb")') == 1
+              and out0.count('(layer "F.SilkS") (uuid "bbb")') == 1)
+
+    # --- 4/5: board-level gr_* behaviour is unchanged ---------------------
+    gr_free = _board('(gr_poly (pts (xy 0 0) (xy 1 0) (xy 1 1))'
+                     ' (stroke (width 0.1) (type solid)) (fill yes)'
+                     ' (layer "F.Cu") (uuid "ccc"))')
+    out, moved, kept = _move(gr_free)
+    check('board-level net-less gr_poly is still moved (#146)',
+          moved == 1 and kept == 0 and '(layer "F.SilkS") (uuid "ccc")' in out,
+          f'moved={moved}')
+
+    gr_tied = _board('(gr_poly (pts (xy 0 0) (xy 1 0) (xy 1 1))'
+                     ' (stroke (width 0.1) (type solid)) (fill yes)'
+                     ' (layer "F.Cu") (net 1 "/N1") (uuid "ddd"))')
+    out, moved, kept = _move(gr_tied)
+    check('board-level net-TIED gr_poly is still left (#337)',
+          out == gr_tied and moved == 0, f'moved={moved}')
+
+    # --- 7: the real corpus ----------------------------------------------
+    # (moved, kept) per board. The `kept` figures are the shapes that used to
+    # be deleted from copper on every write.
+    expect = {
+        'esp_prog': (0, 1),
+        'tigard': (0, 1),
+        'ulx3s': (0, 6),
+        'watchy': (0, 12),
+        'orangecrab_ext_pll': (4, 0),
+        'splitflap_driver': (0, 0),
+    }
+    seen = 0
+    for board, (want_moved, want_kept) in sorted(expect.items()):
+        path = os.path.join(ROOT_DIR, 'kicad_files', f'{board}.kicad_pcb')
+        if not os.path.isfile(path):
+            check(f'{board}: corpus board present', False, path)
+            continue
+        evidence(path, f'{board} corpus board')
+        with open(path, encoding='utf-8', errors='replace') as fh:
+            src = fh.read()
+        out, moved, kept = _move(src)
+        seen += 1
+        check(f'{board}: moved={want_moved} kept={want_kept}',
+              (moved, kept) == (want_moved, want_kept),
+              f'got moved={moved} kept={kept}')
+        check(f'{board}: text changes only when something moved',
+              (out != src) == (want_moved > 0))
+    # Anti-vacuity: an empty corpus must not pass this section silently.
+    check('the corpus section actually ran', seen == len(expect),
+          f'{seen}/{len(expect)}')
+
+    print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'ALL PASS'}")
+    return 1 if fails else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_909_impedance_achievability.py
+++ b/tests/test_909_impedance_achievability.py
@@ -75,9 +75,20 @@ def main():
             pcb = parse_kicad_pcb(path)
         check('esp_prog really declares no stackup (the premise)',
               not pcb.board_info.stackup)
+        # The pin gap is DERIVED from the board for the pair's own net scope,
+        # not hardcoded: a gate that supplies its own 0.325 pins the solver
+        # and nothing else, and the number is scope-dependent (over the whole
+        # board the tightest gap is 0.125mm, i.e. 19.3x, not 7.4x).
+        usb = _impedance_scope_net_ids(pcb, ['/D_P', '/D_N'])
+        gap = tightest_pin_gap(pcb, usb)
+        check("the USB pair's own pin gap is derived as 0.325mm",
+              abs(gap - 0.325) < 1e-6, f'{gap}')
+        check('and the WHOLE-BOARD scope gives a different, tighter answer',
+              abs(tightest_pin_gap(pcb, _impedance_scope_net_ids(pcb, None))
+                  - 0.125) < 1e-6)
         text, detail = achievability_note(pcb, 'F.Cu', 90.0,
                                           is_differential=True, spacing=0.15,
-                                          min_pitch_gap=0.325)
+                                          min_pitch_gap=gap)
         # The issue measured 1.133mm at zdiff 89.7 and 2.42mm for the pair.
         check('90 ohm differential leg = 1.133mm (the issue\'s own figure)',
               detail and abs(detail['width_mm'] - 1.133) < 0.002,

--- a/tests/test_909_impedance_achievability.py
+++ b/tests/test_909_impedance_achievability.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""#909: a board with no stackup should STATE the impedance numbers, not skip.
+
+`route.py` printed one line on a stackup-less board -- "No stackup found in PCB
+file. Using fixed track width." -- which is true and tells the reader nothing
+about whether authoring a stackup would have helped. The repo's own solvers
+answer that in one call against a NOMINAL FR4 stack.
+
+Invariants gated here:
+  1. `nominal_stackup` is a usable stackup: copper/dielectric alternating,
+     summing to the declared board thickness, and it scales to N layers.
+  2. `achievability_note` reproduces the issue's own measured figures on
+     esp_prog: 90 ohm differential at gap 0.15 on 2-layer 1.6mm FR4 needs a
+     1.133mm leg / 2.42mm channel.
+  3. It is SILENT on a board that HAS a stackup -- there the real solver runs
+     and this has nothing to add.
+  4. It names its assumption; a caller cannot mistake it for a measurement.
+  5. `tightest_pin_gap` measures the gap to the nearest OTHER pad of the SAME
+     footprint, and returns 0.0 when it cannot answer.
+  6. `_impedance_scope_net_ids` resolves globs, and an empty selection means
+     every net (what the CLIs mean by it).
+  7. NOTHING here writes a stackup: the probe leaves `pcb.board_info.stackup`
+     empty. #909 point 2 is explicit about that.
+
+Run:
+    python3 tests/test_909_impedance_achievability.py
+"""
+
+import contextlib
+import io
+import os
+import sys
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(TESTS_DIR)
+sys.path.insert(0, ROOT_DIR)
+sys.path.insert(0, os.path.join(ROOT_DIR, 'py_router'))  # #522
+sys.path.insert(0, os.path.join(ROOT_DIR, 'py_tools'))  # #522
+
+from kicad_parser import parse_kicad_pcb
+from impedance import (achievability_note, nominal_stackup, tightest_pin_gap,
+                       _impedance_scope_net_ids, NOMINAL_EPSILON_R)
+
+RUN_ALL_FAST_OK = True
+
+
+def main():
+    fails = []
+
+    def check(name, cond, detail=''):
+        print(f"  {'PASS' if cond else 'FAIL'}: {name}"
+              + (f"   [{detail}]" if detail and not cond else ''))
+        if not cond:
+            fails.append(name)
+
+    # --- 1: the synthetic stackup -----------------------------------------
+    for n, thick in ((2, 1.6), (4, 1.6), (6, 0.8)):
+        st = nominal_stackup(n, thick)
+        cu = [l for l in st if l.layer_type == 'copper']
+        total = sum(l.thickness for l in st)
+        check(f'{n}-layer nominal stack has {n} copper layers',
+              len(cu) == n, f'{len(cu)}')
+        check(f'{n}-layer nominal stack sums to {thick}mm',
+              abs(total - thick) < 1e-6, f'{total}')
+        check(f'{n}-layer nominal dielectrics carry er {NOMINAL_EPSILON_R}',
+              all(l.epsilon_r == NOMINAL_EPSILON_R for l in st
+                  if l.layer_type in ('core', 'prepreg')))
+
+    # --- 2/3/4/7: the note on a real stackup-less board --------------------
+    path = os.path.join(ROOT_DIR, 'kicad_files', 'esp_prog.kicad_pcb')
+    if not os.path.isfile(path):
+        check('esp_prog present', False, path)
+    else:
+        with contextlib.redirect_stdout(io.StringIO()):
+            pcb = parse_kicad_pcb(path)
+        check('esp_prog really declares no stackup (the premise)',
+              not pcb.board_info.stackup)
+        text, detail = achievability_note(pcb, 'F.Cu', 90.0,
+                                          is_differential=True, spacing=0.15,
+                                          min_pitch_gap=0.325)
+        # The issue measured 1.133mm at zdiff 89.7 and 2.42mm for the pair.
+        check('90 ohm differential leg = 1.133mm (the issue\'s own figure)',
+              detail and abs(detail['width_mm'] - 1.133) < 0.002,
+              f'{detail and detail.get("width_mm")}')
+        check('the pair channel = 2.42mm',
+              detail and abs(detail['channel_mm'] - 2.42) < 0.005,
+              f'{detail and detail.get("channel_mm")}')
+        check('the pin-gap ratio is reported',
+              detail and abs(detail['channel_over_pin_gap'] - 7.4) < 0.1,
+              f'{detail and detail.get("channel_over_pin_gap")}')
+        check('the text names the assumption as NOMINAL',
+              'NOMINAL' in text and 'er 4.5' in text, text[:80])
+        check('the text says the target is not achievable here',
+              'Not achievable' in text)
+        check('the probe wrote NO stackup onto the board (#909 point 2)',
+              not pcb.board_info.stackup)
+
+        # 5: the pin gap, measured on the same board
+        nid = next((i for i in pcb.nets if i and pcb.pads_by_net.get(i)), None)
+        gap = tightest_pin_gap(pcb, [nid])
+        check('tightest_pin_gap returns a positive gap on a real board',
+              gap > 0, f'{gap}')
+        check('tightest_pin_gap on nothing is 0.0',
+              tightest_pin_gap(pcb, []) == 0.0
+              and tightest_pin_gap(pcb, None) == 0.0)
+
+        # 6: scope resolution
+        allnets = _impedance_scope_net_ids(pcb, None)
+        check('an empty selection means every net',
+              len(allnets) == len([i for i in pcb.nets if i]),
+              f'{len(allnets)}')
+        star = _impedance_scope_net_ids(pcb, ['*'])
+        check('a "*" glob selects every named net', len(star) > 0)
+        none = _impedance_scope_net_ids(pcb, ['/definitely-not-a-net'])
+        check('a non-matching pattern selects nothing', none == [])
+
+    # --- 3: a board WITH a stackup gets nothing from this ------------------
+    flat = os.path.join(ROOT_DIR, 'kicad_files', 'flat_hierarchy.kicad_pcb')
+    if not os.path.isfile(flat):
+        check('flat_hierarchy present', False, flat)
+    else:
+        with contextlib.redirect_stdout(io.StringIO()):
+            pcb2 = parse_kicad_pcb(flat)
+        check('flat_hierarchy really HAS a stackup (the premise)',
+              bool(pcb2.board_info.stackup))
+        t2, d2 = achievability_note(pcb2, 'F.Cu', 50.0)
+        check('a board with a stackup gets no note (the real solver runs)',
+              t2 == '' and d2 is None, f'{t2[:60]}')
+
+    print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'ALL PASS'}")
+    return 1 if fails else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_910_fill_for_delivery.py
+++ b/tests/test_910_fill_for_delivery.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""#910: the opt-in delivery fill, and the trap it must not re-open.
+
+A routed board ships zone OUTLINES with no `(filled_polygon ...)`. Opened in
+KiCad before a refill -- or graded by `kicad-cli pcb drc` WITHOUT
+`--refill-zones` -- it reports plane-net opens that are not real.
+
+Invariants gated here:
+  1. `write_filled_board` REFUSES rather than crashes when KiCad's python is
+     absent, and leaves the destination untouched.
+  2. It writes the destination only on success (no half-written deliverable).
+  3. On a real zoned board it produces `filled_polygon` blocks, and the
+     unconnected count read WITHOUT `--refill-zones` drops -- the phantom
+     opens the step exists to remove. Measured on
+     lvds_converter_dualclk_gnd with its fills stripped: 54 -> 42.
+  4. The sibling `.kicad_pro` survives with every net class intact. This is
+     the trap: a plain `pcbnew.SaveBoard` rewrites the project from KiCad's
+     in-memory view and deletes every non-Default class.
+  5. The CLI refuses (exit 1) and removes its output if a class went missing,
+     rather than shipping a board graded against rules it no longer carries.
+
+Arms 3-5 need KiCad's bundled python. Without it the file exits 77 (SKIP),
+which `run_all` counts apart from a pass -- it does NOT quietly report green.
+
+Run:
+    python3 tests/test_910_fill_for_delivery.py
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(TESTS_DIR)
+sys.path.insert(0, ROOT_DIR)
+sys.path.insert(0, os.path.join(ROOT_DIR, 'py_router'))  # #522
+sys.path.insert(0, os.path.join(ROOT_DIR, 'py_tools'))  # #522
+
+from run_utils import check, evidence, tool
+from kicad_exact_fill import write_filled_board, find_kicad_python
+from kicad_parser import find_matching_paren
+
+RUN_ALL_TIMEOUT = 1200
+SKIP_EXIT = 77
+
+BOARD = os.path.join(ROOT_DIR, 'kicad_files',
+                     'lvds_converter_dualclk_gnd.kicad_pcb')
+
+
+def _strip_fills(src, dst):
+    """A copy of `src` with every `(filled_polygon ...)` block removed."""
+    with open(src, encoding='utf-8', errors='replace') as fh:
+        t = fh.read()
+    out, pos = [], 0
+    while True:
+        i = t.find('(filled_polygon', pos)
+        if i < 0:
+            break
+        out.append(t[pos:i])
+        pos = find_matching_paren(t, i)
+    out.append(t[pos:])
+    with open(dst, 'w', encoding='utf-8') as fh:
+        fh.write(''.join(out))
+
+
+def _classes(pcb):
+    pro = os.path.splitext(pcb)[0] + '.kicad_pro'
+    if not os.path.isfile(pro):
+        return None
+    with open(pro, encoding='utf-8') as fh:
+        doc = json.load(fh)
+    return {c.get('name')
+            for c in (doc.get('net_settings') or {}).get('classes') or []}
+
+
+def main():
+    fails = []
+
+    def ck(name, cond, detail=''):
+        print(f"  {'PASS' if cond else 'FAIL'}: {name}"
+              + (f"   [{detail}]" if detail and not cond else ''))
+        if not cond:
+            fails.append(name)
+
+    evidence(BOARD, 'the zoned fixture board')
+    tmp = tempfile.mkdtemp(prefix='t910_')
+    try:
+        # --- 1/2: the refusal path, with no KiCad python -------------------
+        import kicad_exact_fill as kef
+        src = os.path.join(tmp, 'in.kicad_pcb')
+        shutil.copyfile(BOARD, src)
+        dst = os.path.join(tmp, 'out_refused.kicad_pcb')
+        real = kef.find_kicad_python
+        try:
+            kef.find_kicad_python = lambda: None
+            st = write_filled_board(src, dst)
+        finally:
+            kef.find_kicad_python = real
+        ck('no KiCad python: refuses with a REASON, not a crash',
+           (not st.ok) and st.reason == 'no_kicad_python', f'{st.reason}')
+        ck('no KiCad python: the destination is untouched',
+           not os.path.exists(dst))
+
+        if find_kicad_python() is None:
+            print("\nSKIP: KiCad's bundled python not found; arms 3-5 need it.")
+            return SKIP_EXIT
+
+        # --- 3: the phantom opens, before and after ------------------------
+        nofill = os.path.join(tmp, 'nofill.kicad_pcb')
+        _strip_fills(BOARD, nofill)
+        with open(nofill, encoding='utf-8', errors='replace') as fh:
+            ck('the fixture really starts with no fills (the premise)',
+               fh.read().count('(filled_polygon') == 0)
+        filled = os.path.join(tmp, 'filled.kicad_pcb')
+        st = write_filled_board(nofill, filled, verbose=True)
+        ck('the fill runs', st.ok, f'{st.reason} {st.detail}')
+        n = 0
+        if os.path.isfile(filled):
+            with open(filled, encoding='utf-8', errors='replace') as fh:
+                n = fh.read().count('(filled_polygon')
+        ck('the filled board carries filled_polygon blocks', n > 0, f'{n}')
+
+        from fill_for_delivery import _unconnected
+        before, after = _unconnected(nofill), _unconnected(filled)
+        if before is None or after is None:
+            print("  (kicad-cli unavailable: skipping the unconnected delta)")
+        else:
+            ck('filling REMOVES phantom opens (unconnected drops)',
+               after < before, f'{before} -> {after}')
+
+        # --- 4/5: the .kicad_pro trap --------------------------------------
+        # Author a project with a non-Default class beside the input, then
+        # check the CLI carries it and refuses if it ever goes missing.
+        pro_src = os.path.splitext(nofill)[0] + '.kicad_pro'
+        with open(pro_src, 'w', encoding='utf-8') as fh:
+            json.dump({'net_settings': {'classes': [
+                {'name': 'Default', 'clearance': 0.2},
+                {'name': 'HighSpeed', 'clearance': 0.15}]}}, fh)
+        out2 = os.path.join(tmp, 'delivered.kicad_pcb')
+        r = check([sys.executable, tool('fill_for_delivery.py'),
+                   nofill, '-o', out2], accept=True, timeout=900)
+        ck('the CLI succeeds on a board with a project', r.returncode == 0)
+        got = _classes(out2)
+        ck('every net class survived the fill',
+           got is not None and {'Default', 'HighSpeed'} <= got, f'{got}')
+        ck('the CLI reported the unconnected delta',
+           'unconnected (no --refill-zones)' in (r.stdout or ''))
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'ALL PASS'}")
+    return 1 if fails else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_910_fill_for_delivery.py
+++ b/tests/test_910_fill_for_delivery.py
@@ -42,7 +42,11 @@ from run_utils import check, evidence, tool
 from kicad_exact_fill import write_filled_board, find_kicad_python
 from kicad_parser import find_matching_paren
 
-RUN_ALL_TIMEOUT = 1200
+#: Four `kicad-cli pcb drc` invocations (two here, two inside the CLI),
+#: each capped at 600 s, plus two KiCad ZONE_FILLER subprocesses.
+#: Measured ~90 s wall on this machine; declared with headroom for a
+#: slower one rather than at the measurement.
+RUN_ALL_TIMEOUT = 3000
 SKIP_EXIT = 77
 
 BOARD = os.path.join(ROOT_DIR, 'kicad_files',
@@ -147,6 +151,54 @@ def main():
            got is not None and {'Default', 'HighSpeed'} <= got, f'{got}')
         ck('the CLI reported the unconnected delta',
            'unconnected (no --refill-zones)' in (r.stdout or ''))
+        # ...and the destination project is the INPUT's, byte for byte. The
+        # class-set check alone is nearly true by construction (the fill runs
+        # on a staged copy in a temp dir, so it CANNOT reach this file) --
+        # this says the delivered board is graded against the rules it came
+        # with, which is the property that actually matters.
+        with open(pro_src, encoding='utf-8') as _a:
+            _want_pro = _a.read()
+        with open(os.path.splitext(out2)[0] + '.kicad_pro',
+                  encoding='utf-8') as _b:
+            _got_pro = _b.read()
+        ck('the destination project is the input project verbatim',
+           _want_pro == _got_pro)
+
+        # --- 5: the refusal arm, which had no arm at all ------------------
+        # Simulate the trap actually firing: the delivered project comes back
+        # missing a class. The CLI must exit 1 and leave NOTHING behind --
+        # board and siblings -- because a board graded against rules it no
+        # longer carries is worse than no board.
+        out3 = os.path.join(tmp, 'lossy.kicad_pcb')
+        drop = os.path.join(tmp, 'drop_class.py')
+        _lines = [
+            "import os, sys",
+            "sys.argv = ['fill_for_delivery.py', %r, '-o', %r]" % (nofill, out3),
+            "sys.path.insert(0, %r)" % os.path.join(ROOT_DIR, 'py_tools'),
+            "import fill_for_delivery as F",
+            "_real = F._netclass_names",
+            "def _fake(p):",
+            "    n = _real(p)",
+            "    if n and os.path.abspath(p) == os.path.abspath(%r):" % out3,
+            "        return {'Default'}",
+            "    return n",
+            "F._netclass_names = _fake",
+            "sys.exit(F.main())",
+        ]
+        with open(drop, 'w', encoding='utf-8') as fh:
+            fh.write(chr(10).join(_lines) + chr(10))
+        r3 = check([sys.executable, drop], code=1, timeout=900,
+                   refuse='REFUSING')
+        ck('the refusal leaves no board behind', not os.path.exists(out3))
+        ck('the refusal leaves no orphan project behind',
+           not os.path.exists(os.path.splitext(out3)[0] + '.kicad_pro'))
+
+        # --- the same-file guard -------------------------------------------
+        r4 = check([sys.executable, tool('fill_for_delivery.py'),
+                    nofill, '-o', nofill], code=1, timeout=300,
+                   refuse='names the input file')
+        ck('filling onto the input refuses instead of raising',
+           'SameFileError' not in (r4.stdout or '') + (r4.stderr or ''))
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 


### PR DESCRIPTION
The four open `Routing:` issues filed from stress run 25, in one PR. They are
independent in code but entangled in that run's history: the hand-drawn
`Eco2.User` keepout the run used to work around #908 is what closed the channel
in #907.

---

## #908 — footprint copper is copper

The #337 graphic-copper scan walks board-level `gr_*` only, so copper drawn
**inside** a footprint — the tab of a SOT89/DPAK, a PCB antenna, a
solder-jumper bridge — reached neither the obstacle builders nor `check_drc`,
which reads the same parser.

It turned out to be **two defects, not one**. Alongside the blindness,
`move_copper_graphics_to_silkscreen` was *relocating exactly this copper to
silkscreen on every write*, on both fronts: its tag list already contained
`fp_poly` and friends, and its "net-tied copper is functional, leave it"
guard (#337/#369) is a **no-op for footprint shapes, because a footprint shape
cannot carry a `(net …)` in KiCad at all**. Measured on the corpus before this
PR: esp_prog 1, watchy 12, tigard 1, ulx3s 6 -- **20 shapes of real
land-pattern copper**, moved off copper on every write. Watchy's twelve are a
PCB antenna. (orangecrab's 4 were relocated too and still are: they are
pad-less logo footprints, which is #146 working correctly.)

**What decides which is which.** Every corpus `fp_poly` on copper is net-less,
so the existing net guard cannot split them. The owning footprint's **pad
count** does, exactly:

| board | ref | pads | copper polys | what it is |
|---|---|---|---|---|
| esp_prog | U2 | 3 | 1 | SOT89 drawn tab |
| watchy | AE1 | 2 | 12 | PCB meander antenna |
| tigard | JP1 | 2 | 1 | bridged solder jumper |
| ulx3s | RP1-3, D9, D51, D52 | 2 each | 1 each | NC jumpers |
| orangecrab_ext_pll | `G***`, `G***~2` | **0** | 1 + 3 | OSHW / LOGO art |

kicad-cli 10.0.0 agrees independently: the pad-bearing footprints produce 17
pad-vs-polygon `shorting_items` between them, the pad-less logo footprints
produce **zero**. So a footprint with copper pads owns a land pattern — modelled,
and no longer relocated — and a pad-less one is a logo, which keeps #146's
treatment unchanged and, for that reason, is not modelled either (modelling
copper the writer is about to move off copper would cost routing area for
nothing). NPTH pads do not count as pads.

### The headline measurement

esp_prog, routed end to end at `529f873d` and at this branch with the same
command, then asked the question neither arm could answer before: **does
foreign copper end up shorting U2's SOT89 tab?**

The base arm cannot be asked directly -- its writer moved the tab to
silkscreen, so kicad-cli sees no copper there to short against. So the tab was
put back exactly where the designer drew it (one `(layer "F.SilkS")` ->
`(layer "F.Cu")` on the delivered board, nothing else touched) and both boards
were graded with kicad-cli 10.0.0:

| arm | electrical violations against the tab | nets involved |
|---|---|---|
| `529f873d`, tab restored | **26** | `/DTR`, `/EN`, `/RTS`, `Net-(R4-Pad2)`, `Net-(C1-Pad1)` |
| this branch | **4** | `Net-(C1-Pad1)` only |

**Foreign nets shorting the tab: 4 -> 0.** The four that remain are the tab's
OWN pad's net reaching its own pad -- the own-pad lift working as designed,
and something KiCad calls a short only because the OLIMEX library gave that
polygon no net. As delivered, the base arm reports none of this: 45
`solder_mask_bridge` items against a polygon now sitting on silkscreen, and
zero electrical findings, on a board with five nets running through a
component's tab.

Both arms route 17/17 with every net fully connected, and both deliverables
grade `NO DRC VIOLATIONS` under `check_drc` -- the difference is that this
branch's board is clean because the router avoided the copper, not because the
copper had been deleted.

### Corpus effect: the scoreboard does not move

`check_drc` verdicts are **identical to `529f873d` on all seven boards graded**
— esp_prog, tigard, watchy, ulx3s and splitflap_driver clean,
orangecrab_ext_pll 522, glasgow_revC 1 — while the copper *is* now modelled
(8 / 4 / 24 / 48 graphic segments on the four affected boards). Two things make
that true rather than lucky:

- own-footprint pad contact is absorbed by KiCad's own connectivity
  unification, which `check_drc` has implemented since #337; and
- watchy's antenna art runs 0.218 mm into its own board-edge zone — three
  `copper_edge_clearance` items to kicad-cli, nine `segment-board-edge` ones
  here (per outline edge rather than per polygon). No routing pass can fix a
  part's own library art, and `check_drc` counts are this repo's A/B currency,
  so those nine are **published** as a new `immutable-graphic` accepted class
  rather than counted — the same publish-don't-drop contract `edge-exempt-pad`
  already uses.

### The own-pad lift

Net-0 copper is foreign to every net *including the pad it was drawn around*.
esp_prog's tab **notches around pad 2**, west edge coincident with the pad's, so
stamping the shape whole pinches the pad's approach — #907's failure mode,
manufactured by #908's fix. Measured on the west approach corridor: 8/8 cells
free with the lift, 5/8 without.

The lift is per **segment** and own-footprint only, never per cluster: watchy's
twelve antenna polys are one connected cluster touching both the feed pad and a
GND pad, so a cluster-wide lift would let a GND route cross the whole antenna —
graded clean by that same reasoning, and a destroyed part. Locally, esp_prog
lifts 5 of 8 edges, watchy 6 of 48.

There are **three** answers to "what net is this graphic on", not two, and the
chain between them is what makes the lift safe:

```
graphic_own_pad_nets                          <- what the obstacle map uses
  subset-of  graphic_effective_nets(include_mutable=False)    (attrs + pads)
  subset-of  graphic_effective_nets(include_mutable=True)     <- the checker
```

`include_mutable=True` is the only value production passes. The `False` arm has
**no production caller**: it exists as the stable middle term of that proof,
because tracks and vias *move* during a route and a rip can withdraw a
permission the router already used, while pads do not move. The generator is
therefore never more permissive than the checker — asserted on synthetic data
and on all four affected boards.

### Three pre-existing defects the gates found

1. `_emit_outline` closed a polygon that **already repeats its first vertex** —
   how KiCad writes all twelve watchy antenna polys — into a zero-length
   "segment". Those model no copper and each became a duplicate DRC row: watchy
   graded 12 board-edge violations where the truth is 9.
2. The board-level `gr_*` scan ran over the raw text, so a custom pad's
   `(primitives (gr_poly …))` was excluded only because real KiCad writes those
   without a `(layer …)`. Incidental, not structural — and a leaked primitive
   lands at **pad-local** coordinates transformed by the footprint pose, i.e.
   millimetres away (3.5 mm on a synthetic 45° part): a false obstacle and
   missing copper at once. The scan now runs over `_mask_pad_primitives`, which
   is what the other board-level scans already do.
3. The segment-**crossing** arm never had #337's graphic exemption at all, so a
   net's own track crossing its own footprint's tab graded as a violation. It
   uses the OWN-PAD map, not `_graphic_pair_is_same_net` — the connectivity
   unification adds the net of every track that touches the art, so a foreign
   track grazing it would exempt *itself* and its crossing would go unreported.

---

## #907 — `--same-net-pad-clearance` names itself when it seals a pad

The **disclosure** arm the issue asks for. No new ladder, no new flag.

The probe is the A/B the router cannot do: take the cells this flag contributes
around one pad, remove them from the via map, and ask again whether any site
that could serve the pad is legal. The map is refcounted, so remove and re-add
are exactly balanced — a cell blocked by the flag *and* by something else keeps
its other reference and stays blocked, which is the right answer — and the
restore runs in a `finally`. The rung mirrors (#530/#568) move symmetrically and
the probe reads `is_via_blocked_rung(…, config.via_rung)`, because the search
consults the rung map and a rung-0-only probe answers a question the router
never asks. "A site that could serve the pad" is the pad's own cells plus
`KICAD_ESCAPE_STUB_RADIUS`, the actual fallback rung.

It surfaces in all four channels: the console cascade (**first**, ahead of #652
and #301, because it is the only cause whose remedy is a command-line change the
caller already controls), the net history, `summary['sealed_by_snpc']`, and
`suggest_route_adjustments` for the GUI.

**The issue's "no fallback by design" is wrong** and the PR should say so: the
off-pad escape-stub rung is the compliant replacement. What is real is that one
configuration has no fallback — the flag active *and*
`KICAD_ESCAPE_STUB_RADIUS=0` — and it took a bare `return None`, which reads as
"no site fits" and sends the reader looking at geometry instead of at two
settings. It now says which two.

---

## #909 — a board with no stackup states the numbers

`impedance.achievability_note()` solves against a **nominal** FR4 stack and says
so. On esp_prog, for the USB pair's own scope, at the pair gap the issue used
(`route_diff.py … --nets /D_P /D_N --impedance 90 --diff-pair-gap 0.15
--clearance 0.15` — `route_diff` otherwise clamps the pair gap up to the
clearance, giving 1.249 mm / 8.5x), reproducing the issue's figures to three
decimals:

> 90 Ω on F.Cu would need a **1.133 mm** differential leg (**2.416 mm** for the
> pair), against a **0.325 mm** gap between the pins it leaves from — **7.4×**.
> Not achievable here.

`tightest_pin_gap` supplies that comparison: for every pad of the nets in scope,
the gap to the nearest *other pad of the same footprint* — the channel the trace
actually has to leave through. It is **scope-dependent and derived from the
board**, not a constant: the 0.325 mm above is the USB pair's own gap, while the
whole-board default scope gives 0.125 mm and 19.3x. The gate derives both rather
than hardcoding either. Wired into the `No stackup found` branch of
`batch_route` and `batch_route_diff_pairs`, so both CLIs and both GUI paths get
it without a flag.

**No stackup is written, and the tests assert it.** #909 point 2 is explicit:
nothing in this repo authors a stackup, and a written default would only make
the width solver print 1.133 mm and clamp it straight back with a "this trace
will be ~169 ohm, not 90" warning — a stated non-goal turned into a clamp
warning. Step 10 rule 1 of the routing skill becomes "no stackup ⇒ **state the
numbers**, then no impedance passes".

---

## #910 — an opt-in fill-for-delivery step

`py_tools/fill_for_delivery.py IN -o OUT`, and `route.py --write-fill`.

Measured on `lvds_converter_dualclk_gnd` with its fills stripped: **54
unconnected without `--refill-zones`, 42 with the fill written** — twelve
phantom opens that were never a routing defect.

The reason this is not a two-line `pcbnew.SaveBoard`: a plain save rewrites the
`.kicad_pro` from KiCad's in-memory view and silently deletes every non-Default
net class (and aborts the process on pre-KiCad-10 projects). The save is
`aSkipSettings=True`, siblings are carried by `copy_board` first, and the CLI
**re-reads the classes afterwards and refuses, deleting its own output**, if any
went missing. Without KiCad's bundled python both front doors refuse with the
reason and write nothing.

CLI-only on purpose, and registered as such: it fills the *written file*, and the
GUI has no written file — it mutates the user's open board, where KiCad fills
live and pressing **B** is the same operation.

---

## Not done, deliberately

- **The two Edge.Cuts footprint scans are untouched.** They disagree by design —
  bbox corners for rotation-invariant bounds (#829) vs real circle segments
  (#628) — and unifying them would change `owns_board_outline` in a PR about
  copper. Only the *copper* field reader is shared.
- **kicad-cli's 17 own-footprint `shorting_items` stay `check_drc`-clean.**
  `check_drc` adopts KiCad's own connectivity-derived net for a graphic (#337)
  while kicad-cli's shorting check does not. This is the repo's existing
  doctrine for fixed library geometry — `tests/test_drc_pad_pad.py:7-11`: *"a
  component's own adjacent pins are fixed library geometry … flagging them would
  flood grading with pre-existing noise"* — applied to the same class. Measured
  and disclosed, not silent.
- **Only the perimeter of a filled poly is modelled**, never the interior — the
  same limit board-level graphics have had since #337. A track lying *entirely
  inside* the tab is still not caught (verified: kicad-cli reports it, we do
  not).
- **`fp_curve` on copper is parsed but not emitted.** No corpus board has one
  and `_bezier_to_segments` on copper is untested.
- **The obstacle lift is not extended to plane pours.** A plane must keep clear
  of an antenna even when its own pad is GND.
- **The pcbnew parse path is slower**, and that is measured, not fixed: copper
  graphics cannot be found without enumerating them, and unlike the text path
  there is no duplicate walk to reclaim with a memo. Paired A/B, fresh process
  per parse, arms alternated, two independent passes: median **+14.5 % to
  +57 %** across esp_prog / splitflap_driver / tigard / watchy. The direction
  is robust in every pass; the magnitude is not tight, and the largest figures
  are on the smallest boards, where fixed cost dominates.
  (The text path is *faster* than before — memoising `_footprint_blocks_by_key`
  pays for the new pass **and** for three older callers that were already doing
  the same whole-file walk: glasgow_revC and watchy −6 to −14 % median,
  orangecrab −2.5 to −5.7 %, sign never flipping.)
- **#907 gets disclosure, not the retry ladder** (the issue's own cheap arm).
- **No Rust change**, and no crate version bump.

## Graphics are not routed copper

`len(pcb.segments)` means *"is this board routed?"* in several places, and a
footprint's own copper is neither routed nor strandable -- it moves with its
part. The full suite caught six regressions from exactly that: watchy's 48
antenna edges and tigard's 4 solder-jumper edges made **copper-free boards
read as routed**, and `place_optimize` / `place_pose` / `place_seed` all
refused to place them ("moving a footprint strands every track"). Fixed at the
one shared guard they call, `placement_state.assess_placement`, plus
`board_score`'s quality key -- where counting art also suppressed the
`DEGENERATE QUALITY KEY` notice a copper-free board is supposed to get.

**One "regression" was the feature working.** `test_703`'s
`esp_prog:portfolio-1` row moved `truth.headline` 0 -> 1, which reads like a
broken route. It is not: `blocking_by` reads `unrouted 0`, `broken 0`, **`drc 1`**.

```
Pad:/DTR (Q1.2) <-> Seg:net_0 [Polygon(U2)]  (no net: a clearance issue, not a short)
  Layer: F.Cu, Overlap: 0.101mm
```

That quench candidate had been placing U2 so its SOT89 tab lands **on Q1's
pads** -- and kicad-cli 10.0.0 independently reports the same board as
`shorting_items` against Q1 pad 2 *and* pad 3. The recorded "truth" for that
row was a placement defect nobody could see. Re-recorded with the cause named,
following that file's own 2026-09-03 precedent, rather than filed as a
regression.

## Verification

Every phase was checked by a separate subagent told to break the claim rather
than confirm it; the parser phase's verifier returned twelve findings, six of
which are fixed in `#908: the verifier's findings on the parser half` (a
string-blind `footprint_pose`, NPTH pads counted as pads, a `try/except` that
swallowed the whole pcbnew walk, `compare_pcb_data` blind to `owner_ref`, a
cache guard that hid real `TypeError`s, and a docstring asserting an immunity
the code did not have). The rest are the measured limits listed above.

Full suite at the final commit: **592 passed, 0 failed** (2 self-skipped,
pre-existing). `tests/run_doc_examples.py` 32 run / 78 skipped / 7 failed,
identical at `529f873d`.

New gates: `test_908_footprint_copper.py` (31 parser invariants, three negative
controls), `test_908_own_pad_lift.py` (the subset chain, locality, the measured
corridor, a foreign net still blocked), `test_908_drc_report.py`,
`test_908_writer_owner_gate.py`, `test_909_impedance_achievability.py`,
`test_910_fill_for_delivery.py`, plus invariant 7 in
`test_581_same_net_pad_via_clearance.py`. The writer gate was mutation-tested:
neutering the owner check turns ten rows red.

Closes #907
Closes #908
Closes #909
Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wa54dFaXWdK4aw3VsV8ay
