### PR TITLE
#936 follow-up: the placement door gates off-outline pad copper, and two gates that asserted less than they printed

### DIFF
--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -2647,6 +2647,27 @@ def _self_test():
                  '--waive', 'congestion:spent']))
             want(out.startswith('<error>') and _want in out,
                  f'a render whose review sheet is {_val!r} is refused')
+        # PAD COPPER OFF THE OUTLINE -- the top-priority placement defect, and
+        # the one this door did not check at all until #936. Held here rather
+        # than only by --dump-refusals: blinding the read left the driver's own
+        # self-test green, which a battery row measured as a SURVIVOR.
+        _rj = dict(_r15)
+        _rj['review_sheet'] = _sheet_file
+        _rj['checklist'] = dict(_rj.get('checklist') or {})
+        _rj['checklist']['a_off_outline'] = {
+            'pad_copper': [{'reference': 'U7'}, {'reference': 'J2'}],
+            'courtyard': []}
+        out = STAGES['P-close'](_args(
+            ['--board', _pb, '--before', _pa,
+             '--render-json', _wr('rs_oob.json', _rj),
+             '--intent-json', _wr('is_oob.json', _covered([], brief=None)),
+             '--congestion-before', _wr('rs_oob2.json', _dmg),
+             '--waive', 'congestion:spent']))
+        want(out.startswith('<error>') and 'PAD COPPER outside' in out
+             and 'U7' in out,
+             'a render naming parts with pad copper off the outline is refused,'
+             ' and the refusal names them')
+
         _rj = dict(_r15)
         _rj['review_sheet'] = _sheet_file
         out = STAGES['P-close'](_args(

--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -1013,14 +1013,17 @@ def _guard_render(a):
     # THE CHANNEL MATTERS, and it is not the one the loop uses. l2 reads
     # `oob_pad_count` out of check_assembly's report, which is a part-level pad
     # AABB inflated by the grading clearance -- its own `oob_pad_basis` string
-    # says so and points here instead. Measured over the 22 tracked boards:
-    # that count is non-zero on three, and on two of them -- glasgow_revC (SW1,
-    # 0.03mm) and watchy (SW1-SW4, 0.17mm each), both human-designed reference
-    # boards with edge-mounted switches -- this per-PAD measure reports an
-    # EMPTY list. The AABB fires on the bounding box of an edge part; the pads
-    # are on the board. Gating on that count would refuse two human boards on a
-    # measurement artifact, which is why CLAUDE.md names this key and adds "a
-    # whole-board pass/fail verdict is the wrong channel for it".
+    # says so and points here instead. Measured over every tracked board: that
+    # count is non-zero on three, and on two of them -- both human-designed
+    # reference boards carrying edge-mounted switches, at 0.03mm and 0.17mm --
+    # this per-PAD measure reports an EMPTY list. The AABB fires on the
+    # bounding box of an edge part; the pads are on the board. Gating on that
+    # count would refuse two human boards on a measurement artifact, which is
+    # why CLAUDE.md names this key and adds "a whole-board pass/fail verdict is
+    # the wrong channel for it". (The boards are named in the PR that added
+    # this, not here: a skill that names corpus boards is what
+    # tests/test_run8_skills_generic.py refuses, because guidance written
+    # around one board stops being guidance.)
     #
     # So this gate binds on the per-pad list and NAMES THE PARTS, because a
     # count is not something you can act on and the refusal exists to be acted

--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -999,6 +999,52 @@ def _guard_render(a):
             'outline, is any part on any other part, is any part on a hole or a '
             'locked part, and did more parts move than the step claimed.\n\n'
             'Re-render with --json-out.')
+    # PAD COPPER OFF THE OUTLINE -- the top-priority placement defect, and
+    # until now checked at ONE of the three doors.
+    #
+    # `loop_driver.l2` refuses a board on it (measured, its own comment:
+    # "`oob_pad_count` alone refuses 24, of which 12 are refusals `blocking`
+    # misses"), and nothing in this file did -- so the same board closed out
+    # clean through the placement door and was refused through the loop.
+    # CLAUDE.md: "A part whose pad copper lies outside the outline is the
+    # top-priority placement defect... Measured, run 10: 11 such parts produced
+    # ALL 13 unrouted nets and most of the 37 broken ones."
+    #
+    # THE CHANNEL MATTERS, and it is not the one the loop uses. l2 reads
+    # `oob_pad_count` out of check_assembly's report, which is a part-level pad
+    # AABB inflated by the grading clearance -- its own `oob_pad_basis` string
+    # says so and points here instead. Measured over the 22 tracked boards:
+    # that count is non-zero on three, and on two of them -- glasgow_revC (SW1,
+    # 0.03mm) and watchy (SW1-SW4, 0.17mm each), both human-designed reference
+    # boards with edge-mounted switches -- this per-PAD measure reports an
+    # EMPTY list. The AABB fires on the bounding box of an edge part; the pads
+    # are on the board. Gating on that count would refuse two human boards on a
+    # measurement artifact, which is why CLAUDE.md names this key and adds "a
+    # whole-board pass/fail verdict is the wrong channel for it".
+    #
+    # So this gate binds on the per-pad list and NAMES THE PARTS, because a
+    # count is not something you can act on and the refusal exists to be acted
+    # on.
+    _oob = (chk.get('a_off_outline') or {}).get('pad_copper')
+    if isinstance(_oob, list) and _oob:
+        _refs = []
+        for _it in _oob:
+            _r = _it.get('reference') if isinstance(_it, dict) else _it
+            if _r and str(_r) not in _refs:
+                _refs.append(str(_r))
+        return False, (
+            f'{len(_oob)} part(s) carry PAD COPPER outside the board outline: '
+            f'{", ".join(_refs) or "see checklist.a_off_outline.pad_copper"}.'
+            f'\n\nThose nets cannot be routed at all, so this converts '
+            f'one-for-one into `unrouted` and `broken` -- measured, run 10: 11 '
+            f'such parts produced ALL 13 unrouted nets and most of the 37 '
+            f'broken ones. It is the top-priority placement defect, ahead of '
+            f'every clearance graze.\n\nMove those parts back inside the '
+            f'outline and re-render. The outline is not yours to change.\n\n'
+            f'This is the per-PAD measure, not check_assembly\'s '
+            f'`oob_pad_count`, which is a part-level AABB inflated by the '
+            f'clearance and reads non-zero on human boards whose pads are '
+            f'fine.')
     d = chk.get('d_moved') or {}
     if d.get('match') is False:
         return False, (
@@ -1871,6 +1917,20 @@ def _refusal_scenarios(tmp):
          + ['--render-json', render(name='r_other.json', of=other)]),
         ('a render with no checklist', with_before
          + ['--render-json', render(name='r_nochk.json', checklist=_DROP)]),
+        ('a render naming parts with pad copper off the outline', with_before
+         + ['--render-json', render(name='r_oob.json', checklist={
+             'a_off_outline': {'pad_copper': [{'reference': 'U7'},
+                                              {'reference': 'J2'}],
+                               'courtyard': []},
+             'd_moved': {'moved': 3, 'expected': None, 'match': None}})]),
+        # ...and the same list carrying no `reference`, which is the arm that
+        # falls back to naming the key. Without this row that fallback is a
+        # branch nothing renders -- exactly what --dump-refusals exists to say.
+        ('a render with off-outline pad copper it cannot attribute', with_before
+         + ['--render-json', render(name='r_oob_anon.json', checklist={
+             'a_off_outline': {'pad_copper': [{'amount_mm': 1.2}],
+                               'courtyard': []},
+             'd_moved': {'moved': 3, 'expected': None, 'match': None}})]),
         ('a render that disagrees on the move count', with_before
          + ['--render-json', render(name='r_moved.json', checklist={
              'd_moved': {'moved': 9, 'expected': 3, 'match': False}})]),

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,15 @@ Thumbs.db
 rust_*/target/
 *.pyd
 
+# render_placement writes <board>_placement.png (and _B/_F on a two-sided
+# board) BESIDE THE BOARD when -o is omitted -- render_placement.py:2220. So
+# grading the corpus leaves 31 PNGs in kicad_files/, and a `git add -A` ships
+# ~14 MB of generated renders into the commit. Measured: it did, into a #936
+# follow-up branch, and only reading the diffstat before pushing caught it.
+/kicad_files/*_placement.png
+/kicad_files/*_placement_B.png
+/kicad_files/*_placement_F.png
+
 # KiCad outputs (routed files, backups, project files)
 /kicad_files/test_diffpair*kicad_pcb
 /kicad_files/fanout_output*.kicad_pcb

--- a/krt_capabilities.py
+++ b/krt_capabilities.py
@@ -443,8 +443,15 @@ def capabilities(root=ROOT):
         _eng = os.path.join(root, 'py_router')
         if os.path.isdir(_eng) and _eng not in sys.path:
             sys.path.insert(0, _eng)        # #522 layout: the engine dir
-        import routing_defaults as _d
-        out['version'] = getattr(_d, 'VERSION', None)
+        # /VERSION is the release triple's own file (Cargo.toml +
+        # /VERSION + metadata.json). This used to read
+        # `routing_defaults.VERSION`, which that module has never
+        # defined -- so `capabilities()['version']` was None on every
+        # call this function has ever made, while /VERSION said 0.22.0.
+        # A capability report whose version is always None cannot
+        # answer the one question it exists for: can THIS clone do X.
+        with open(os.path.join(root, 'VERSION'), encoding='utf-8') as _vf:
+            out['version'] = _vf.read().strip() or None
     except Exception:
         out['version'] = None
     return out

--- a/py_placer/converge.py
+++ b/py_placer/converge.py
@@ -1086,8 +1086,13 @@ def cmd_record(a):
         _miss = sorted(_need - _seen)
         if _miss:
             # The old text said "routing_driver --stage V5 fans them out".
-            # There is no routing_driver.py in this repo and there never has
-            # been; V1-V5 survive only as prose. This is a REFUSAL, i.e. the
+            # There is no routing_driver.py on main, and V1-V5 survive here
+            # only as prose. (It DID exist -- created at 255af97d, grown to
+            # 19 stages, on 10 commits, none of them on main; the maintainer
+            # removed it twice by name because it forked before #562 and went
+            # on emitting two steps main had deleted. "Never has been" was
+            # wrong, and a refusal is the worst place to be wrong about what
+            # exists.) This is a REFUSAL, i.e. the
             # one message whose entire job is to say what to do next, so it
             # names a file the reader can open instead of a tool they cannot
             # find.

--- a/tests/mutate_936.py
+++ b/tests/mutate_936.py
@@ -140,6 +140,25 @@ ROWS = [
      '            out |= set()\n',
      (T_DFL,), KILLED),
 
+    # ---- the placement door gates off-outline pad copper --------------------
+    # The top-priority placement defect, checked at one door of three until now.
+    # Deliberately on the PER-PAD channel: check_assembly's `oob_pad_count` is a
+    # part-level AABB that reads non-zero on two HUMAN boards whose pads are
+    # fine (glasgow_revC 0.03mm, watchy 0.17mm), so gating on that count would
+    # refuse them. Blinding the read must redden the driver's own self-test.
+    ('off-outline-gate-blinded', 'pd',
+     "    _oob = (chk.get('a_off_outline') or {}).get('pad_copper')\n",
+     "    _oob = None\n",
+     (T_DRIVERS,), KILLED),
+
+    # ---- test_431's exit-code scanner, its only live half -------------------
+    # The corpus has 0 annotated commands, so a scanner that stopped matching
+    # reports the same 0. The positive control is what tells those apart.
+    ('exit3-scanner-blinded', 't431',
+     "            blk = '\\n'.join(ls[i + 1:i + 4])\n",
+     "            blk = ''\n",
+     (T_431,), KILLED),
+
     # ---- B6: a gate must not pin the citation it exists to keep correct -----
     # `def better` moved from 358 to 564. The gate hardcoded 358, so correcting
     # the skill FAILED the test whose job is keeping the skill correct.

--- a/tests/test_431_skill_commands.py
+++ b/tests/test_431_skill_commands.py
@@ -497,6 +497,7 @@ def test_driver_commands_supply_required_options_and_values():
     """
     problems = []
     checked = 0
+    unparsed = {}
     for src in DRIVERS:
         text = source_text(src)
         for tool in TOOLS:
@@ -507,7 +508,20 @@ def test_driver_commands_supply_required_options_and_values():
             try:
                 parser = _parser_obj(tool)
             except Exception:
-                continue          # covered by the flag test's own <parser> row
+                # DECLARED, not dropped. `_parser_obj` builds the parser by
+                # importing the tool and calling `main()` with --help
+                # intercepted; a tool that parses its args anywhere else has no
+                # `main` to call, and this arm used to `continue` in silence --
+                # 13 emitted command spans went unchecked while the gate
+                # printed a clean count. The flag NAMES in them are still
+                # covered, by the flag test's `--help` reader; what is not
+                # covered is whether each flag was given a VALUE.
+                #
+                # Counted and held to no growth, the shape test_923 uses for
+                # its skipped sections: a population that is legitimate to have
+                # and illegitimate to grow.
+                unparsed[tool] = unparsed.get(tool, 0) + len(spans)
+                continue
             import argparse as _ap
             # store_true/store_false/count/help consume nothing; every other
             # action stores a value and argparse errors without one -- EXCEPT
@@ -550,7 +564,21 @@ def test_driver_commands_supply_required_options_and_values():
     # with the refusal half gone -- measured, as a battery row that SURVIVED.
     # Measured after: 154.
     assert checked >= 90, f'only {checked} driver command(s) scanned'
-    print(f'  PASS: {checked} driver command spans, all runnable')
+    # The population this arm cannot value-check, named and capped. 13 today:
+    # check_drc.py 10, check_connected.py 3 -- both parse their args outside a
+    # `main()`, so `_parser_obj` has nothing to call. Giving either one a
+    # `main()` moves its spans into `checked` and this number DOWN, which is
+    # why the guard is a ceiling and not an equality.
+    _unp = sum(unparsed.values())
+    assert _unp <= 13, (
+        f'{_unp} driver command span(s) are value-unchecked, up from 13:\n'
+        + '\n'.join(f'  {t}: {n}' for t, n in sorted(unparsed.items()))
+        + '\n\nA tool whose parser cannot be built has its flag NAMES checked '
+          'by the --help reader but not whether each was given a VALUE. Give '
+          'it a main(), or raise this ceiling deliberately and say why.')
+    print(f'  PASS: {checked} driver command spans, all runnable '
+          f'({_unp} value-unchecked: '
+          f'{", ".join(f"{os.path.basename(t)} {n}" for t, n in sorted(unparsed.items())) or "none"})')
 
 
 def test_the_refusal_branches_are_scanned():
@@ -985,10 +1013,44 @@ def test_exit_code_contract_is_documented():
         'commands annotated "exits 3" whose flag returns before the board-state '
         'gate:\n' + '\n'.join(f'  {w}: {t} {f} answers and returns 0'
                               for w, t, f in sorted(set(problems))))
+    # POSITIVE CONTROL on the SCANNER, because `checked == 0` today and a
+    # scanner that has stopped matching reports exactly the same zero. The two
+    # `_returns_before_gate` assertions above hold the ANALYSER down; nothing
+    # held down the thing that feeds it. Synthetic text in the shape the scan
+    # looks for -- a `#` comment carrying "exits 3", a command within the next
+    # three lines -- must produce exactly one row, and the same text with the
+    # annotation as prose rather than a comment must produce none.
+    def _scan(sample):
+        n = 0
+        ls = sample.splitlines()
+        for i, line in enumerate(ls):
+            if 'exits 3' not in line and 'exit 3' not in line:
+                continue
+            if not line.lstrip().startswith('#'):
+                continue
+            blk = '\n'.join(ls[i + 1:i + 4])
+            for tool in TOOLS:
+                for b in _continued_blocks(blk, tool):
+                    n += len(_cited_flags(b, tool))
+        return n
+
+    _hit = ('# --suggest-locks exits 3 when the board is unplaced\n'
+            'python3 -X utf8 py_placer/place_optimize.py b.kicad_pcb '
+            '--suggest-locks\n')
+    _miss = ('The tool exits 3 when the board is unplaced.\n'
+             'python3 -X utf8 py_placer/place_optimize.py b.kicad_pcb '
+             '--suggest-locks\n')
+    assert _scan(_hit) == 1, (
+        'the exit-code scanner no longer finds an annotated command -- so its '
+        f'{checked} is a claim about the scanner, not about the skills')
+    assert _scan(_miss) == 0, (
+        'the exit-code scanner reads PROSE as an annotation; an "exits 3" in a '
+        'sentence is not a claim attached to a command')
     print(f'  PASS: exit-3 contract; {checked} annotated flag(s) reach the gate'
           if checked else
-          '  PASS: exit-3 contract; no command in the skills is annotated with '
-          'an exit code today, so the analyser control above is the live half')
+          '  PASS: exit-3 contract; 0 commands in the skills are annotated with '
+          'an exit code today -- the analyser controls and the scanner control '
+          'are what is live')
 
 
 def test_skill_decides_placement_by_measurement_not_by_default():

--- a/tests/test_run8_skill_drivers.py
+++ b/tests/test_run8_skill_drivers.py
@@ -179,6 +179,27 @@ def test_loop_driver():
     check('...and says delegation is now a correctness decision',
           'CORRECTNESS one' in text)
 
+    # THE ROUTING SKILL, which this file declared and never read. `ROUTING_SKILL`
+    # was assigned and referenced nowhere else, so of this file's checks 0 were
+    # about the routing half -- the door with no driver, and therefore the one
+    # whose contract lives entirely in prose. A declared-but-unused path is a
+    # gate that looks present in a grep and asserts nothing.
+    #
+    # These pin what the LOOP relies on being true over there. They are
+    # deliberately not a driver contract: routing has no driver, and #937 is
+    # where whether it should have one is being decided.
+    rtext = open(ROUTING_SKILL, encoding='utf-8').read()
+    check('the routing skill ships', os.path.isfile(ROUTING_SKILL))
+    check('the routing skill still opens at the step the loop hands off to',
+          'Step 1: Load and Analyze PCB Structure' in rtext)
+    check('...and still ends its chain on route.py, which the loop assumes',
+          'route.py' in rtext)
+    # The handback the loop reads. L2 tells a delegate to follow this skill and
+    # then reads a close-out; if the reconciliation section is renamed away, the
+    # loop's instruction points at nothing and only a run would find out.
+    check('...and keeps the net-coverage reconciliation the loop cites',
+          'Net-Coverage Reconciliation' in rtext)
+
 
 def main():
     check('the driver ships with the skill', os.path.isfile(DRIVER))


### PR DESCRIPTION
Follow-up to #938 (merged). Six commits on current `main`.

These are defects an advisory pass over #937 turned up while #938 was in review —
four in code the merged PR touched, one in a gate it depends on, and one hazard
that nearly shipped 14 MB of generated renders into this branch.

`Refs #936` — same family as the merged work, but none of these is a #936 item;
they were found by measuring, not by the issue.

---

## 1. The placement door now gates off-outline pad copper — on the RIGHT channel

**The defect.** `loop_driver`'s L2 refuses a board that carries pad copper off
the outline, and records the measurement in its own comment: *"`oob_pad_count`
alone refuses 24, of which 12 are refusals `blocking` misses."* **No placement
stage checked it at all** — it appeared only as prose in P3, and `P-close` had
no such guard. So the same board closed out clean through `/plan-pcb-placement`
and was refused through the loop.

That matters because CLAUDE.md calls it the top-priority placement defect:
*"A part whose pad copper lies outside the outline… converts one-for-one into
`unrouted` and `broken`. Measured, run 10: 11 such parts produced ALL 13
unrouted nets and most of the 37 broken ones."*

**The obvious fix is wrong, and measuring it is what showed that.** Making
`check_assembly`'s `oob_pad_count` a sixth `not_buildable` conjunct would give
all three doors the gate for free. Over the 22 tracked boards:

| board | `oob_pad_count` | `checklist.a_off_outline.pad_copper` |
|---|---|---|
| `glasgow_revC` | SW1, 0.03 mm | **`[]`** |
| `watchy` | SW1–SW4, 0.17 mm each | **`[]`** |
| `rp2350_fpga_eensy_prePlane` | U8, 3.15 mm | 1 part |

`oob_pad_count` is a part-level pad **AABB inflated by the grading clearance** —
its own `oob_pad_basis` string says so and points at the per-pad measure
instead. On an edge-mounted switch the bounding box crosses the outline while
the pads do not. Gating on it would flip **two human-designed reference boards**
to NOT BUILDABLE on a measurement artifact. CLAUDE.md already names the right
key and adds *"a whole-board pass/fail verdict is the wrong channel for it."*

**So the gate is in `_guard_render`, on `checklist.a_off_outline.pad_copper`** —
the per-pad list, in the render every stage that FOLLOWS a move already has to
supply. It fires on **1 of the 22 tracked boards**, the one already graded NOT
BUILDABLE, and on neither human board. It **names the parts**, because a count
is not something a reader can act on and a refusal exists to be acted on.

Two `--dump-refusals` scenarios, not one: the second reaches the arm that falls
back to naming the key when an entry carries no `reference`, which was otherwise
a branch nothing rendered.

**Reported, not fixed:** `loop_driver` L2 still reads the COARSE channel, so it
will refuse `glasgow_revC` and `watchy` on the artifact. That is a behaviour
change to a shipped gate on the routing side of the boundary and wants its own
measurement — and the `--accept-residue oob_pad_count` escape it already carries
is probably why nobody has hit it.

## 2. `test_431`'s two blind spots

**A silent drop.** `test_driver_commands_supply_required_options_and_values` did
`except Exception: continue` when a tool's parser could not be built, on the
comment *"covered by the flag test's own `<parser>` row"*. Measured: that drops
**13 emitted command spans** — `check_drc.py` 10, `check_connected.py` 3 —
because `_parser_obj` builds a parser by importing the tool and calling
`main()`, and both parse their args outside one. The flag NAMES in those spans
are covered by the `--help` reader; whether each flag was given a VALUE is not,
and the gate printed a clean `161` without saying so.

Now declared and capped at 13, the shape `test_923` uses for its skipped
sections: legitimate to have, illegitimate to grow. A **ceiling**, not an
equality — giving either tool a `main()` moves its spans into `checked` and the
number down. The pass line names the tools.

**A scan nothing controlled.** `test_exit_code_contract_is_documented` has two
live `_returns_before_gate` assertions holding the ANALYSER down, and a corpus
scan that finds **0** annotated commands — which is exactly what a scanner that
has stopped matching also reports. A positive control now runs the scan over
synthetic text: a `#` comment carrying "exits 3" with a command in the next three
lines must produce exactly one row, and the same text with the annotation as
PROSE must produce none. The zero is now a fact about the skills rather than a
claim about the scanner.

## 3. Three true-but-stale facts, each where it answers a question

- **`krt_capabilities.capabilities()['version']` was `None` on every call this
  function has ever made.** It read `routing_defaults.VERSION`, which that module
  has never defined, inside a `try/except` that turns the `AttributeError` into
  the same `None`. `/VERSION` says `0.22.0`. A capability report exists to answer
  "can THIS clone do X"; a version that is always None cannot. It reads
  `/VERSION` now.
- **`py_placer/converge.py`'s refusal said "there is no routing_driver.py in this
  repo and there never has been".** It did exist — created at `255af97d`, grown
  to 19 stages, on 10 commits, none on `main`, and removed twice by the
  maintainer by name because it forked before #562 and kept emitting two steps
  main had deleted. V1–V5 come from it. The operative claim (none on main; V1–V5
  survive here only as prose) is true and is what the refusal needs; *"never has
  been"* was not, and a refusal is the worst place to be wrong about what exists.
- **`tests/test_run8_skill_drivers.py` declared `ROUTING_SKILL` and referenced it
  nowhere else**, so ZERO of its checks were about the routing half — the door
  with no driver, and therefore the one whose whole contract is prose. It now
  pins the three things the LOOP relies on: the step L2 hands off to, that the
  chain still ends on `route.py`, and the net-coverage reconciliation section the
  loop cites by name. Deliberately not a driver contract — routing has no driver,
  and #937 is where that is being decided. Mutation-checked by renaming the
  heading it cites.

## 4. `.gitignore`: render output written beside the board

`render_placement` writes `<board>_placement.png` (and `_B`/`_F` on a two-sided
board) next to the board when `-o` is omitted — `render_placement.py:2220`. So
grading the corpus leaves **31 PNGs in `kicad_files/`**, and a `git add -A` ships
~14 MB of generated renders. Nothing in `.gitignore` covered the pattern.

Measured: it happened on this branch, and only reading the diffstat before
pushing caught it. The PNGs were stripped; the rule stops the next one.

## Verification

At `d6c82bd4` + these six commits:

```
tests/test_431_skill_commands.py            ALL PASS
  909 flag citations, all real
  161 driver command spans, all runnable (13 value-unchecked: named)
  placement_driver.py: 39 refusal texts, all rendered (77 chunks)
  loop_driver.py:      49 refusal texts, all rendered (116 chunks)
  exit-3 contract: 0 annotated commands; analyser + scanner controls live

tests/mutate_936.py       13 rows, 13 killed, 0 survived, 0 broken
tests/mutation_anchors.py 48 batteries, 1076 anchors, 0 stale, 0 unresolved
```

and green: `test_run8_skill_drivers`, `test_placement_run`, `test_refusal_checks`,
`test_krt_capabilities`, `test_converge`, `test_718_static_test_hygiene`,
`test_923_output_key_claims`, `test_803_cited_paths_are_tracked`,
`test_918_gate_wording`, `test_doc_flag_liveness`; `placement_driver --self-test`
and `--dump-refusals` exit 0.

Two new mutation rows prove the new gates bind: `off-outline-gate-blinded` and
`exit3-scanner-blinded`. The first was measured as a **SURVIVOR** on its first
run — the gate was reachable only through `--dump-refusals`, so blinding it left
`--self-test` green. A P-close self-test arm now drives it directly and asserts
the refusal names the parts. A row that survives is a hole, and that one was the
gate's own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wa54dFaXWdK4aw3VsV8ay
