### PR TITLE
#937: one flow of verbs -- a gated tool registry, the routing door's entry gate, and a checker that proves the plan

### DIFF
--- a/.claude/skills/plan-pcb-placement-and-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-placement-and-routing/SKILL.md
@@ -118,15 +118,25 @@ finished with: anything after that — a pour, a repair, a placement re-entry �
 leaves its verdicts stale, and a verdict recorded against a board it did not
 read is the defect this loop exists to catch.
 
-**The agent TYPE is a cost decision, so make it rather than default it.** A
-fresh agent starts empty and will rebuild the context it was not given — one
-measured half spent its first hour writing read-only probe scripts for facts
-this loop already held. A fork starts with the parent's whole conversation and
-rebuilds nothing, but carries those tokens into every turn of its own, mostly
-cached, and is a bigger context to reason inside. The fork buys the REBUILD, not
-the per-turn cost. Fork when the parent holds facts the half cannot re-derive
-from the files named in its brief; use a fresh agent when everything it needs is
-one of those files; and say in the report which you chose.
+**The agent TYPE is a cost decision. The driver makes it for you, and you
+override it when the criterion says so — what you must not do is let it pass
+unread.** A fresh agent starts empty and will rebuild the context it was not
+given — one measured half spent its first hour writing read-only probe scripts
+for facts this loop already held. A fork starts with the parent's whole
+conversation and rebuilds nothing, but carries those tokens into every turn of
+its own, mostly cached, and is a bigger context to reason inside. The fork buys
+the REBUILD, not the per-turn cost.
+
+So the default is `fork`, and it is a measured default rather than a
+convenience. **The criterion for overriding it:** use `--delegate-mode fresh`
+when everything the half needs is in the files its brief names, so there is no
+rebuild to buy. Say in the report which you used and why.
+
+(This paragraph used to say "make it rather than default it" while the
+paragraph thirteen lines above said the tool now takes the decision, and the
+code has no path that evaluates the criterion at all — it reads one flag and
+falls back to `fork`. Two sentences that close together must not disagree;
+the tool proposing and the reader disposing is what both were reaching for.)
 
 **The END-TO-END VERIFIER is never a fork, in either mode.** Its prompt ends
 "Re-derive every number yourself. Do not trust the report", and

--- a/.claude/skills/plan-pcb-placement-and-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-placement-and-routing/SKILL.md
@@ -70,7 +70,7 @@ Its guards are the four this skill exists to enforce:
 | `L2` route | a placement close-out | routing cannot start on a placement nobody proved, and a board with a blocking pair fails for a reason routing cannot fix |
 | `L3` classify | a routing score | a retry without a classification is a guess |
 | `L4` re-enter | a measured `--shape` | the three shapes re-enter at three different points, and the cost of guessing is asymmetric |
-| `L5` close out | a `check_complete` close-out that **agrees** with `converge` | nothing refused to FINISH, so a run reached the terminal artifact having never entered routing's own V1–V5 loop, and shipped a power-to-signal short. It builds FOUR refusals, not one: a `--final` lens PASS against that row's own score; all-PASS live lenses against an `INCOMPLETE`/`UNSOUND` close-out; `DONE-EXHAUSTED` against a non-`DONE` close-out; and, opt-in, the on-disk verdict file against the ledger's live claim under its own `verifier` waiver token. Prepare for all four |
+| `L5` close out | a `check_complete` close-out that **agrees** with `converge` | nothing refused to FINISH, so a run reached the terminal artifact having never run routing's own close-out, and shipped a power-to-signal short. It builds FOUR refusals, not one: a `--final` lens PASS against that row's own score; all-PASS live lenses against an `INCOMPLETE`/`UNSOUND` close-out; `DONE-EXHAUSTED` against a non-`DONE` close-out; and, opt-in, the on-disk verdict file against the ledger's live claim under its own `verifier` waiver token. Prepare for all four |
 
 **Both inner halves go to a teammate. Always, at every board size.** You do not
 decide it and you cannot forget it — the driver reads the board, delegates, and
@@ -155,10 +155,12 @@ the run, and a watcher had to reconstruct both from the transcript.
 2. **Freeze what the placement decided.** Lock the refs whose poses are
    decisions (mechanically fixed parts, anything a spec pins). A later step
    that moves them silently undoes the placement work.
-3. **Route.** Follow `/plan-pcb-routing` from Step 1 on the placed board. Its
-   Step 0 gate will pass, because you just did that work.
-4. **On a routing failure, classify before retrying** (the routing skill's
-   convergence section owns the classifier):
+3. **Route.** Follow `/plan-pcb-routing` from its Step 0 on the placed
+   board. That gate will pass, because you just did that work -- say so and
+   move on rather than re-deriving it.
+4. **On a routing failure, classify before retrying** (the classifier lives
+   in `references/convergence.md`, here -- `ca6bb455` moved it out of the
+   routing skill, and this line went on citing where it used to be):
 
    | the diagnosis says | re-enter at |
    |---|---|
@@ -731,7 +733,7 @@ Three rules about that number:
   never let it read as clean.
 
 **`place_route_loop`'s own `ACCEPTED` / `REJECTED` is NOT a quality verdict.**
-`better()` (`py_placer/place_route_loop.py:564`) compares `failures` and `iterations`, both
+`better()` (`py_placer/place_route_loop.py:569`) compares `failures` and `iterations`, both
 from route.py's own `JSON_SUMMARY`; it never runs a checker. Treat it as a cheap
 pre-filter and **re-score with `board_score.py` before believing it.**
 

--- a/.claude/skills/plan-pcb-placement-and-routing/scripts/board_score.py
+++ b/.claude/skills/plan-pcb-placement-and-routing/scripts/board_score.py
@@ -51,6 +51,11 @@ Exit codes (deliberately the same dialect as check_floorplan.py)
     3  board state (missing file, unparseable board)
     4  graded, blocking > 0
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'routing', 'combined'], 'kind': 'instrument'}
+
 import argparse
 import json
 import os

--- a/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
+++ b/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
@@ -1242,12 +1242,45 @@ def l2(a):
     if _ooberr:
         return err(_ooberr)
     if oob and oob > 0 and not _accept(a, 'oob_pad_count'):
+        # NAME WHICH CHANNEL, AND SHOW THE OTHER ONE (#937).
+        #
+        # This gate reads the part-level AABB inflated by the grading
+        # clearance, and it is right to: over 119 graded rows it refuses 24
+        # boards, 12 of them refusals `blocking` does not make. But the
+        # refusal it writes says "their nets cannot be routed at all", which
+        # is true of copper genuinely off the outline and NOT true of an
+        # edge-mounted part whose bounding box crosses an INFLATED outline
+        # while every pad stays on the board. Measured over the tracked
+        # corpus: of the three boards this fires on, two are exactly that --
+        # human reference boards with edge-mounted switches -- and a reader
+        # who saw only the count could not tell which they had.
+        #
+        # check_assembly carries both channels now, so print both and say
+        # which one is being refused on. The GATE is unchanged: same channel,
+        # same threshold, same waiver.
+        _exact = rep.get('oob_pad_copper_refs')
+        _exact = _exact if isinstance(_exact, list) else []
+        _named = ', '.join(f'{r} ({v}mm)' for r, v in _exact[:8]) or 'none'
+        if _exact:
+            _reading = ('Both channels agree: that copper really is off the '
+                        'board, and those nets cannot be routed at all.')
+        else:
+            _reading = ('THE TWO DISAGREE, and read that before you act: NO '
+                        'PAD crosses the real outline. The count above is the '
+                        'bounding box of an edge-mounted part against an '
+                        'outline inflated by the grading clearance. If that '
+                        'is what this board has, the overhang is probably BY '
+                        'DESIGN and the declaration below is the right answer '
+                        'rather than a placement re-entry.')
         return err(
             f'The placement close-out reports blocking = 0, but '
             f'oob_pad_count = {oob}: {oob} part(s) carry pad copper OFF the '
-            f'board. Those parts are assembly-clean precisely because nothing '
-            f'is out there to collide with, and their nets cannot be routed at '
-            f'all.\n\nThis is placement-shaped damage, and it is cheaper to '
+            f'board.\n\n'
+            f'    part AABB vs the inflated outline: {oob}\n'
+            f'    pad copper vs the REAL outline:    {len(_exact)}  '
+            f'[{_named}]\n\n'
+            f'{_reading}\n\nThis is placement-shaped damage, and it is '
+            f'cheaper to '
             f'fix now than to discover it as a routing failure and re-enter. '
             f'Go back to the placement half.\n\nIf the overhang is BY DESIGN '
             f'-- a card edge, a switch actuator, a castellated module -- '
@@ -3294,9 +3327,21 @@ def _refusal_scenarios(tmp):
         ('an oob_pad_count that is not a number', base
          + ['--score', score, '--placement-report', bent(
              'p_ox.json', oob_pad_count='five')]),
-        ('pad copper off the board', base
+        # BOTH ARMS of the off-outline refusal (#937). The first renders the
+        # DISAGREE reading (the AABB fires, no pad crosses the real outline --
+        # the edge-mounted-part case, which is 2 of the 3 boards this gate
+        # fires on across the tracked corpus); the second renders the AGREE
+        # reading. One row covered only the first, and `--dump-refusals` still
+        # reported 49 of 49 texts rendered, because the two readings are
+        # composed OUTSIDE the `err(...)` call and the site scanner only sees
+        # literals inside it. An arm nothing renders is the hole, not a gap.
+        ('pad copper off the board, and no pad actually crosses it', base
          + ['--score', score, '--placement-report', bent(
              'p_oob.json', oob_pad_count=5)]),
+        ('pad copper off the board, both channels agreeing', base
+         + ['--score', score, '--placement-report', bent(
+             'p_oob2.json', oob_pad_count=2,
+             oob_pad_copper_refs=[['U8', 0.8], ['J3', 1.25]])]),
         # the recording spine: a board no ledger row names
         ('a board no ledger row records', ['--board', other, '--ledger', led,
          '--score', wrote('s_o.json', {'blocking': 2}),

--- a/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
+++ b/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
@@ -2767,6 +2767,22 @@ def _close_out(a, name):
     return _cross_check(a, name, doc)
 
 
+#: Every POPULATED arm `--dump-all` renders, held where it was measured
+#: (#937). See the check at the end of the `--dump-all` block for why one
+#: shared number was never right here: `_CAP` grades whatever the cheap
+#: fixture returns, and every stage but L1 refuses there, so L2's 196-line
+#: delegated body and L5's three 161-line terminal arms had never been
+#: measured by anything.
+#:
+#: Ceilings against silent growth, not targets. An arm missing from this table
+#: FAILS, so a new one cannot arrive unmeasured.
+_ARM_CEILING = {
+    'L1': 90, 'L1 (delegated)': 90, 'L1 (inline)': 25,
+    'L2': 200, 'L2 (delegated)': 200, 'L2 (inline)': 95,
+    'L3': 75, 'L4': 45, 'L5': 40,
+    'L5 (DONE-EXHAUSTED)': 170, 'L5 (STUCK)': 170, 'L5 (BUDGET)': 170,
+}
+
 STAGES = {'L1': l1, 'L2': l2, 'L3': l3, 'L4': l4, 'L5': l5}
 TITLES = {'L1': 'place (inline or delegated)',
           'L2': 'freeze what placement decided, then route',
@@ -2910,6 +2926,7 @@ def main(argv=None):
         # opposite of what a dump is for.
         import tempfile
         refused = []
+        sizes = {}
         with tempfile.TemporaryDirectory() as tmp:
             def wrote(name, doc):
                 p = os.path.join(tmp, name)
@@ -2966,6 +2983,7 @@ def main(argv=None):
                 print(f'===== {k} =====')
                 body = STAGES[k](loose)
                 print(body)
+                sizes[k] = len(body.splitlines())
                 if body.startswith('<error>'):
                     refused.append(k)
             # Both halves can delegate, and the teammate prompts are where the
@@ -2976,6 +2994,7 @@ def main(argv=None):
                 print(f'===== {k} (delegated) =====')
                 body = STAGES[k](loose)
                 print(body)
+                sizes[f'{k} (delegated)'] = len(body.splitlines())
                 if body.startswith('<error>'):
                     refused.append(f'{k}/delegated')
             loose.delegate = False
@@ -2991,6 +3010,7 @@ def main(argv=None):
                 print(f'===== {k} (inline) =====')
                 body = STAGES[k](loose)
                 print(body)
+                sizes[f'{k} (inline)'] = len(body.splitlines())
                 if body.startswith('<error>'):
                     refused.append(f'{k}/inline')
             loose.no_delegate = False
@@ -3046,11 +3066,37 @@ def main(argv=None):
                 print(f'===== L5 ({label}) =====')
                 body = STAGES['L5'](v)
                 print(body)
+                sizes[f'L5 ({label})'] = len(body.splitlines())
                 if body.startswith('<error>'):
                     refused.append(f'L5/{label}')
+        # EVERY ARM'S SIZE, MEASURED AND HELD (#937). The `_CAP` assertion in
+        # `_self_test` measures whatever the CHEAP fixture returns, and every
+        # stage but L1 REFUSES there -- so it was grading 6-to-9-line refusals
+        # and calling them bodies. What that hid, measured here: L2 delegated
+        # is 196 lines and L5's three terminal arms are 161 each, against a
+        # "cap" of 90. Nothing in the suite had ever seen them.
+        #
+        # One number was never right for these: L2 delegates an entire half
+        # and carries its teammate's whole brief. So each arm is held where it
+        # is MEASURED, as a ceiling against silent growth rather than a target
+        # to shrink to -- and an arm with no declared ceiling fails, so a new
+        # one cannot arrive unmeasured.
+        print('\n----- populated arm sizes -----')
+        _over = []
+        for _k in sorted(sizes):
+            _ceil = _ARM_CEILING.get(_k)
+            _mark = 'ok ' if _ceil is not None and sizes[_k] <= _ceil else '!! '
+            print(f'  {_mark} {_k:<18} {sizes[_k]:>4} line(s)   ceiling '
+                  f'{_ceil if _ceil is not None else "UNDECLARED"}')
+            if _ceil is None or sizes[_k] > _ceil:
+                _over.append(f'{_k} ({sizes[_k]}, ceiling {_ceil})')
+        if _over:
+            print(f'\n!! {len(_over)} arm(s) over their ceiling or '
+                  f'undeclared: {", ".join(_over)}')
         if refused:
             print(f'\n!! {len(refused)} stage(s) dumped a REFUSAL, not their '
                   f'instructions: {", ".join(refused)}')
+        if refused or _over:
             return 1
         return 0
     if a.dump_refusals:

--- a/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
+++ b/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
@@ -300,8 +300,20 @@ def _guard_congestion(a):
     # matrix. hpwl's direction has to be checked per board, not assumed.
     # See docs/placement-calibration.md.
     b, n = float(m_base['hpwl']), float(m_now['hpwl'])
+    _cx_b = m_base.get('crossings')
+    _cx_n = m_now.get('crossings')
+    _cx = (f'    crossings  {float(_cx_b):.0f} -> {float(_cx_n):.0f}'
+           f'   [REPORTED, never gated -- non-negotiable 4]\n'
+           if isinstance(_cx_b, (int, float))
+           and isinstance(_cx_n, (int, float)) else '')
     if b <= 0:
-        return True, None
+        # PRINT, even here. This arm passed with `None` -- a baseline hpwl of
+        # 0 means the renders cannot be compared, and saying nothing is
+        # indistinguishable from saying "congestion is fine" (#937).
+        return True, (f'  CONGESTION READ: the baseline render reports hpwl '
+                      f'{b:.1f}, so no gain can be computed from it. This '
+                      f'stage is NOT telling you the placement is fine; it is '
+                      f'telling you the comparison is unavailable.\n' + _cx)
     gain = (b - n) / b
     # REPORT, do not refuse. The threshold that used to live here was withdrawn
     # on measurement (docs/placement-calibration.md): the same premise --
@@ -313,13 +325,24 @@ def _guard_congestion(a):
     # `parameter`-shaped, because every per-net test can pass on a board no
     # router can finish. That part needs no threshold.
     if gain >= _CONGESTION_RATIO:
-        return True, None
-    _cx_b = m_base.get('crossings')
-    _cx_n = m_now.get('crossings')
-    _cx = (f'  crossings  {float(_cx_b):.0f} -> {float(_cx_n):.0f}'
-           f'   [REPORTED, never gated -- non-negotiable 4]\n'
-           if isinstance(_cx_b, (int, float))
-           and isinstance(_cx_n, (int, float)) else '')
+        # PRINT THE MEASUREMENT IN THIS ARM TOO (#937). This returned
+        # `(True, None)`, so a board that PASSED the cut was waved through
+        # with the numbers on neither screen nor record -- and the crossings
+        # pair was computed only below this line, so on a passing board the
+        # one figure non-negotiable 4 says must ALWAYS be reported was never
+        # printed at all.
+        #
+        # _CONGESTION_RATIO's own comment says it "decides whether to print a
+        # warning beside the numbers -- it does NOT decide anything". That was
+        # the intent and this is what makes it true: the threshold now decides
+        # which READING accompanies the measurement, never whether the
+        # operator sees it. An instrument that withholds a measurement is not
+        # an instrument.
+        return True, (
+            f'  CONGESTION READ: hpwl {b:.1f} -> {n:.1f} '
+            f'({gain * 100:+.1f}% of the gap closed), at or above the '
+            f'{_CONGESTION_RATIO * 100:.0f}% mark where this stage stops '
+            f'asking for a disposition.\n' + _cx)
     if a.accept_congestion and str(a.accept_congestion).strip():
         return True, (
             f'  CONGESTION READ (accepted): hpwl {b:.1f} -> {n:.1f} '
@@ -334,7 +357,10 @@ def _guard_congestion(a):
         f'The congestion read says this may be PLACEMENT-shaped, and nothing '
         f'has said otherwise.\n\n'
         f'    hpwl       {b:.1f} -> {n:.1f}   ({gain * 100:+.1f}% of the gap '
-        f'closed)\n' + _cx.replace('  crossings', '    crossings') +
+        # _cx already carries the 4-space indent this block wants. It used to
+        # be built at 2 and re-indented here -- which, once the shared builder
+        # moved to 4, would have matched INSIDE its own indent and produced 6.
+        f'closed)\n' + _cx +
         f'\n'
         f'    The placement left {(1 - gain) * 100:.1f}% of the wirelength it '
         f'started with.\n'
@@ -3896,8 +3922,19 @@ def _self_test():
         out = STAGES['L4'](_args(base + ['--shape', 'parameter',
                                          '--congestion-json', _cgood,
                                          '--congestion-baseline', _cbase]))
-        want('CONGESTION READ' not in out,
-             'a healthy congestion gain adds no warning')
+        # A healthy gain adds no REFUSAL and demands no disposition -- but it
+        # does print the numbers. This used to assert `'CONGESTION READ' not
+        # in out`, which pinned the defect rather than the property: above the
+        # ratio the stage returned (True, None) and the operator saw no hpwl
+        # and no crossings at all, while _CONGESTION_RATIO's own comment
+        # claimed it only "decides whether to print a warning BESIDE the
+        # numbers" (#937).
+        want(not out.startswith('<error>') and 'CONGESTION READ' in out
+             and 'hpwl' in out,
+             'a healthy congestion gain still PRINTS the measurement')
+        want('--accept-congestion' not in out.split('CONGESTION READ')[-1]
+             .split('\n\n')[0],
+             '...and asks for no disposition, which is what the ratio decides')
         out = STAGES['L4'](_args(base + ['--shape', 'parameter',
                                          '--congestion-json', _cgood]))
         want(out.startswith('<error>') and '--congestion-baseline' in out,

--- a/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
+++ b/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
@@ -33,6 +33,11 @@ teammate; <error> you skipped evidence.
 
 Exit: 0 emitted, 2 usage, 4 a guard refused.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['combined'], 'kind': 'driver'}
+
 import argparse
 import hashlib
 import json

--- a/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
+++ b/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
@@ -1482,8 +1482,7 @@ half, and a teammate that receives an unfrozen board cannot know which poses
 were deliberate.
 
 Then delegate the routing half to a TEAMMATE of the agent type named in the
-tag below, for the same reason L1 does: it HAS the Agent tool, and the routing
-skill fans out three verification subagents at close-out. This half produces
+tag below, for the same reason L1 does: this half produces
 the most output of anything in the loop -- a route log here runs to thousands
 of lines -- and a fork does not change that: context is inherited inward, its
 output still does not come back.
@@ -1567,7 +1566,11 @@ were handed is the last thing left to compare against.
 Return, and return ONLY:
   1. confirmation that each of the four paths above exists, or WHICH does not;
   2. the PATH of every lens verdict you wrote, and the board sha each one
-     graded. Your lenses are YOUR gate while you loop; this run's --final row
+     graded -- or `none`, which is the expected answer: the routing skill
+     does NOT dispatch verification lenses, and the run-closing lenses are
+     dispatched once, by L5, on the board this loop ships. Do not invent
+     verifications to fill this line.
+     Your lenses, if you ran any, are YOUR gate while you loop; this --final row
      is recorded against the board the OUTER loop ships, and a verdict taken
      on an earlier board is history, not evidence for that row;
   3. SHAPE=<parameter|placement|floorplan>, or `none` if nothing failed;

--- a/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
+++ b/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
@@ -2543,8 +2543,13 @@ def _close_out(a, name):
 
     The asymmetry this exists to remove: L2 refuses to START routing without a
     placement close-out, while nothing ever refused to FINISH. A run reached
-    the terminal artifact having never invoked the routing half's own V1-V5 at
+    the terminal artifact having never run the routing half's own close-out at
     all, and shipped a board carrying a power-rail-to-signal short.
+
+    (This said "the routing half's own V1-V5". Those stages were a
+    `routing_driver.py` that never reached main and was removed twice; the
+    convergence loop they came from lives in references/convergence.md, and
+    the routing skill's own proof is its Step 9 plan checker. #937.)
 
     The gate is NOT "produce a document" -- a well-shaped empty one would
     satisfy that. It is that TWO INDEPENDENT INSTRUMENTS MUST NOT CONTRADICT
@@ -2794,8 +2799,8 @@ def _args(argv=None):
                          '--json`. L5 refuses without it: L2 refuses to START '
                          'routing without a placement close-out and nothing '
                          'ever refused to FINISH, so a run reached the '
-                         'terminal artifact having never entered the routing '
-                         "half's own V1-V5 loop at all.")
+                         'terminal artifact having never run the routing '
+                         "half's own close-out at all.")
     ap.add_argument('--accept-unclosed', nargs='*', action='extend',
                     metavar='CHECK', default=None,
                     help='ship with a NAMED close-out check unsatisfied: '

--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -167,27 +167,62 @@ def _p0_reading(a):
         # coincident-origin stack or a containment reads `blocking` 0 -- and
         # one tracked board does exactly that.
         b = _dig(asm, 'buildable')
+        # "[blocking 0, 1 of its 5 conjuncts]" PARSED BACKWARDS: beside a count
+        # it reads as "one of the five fired". Worse on a healthy board, where
+        # check_assembly writes the verdict as the literal string "buildable
+        # (blocking 0)" -- the line became "buildable (blocking 0)  [blocking
+        # 0, 1 of its 5 conjuncts]", whose plain reading is "buildable BECAUSE
+        # blocking is 0", the exact inference #918 exists to kill.
         rows.append('  check_assembly  : '
                     + str(_dig(asm, 'verdict') or 'no verdict recorded')
-                    + (f'   [blocking {_dig(asm, "blocking")}, 1 of its 5 '
-                       f'conjuncts]' if _dig(asm, 'blocking') is not None
-                       else ''))
+                    + (f'   (blocking {_dig(asm, "blocking")} is only ONE of '
+                       f'the five conjuncts this verdict is made of -- act on '
+                       f'the verdict, never on the count)'
+                       if _dig(asm, 'blocking') is not None else ''))
         oob = _dig(asm, 'oob_pad_copper_count')
         if isinstance(oob, int) and oob > 0:
+            # NAME THE PARTS: a count is not something a reader can act on,
+            # which is the argument the off-outline refusal itself makes, and
+            # the refs sit one key away in the same document.
+            _refs = [r[0] if isinstance(r, (list, tuple)) else r
+                     for r in (_dig(asm, 'oob_pad_copper_refs') or [])]
             rows.append(f'  ...and PAD COPPER OFF THE OUTLINE on {oob} '
-                        f'part(s) -- the top-priority placement defect, '
-                        f'because those nets cannot be routed at all')
+                        f'part(s): '
+                        + (', '.join(str(r) for r in _refs[:8]) or
+                           'see oob_pad_copper_refs'))
+            # ...and give it a row. The five-row table below has none for this
+            # finding, so a board with drc 0 + buildable true + copper off the
+            # outline landed on "both clean -> hand it to routing and stop",
+            # carrying the defect that produces 100% of unrouted nets.
+            rows.append('                    This OUTRANKS every row below: '
+                        'those nets cannot be routed at all. Re-seat them '
+                        '(P2 -> P3) before you classify. If they are '
+                        'castellations or a declared card edge, the crossing '
+                        'is by design -- say so and carry on.')
     clash = ''
     if isinstance(v, int) and isinstance(b, bool) and (v == 0) != b:
-        clash = ('\nTHE TWO DISAGREE: one reads clean and the other does not. '
-                 'Say which you are acting on, and why, before you move a '
-                 'part.\n')
+        clash = (f'\nTHE TWO DISAGREE: check_drc reads {v} violation(s) and '
+                 f'check_assembly reads '
+                 f'{"buildable" if b else "NOT BUILDABLE"}. Say which you are '
+                 f'acting on, and why, before you move a part.\n')
+    elif a.assembly_json and b is None:
+        clash = ('\nThat assembly document carries no `buildable` field, so '
+                 'the two could not be compared. Treat the VERDICT string '
+                 'above as authoritative.\n')
+    # "dispose of any disagreement above" used to print even when nothing
+    # disagreed -- and a reader hunting for the disagreement they were told to
+    # dispose of finds `NOT BUILDABLE` beside `blocking 0` and "resolves" it by
+    # trusting the count. Only ask when there is something to ask about.
     return ('\nWHAT THE INSTRUMENTS SAY about the files you named -- the row '
             'is still yours to pick:\n\n' + '\n'.join(rows) + '\n' + clash +
-            '\nNeither document can tell you whether this board is UNPLACED '
-            'or whether it CARRIES COPPER: no pose census and no track count '
-            'is in either. Those two rows need py_tools/board_brief.py.\n\n'
-            'Name your row, and dispose of any disagreement above.\n')
+            '\nNeither document says whether this board is UNPLACED or '
+            'whether it CARRIES COPPER. Both are in one more command:\n'
+            '  python3 -X utf8 py_tools/board_brief.py ' + str(a.board) +
+            ' --json wk/brief0.json\n'
+            'Read `unplaced` / `partially_unplaced` for the first, and '
+            '`has_copper` / `segments` / `vias` for the second.\n\n'
+            + ('Name your row, and dispose of the disagreement above.\n'
+               if clash else 'Name your row.\n'))
 
 
 def p0(a):
@@ -1111,7 +1146,26 @@ def _guard_render(a):
     # So this gate binds on the per-pad list and NAMES THE PARTS, because a
     # count is not something you can act on and the refusal exists to be acted
     # on.
+    # THE BY-DESIGN ESCAPE (#937). This census is per-pad against the real
+    # outline with NO exemption for castellations, card edges or a declared
+    # `edge_connectors` band -- and this skill says elsewhere that a
+    # castellated pad is centred ON the outline and such parts are MEANT to
+    # cross it. Without an escape the refusal ordered a reader to drag a
+    # mating connector inboard, which breaks the thing the board exists to
+    # mate with, and no flag could clear it.
+    #
+    # A REASON IS REQUIRED, like every other waiver here: `--waive
+    # off-outline:` with nothing after it is refused rather than honoured,
+    # because a waiver with no reason is a flag that makes a gate disappear.
+    _oobw = _waiver_for(a, 'off-outline')
+    if _oobw == '':
+        return False, ('--waive off-outline needs a REASON after the colon: '
+                       'which refs are by design, and to what mating '
+                       'standard. A waiver with no reason is a flag that '
+                       'makes the gate disappear.')
     _oob = (chk.get('a_off_outline') or {}).get('pad_copper')
+    if _oobw:
+        _oob = None
     if isinstance(_oob, list) and _oob:
         _refs = []
         for _it in _oob:
@@ -1125,8 +1179,19 @@ def _guard_render(a):
             f'one-for-one into `unrouted` and `broken` -- measured, run 10: 11 '
             f'such parts produced ALL 13 unrouted nets and most of the 37 '
             f'broken ones. It is the top-priority placement defect, ahead of '
-            f'every clearance graze.\n\nMove those parts back inside the '
-            f'outline and re-render. The outline is not yours to change.\n\n'
+            f'every clearance graze.\n\nUNLESS THE CROSSING IS BY DESIGN. A '
+            f'castellated row, a card edge and a declared `edge_connectors` '
+            f'part are all MEANT to cross the boundary -- this census has no '
+            f'exemption for them, so it names them too. If that is what these '
+            f'are, declare them in the intent\'s `edge_connectors` and re-run '
+            f'this stage with --waive off-outline:<the refs and the mating '
+            f'standard>. Do not move a connector inboard to satisfy a gate; '
+            f'that breaks the thing the board exists to mate with.\n\n'
+            f'Otherwise RE-SEAT them -- by net centroid, not back to an old '
+            f'pose (the objective is a board that routes, not a board '
+            f'restored):\n  python3 -X utf8 py_placer/place_seed.py <board> '
+            f'<out> --intent <intent> --reseat --clearance <the floor>\n'
+            f'The outline itself is never yours to change.\n\n'
             f'This is the per-PAD measure, not check_assembly\'s '
             f'`oob_pad_count`, which is a part-level AABB inflated by the '
             f'clearance and reads non-zero on human boards whose pads are '
@@ -2035,6 +2100,16 @@ def _refusal_scenarios(tmp):
                                               {'reference': 'J2'}],
                                'courtyard': []},
              'd_moved': {'moved': 3, 'expected': None, 'match': None}})]),
+        # ...and the by-design escape WITHOUT its reason (#937). The waiver
+        # exists because a castellated row or a card edge is meant to cross
+        # the outline and this census has no exemption for one; a waiver with
+        # no reason is refused rather than honoured.
+        ('an off-outline waiver with no reason', with_before
+         + ['--waive', 'off-outline:',
+            '--render-json', render(name='r_oobw.json', checklist={
+                'a_off_outline': {'pad_copper': [{'reference': 'J9'}],
+                                  'courtyard': []},
+                'd_moved': {'moved': 1, 'expected': None, 'match': None}})]),
         # ...and the same list carrying no `reference`, which is the arm that
         # falls back to naming the key. Without this row that fallback is a
         # branch nothing renders -- exactly what --dump-refusals exists to say.

--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -2647,6 +2647,27 @@ def _self_test():
                  '--waive', 'congestion:spent']))
             want(out.startswith('<error>') and _want in out,
                  f'a render whose review sheet is {_val!r} is refused')
+        # PAD COPPER OFF THE OUTLINE -- the top-priority placement defect, and
+        # the one this door did not check at all until #936. Held here rather
+        # than only by --dump-refusals: blinding the read left the driver's own
+        # self-test green, which a battery row measured as a SURVIVOR.
+        _rj = dict(_r15)
+        _rj['review_sheet'] = _sheet_file
+        _rj['checklist'] = dict(_rj.get('checklist') or {})
+        _rj['checklist']['a_off_outline'] = {
+            'pad_copper': [{'reference': 'U7'}, {'reference': 'J2'}],
+            'courtyard': []}
+        out = STAGES['P-close'](_args(
+            ['--board', _pb, '--before', _pa,
+             '--render-json', _wr('rs_oob.json', _rj),
+             '--intent-json', _wr('is_oob.json', _covered([], brief=None)),
+             '--congestion-before', _wr('rs_oob2.json', _dmg),
+             '--waive', 'congestion:spent']))
+        want(out.startswith('<error>') and 'PAD COPPER outside' in out
+             and 'U7' in out,
+             'a render naming parts with pad copper off the outline is refused,'
+             ' and the refusal names them')
+
         _rj = dict(_r15)
         _rj['review_sheet'] = _sheet_file
         out = STAGES['P-close'](_args(

--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -24,6 +24,11 @@ Output carries exactly three tags:
 
 Exit: 0 emitted, 2 usage, 4 a guard refused.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement'], 'kind': 'driver'}
+
 import argparse
 import json
 import os

--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -127,6 +127,69 @@ Next: python3 -X utf8 {sys.argv[0]} --stage P0 --board {a.board}
 </stage_instructions>'''
 
 
+def _p0_reading(a):
+    """What the two instruments SAY, once they have been produced (#937).
+
+    P0 asks the reader to "say which row you are in" over a five-row table
+    whose first and fourth rows are arithmetic on two numbers this stage's own
+    flags already name -- and P0 never opened either file. Judgement spent on
+    arithmetic is judgement not spent on the board, so the driver does the
+    arithmetic and the reader disposes.
+
+    WHAT IT DOES NOT DO IS PICK THE ROW. Two of the five -- `unplaced` and
+    `board carries copper` -- are not derivable from these documents at all
+    (P1's own text says an exit code does not test placedness, and neither
+    file carries a track or via count), so a driver that announced a row would
+    be announcing one it cannot see. It reports what each instrument reads and
+    NAMES what it cannot.
+
+    Returns '' when neither document was supplied -- the first-entry case,
+    where there is nothing to read yet.
+    """
+    if not a.drc_json and not a.assembly_json:
+        return ''
+    drc = _load(a.drc_json, 'drc')[0] if a.drc_json else None
+    asm = _load(a.assembly_json, 'assembly')[0] if a.assembly_json else None
+    rows, v, b = [], None, None
+    if a.drc_json:
+        v = _dig(drc, 'violations')
+        if v is None:
+            v = _dig(drc, 'total_violations')
+        if isinstance(v, list):
+            v = len(v)
+        rows.append('  check_drc       : ' + (
+            f'{v} violation(s) on the copper-free board'
+            if isinstance(v, int) else
+            f'NO violation count in {a.drc_json} -- that file answers nothing'))
+    if a.assembly_json:
+        # THE VERDICT, not `blocking`. Since #918 `blocking` is one of five
+        # not_buildable conjuncts, so a board unbuildable through a
+        # coincident-origin stack or a containment reads `blocking` 0 -- and
+        # one tracked board does exactly that.
+        b = _dig(asm, 'buildable')
+        rows.append('  check_assembly  : '
+                    + str(_dig(asm, 'verdict') or 'no verdict recorded')
+                    + (f'   [blocking {_dig(asm, "blocking")}, 1 of its 5 '
+                       f'conjuncts]' if _dig(asm, 'blocking') is not None
+                       else ''))
+        oob = _dig(asm, 'oob_pad_copper_count')
+        if isinstance(oob, int) and oob > 0:
+            rows.append(f'  ...and PAD COPPER OFF THE OUTLINE on {oob} '
+                        f'part(s) -- the top-priority placement defect, '
+                        f'because those nets cannot be routed at all')
+    clash = ''
+    if isinstance(v, int) and isinstance(b, bool) and (v == 0) != b:
+        clash = ('\nTHE TWO DISAGREE: one reads clean and the other does not. '
+                 'Say which you are acting on, and why, before you move a '
+                 'part.\n')
+    return ('\nWHAT THE INSTRUMENTS SAY about the files you named -- the row '
+            'is still yours to pick:\n\n' + '\n'.join(rows) + '\n' + clash +
+            '\nNeither document can tell you whether this board is UNPLACED '
+            'or whether it CARRIES COPPER: no pose census and no track count '
+            'is in either. Those two rows need py_tools/board_brief.py.\n\n'
+            'Name your row, and dispose of any disagreement above.\n')
+
+
 def p0(a):
     """Decide whether to touch the placement at all."""
     return f'''<stage_instructions stage="P0" name="gate" of="{len(STAGES)}">
@@ -161,6 +224,7 @@ the board declared nothing and the number is a fallback, not agreement.
 Every violation a COPPER-FREE board returns is a placement defect that no
 router can remove.
 
+{_p0_reading(a)}
 Then classify by what you MEASURED, and say which row you are in:
 
   both clean                  -> the placement is fit. Do not run a pass over
@@ -935,11 +999,25 @@ def _guard_damage(a):
             '--json wk/drc0.json')
     if isinstance(count, int) and count == 0:
         asm, _ = _load(a.assembly_json, 'assembly')
+        # THE VERDICT, not `blocking` (#937). `blocking` is ONE of
+        # check_assembly's five not_buildable conjuncts since #918, so a board
+        # unbuildable through a coincident-origin stack, a containment, copper
+        # on a locked part or a moved-vs-baseline courtyard gate reads
+        # `blocking` 0 -- and then this guard told the reader there was "no
+        # damage for this stage to repair" about a board its own instrument
+        # had just graded NOT BUILDABLE. One tracked board is exactly that
+        # case. `buildable` is the field that answers the question this guard
+        # is asking; `blocking` is the fallback for a document old enough not
+        # to carry it.
+        buildable = _dig(asm, 'buildable') if asm else None
         blocking = _dig(asm, 'blocking') if asm else None
-        if not blocking:
+        undamaged = (not blocking) if buildable is None else bool(buildable)
+        if undamaged:
             return False, (
-                'The copper-free board reports 0 violations and no blocking '
-                'assembly pair. There is no damage for this stage to repair, '
+                'The copper-free board reports 0 violations and '
+                + ('an assembly verdict of buildable'
+                   if buildable is not None else 'no blocking assembly pair')
+                + '. There is no damage for this stage to repair, '
                 'and running a placement search on a legal board makes it '
                 'worse (measured).\n\nIf you want a different ARRANGEMENT '
                 'rather than a repair, that is --stage P5. If you were '
@@ -1908,8 +1986,19 @@ def _refusal_scenarios(tmp):
         ('a DRC json that measures nothing', base
          + ['--drc-json', wrote('bare.json', {'schema': 1})]),
         ('a JSON file that does not parse', base + ['--drc-json', unreadable]),
+        # BOTH ARMS of the no-damage refusal (#937). The first has no
+        # assembly document at all, so the guard falls back to `blocking`;
+        # the second supplies a verdict, which is the field it now reads --
+        # `blocking` is 1 of check_assembly's 5 not_buildable conjuncts since
+        # #918, so a board can be NOT BUILDABLE at blocking 0 and this guard
+        # used to call that "no damage to repair".
         ('a board with no damage to repair', base
          + ['--drc-json', wrote('clean.json', {'violations': 0})]),
+        ('a board the assembly verdict calls buildable', base
+         + ['--drc-json', wrote('clean2.json', {'violations': 0}),
+            '--assembly-json', wrote('asm_ok.json',
+                                     {'buildable': True, 'blocking': 0,
+                                      'verdict': 'buildable (blocking 0)'})]),
         # P3's lock advice
         ('no lock advice', base + damaged),
         ('unlocked_high with nothing waived', base + damaged

--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -1013,14 +1013,17 @@ def _guard_render(a):
     # THE CHANNEL MATTERS, and it is not the one the loop uses. l2 reads
     # `oob_pad_count` out of check_assembly's report, which is a part-level pad
     # AABB inflated by the grading clearance -- its own `oob_pad_basis` string
-    # says so and points here instead. Measured over the 22 tracked boards:
-    # that count is non-zero on three, and on two of them -- glasgow_revC (SW1,
-    # 0.03mm) and watchy (SW1-SW4, 0.17mm each), both human-designed reference
-    # boards with edge-mounted switches -- this per-PAD measure reports an
-    # EMPTY list. The AABB fires on the bounding box of an edge part; the pads
-    # are on the board. Gating on that count would refuse two human boards on a
-    # measurement artifact, which is why CLAUDE.md names this key and adds "a
-    # whole-board pass/fail verdict is the wrong channel for it".
+    # says so and points here instead. Measured over every tracked board: that
+    # count is non-zero on three, and on two of them -- both human-designed
+    # reference boards carrying edge-mounted switches, at 0.03mm and 0.17mm --
+    # this per-PAD measure reports an EMPTY list. The AABB fires on the
+    # bounding box of an edge part; the pads are on the board. Gating on that
+    # count would refuse two human boards on a measurement artifact, which is
+    # why CLAUDE.md names this key and adds "a whole-board pass/fail verdict is
+    # the wrong channel for it". (The boards are named in the PR that added
+    # this, not here: a skill that names corpus boards is what
+    # tests/test_run8_skills_generic.py refuses, because guidance written
+    # around one board stops being guidance.)
     #
     # So this gate binds on the per-pad list and NAMES THE PARTS, because a
     # count is not something you can act on and the refusal exists to be acted

--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -1507,6 +1507,21 @@ def _guard_congestion(a):
     return _tail()
 
 
+#: Every stage's POPULATED body, held where it was measured (#937).
+#:
+#: Not one shared number: the 80-line assertion in `_self_test` measures
+#: whatever the CHEAP fixture returns, so a stage that refuses there is
+#: measured as its 3-line refusal and its instructions were never seen at all.
+#: P4's 98 passed that way. These are the real figures, and they are ceilings
+#: rather than targets -- their job is to stop silent growth, and raising one
+#: is a deliberate edit here with a reason beside it.
+#:
+#: P4 is over the 80-line norm and pinned at what it is: the structural
+#: finding is that its body holds FIVE VERBS (measure, act, prove, record,
+#: loop), so the remedy is a split, not a trim.
+_BODY_CEILING = {'P-brief': 60, 'P0': 70, 'P1': 35, 'P2': 45, 'P3': 80,
+                 'P4': 100, 'P5': 45, 'P6': 30, 'P-close': 60}
+
 STAGES = {
     'P-brief': p_brief,
     'P0': p0, 'P1': p1, 'P2': p2, 'P3': p3, 'P4': p4, 'P5': p5, 'P6': p6,
@@ -2276,18 +2291,36 @@ def _self_test():
                  f'{_k} counts the stages the registry has '
                  f'({_m.group(1) if _m else "no of= tag in its body"})')
 
-        # THE BODY LENGTHS, out loud. The cap above measures whichever arm the
-        # cheap fixture produces, so for a stage that refuses there it has
-        # never seen the instructions at all. These are the real numbers; P4 is
-        # over the 80-line norm today and trimming it is an editorial job, not
-        # a fact fix, so this reports rather than refuses. Reported > silent:
-        # a number nobody prints is a number nobody argues with.
+        # THE BODY LENGTHS, out loud -- AND HELD (#937). The cap above
+        # measures whichever arm the CHEAP fixture produces, so for a stage
+        # that refuses there it has never seen the instructions at all: P4's
+        # 98 lines passed that assertion as a 3-line refusal, and P3 at 79 sits
+        # in the same blind spot one line under the line.
+        #
+        # Reporting alone was the previous answer and it is not enough: a
+        # number nobody can exceed is a number nobody has to argue with, and
+        # over this PR P0 grew by 10 with nothing to notice. So every stage is
+        # now held at a MEASURED ceiling rather than at one shared number.
+        #
+        # A ceiling, not a target: it exists to stop silent growth, and moving
+        # one is a deliberate edit here with a reason. P4 is over the 80-line
+        # norm and is pinned at what it is, because trimming it is an
+        # editorial job -- and the structural finding is that its 98 lines are
+        # FIVE VERBS (measure, act, prove, record, loop), so the fix is a split
+        # rather than a trim.
         _over = {k: len(v.splitlines()) for k, v in _bodies.items()}
         print('  NOTE  stage body lines: '
               + ', '.join(f'{k} {v}' for k, v in _over.items())
               + f" -- over the 80-line norm: "
               + (', '.join(f'{k} ({v})' for k, v in _over.items() if v > 80)
                  or 'none'))
+        for _k, _n in sorted(_over.items()):
+            _ceil = _BODY_CEILING.get(_k)
+            want(_ceil is not None,
+                 f'{_k} declares a body ceiling (a new stage must)')
+            if _ceil is not None:
+                want(_n <= _ceil,
+                     f'{_k} body is {_n} line(s), ceiling {_ceil}')
 
         _checked = 0
         for key, _body in _bodies.items():

--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -999,6 +999,52 @@ def _guard_render(a):
             'outline, is any part on any other part, is any part on a hole or a '
             'locked part, and did more parts move than the step claimed.\n\n'
             'Re-render with --json-out.')
+    # PAD COPPER OFF THE OUTLINE -- the top-priority placement defect, and
+    # until now checked at ONE of the three doors.
+    #
+    # `loop_driver.l2` refuses a board on it (measured, its own comment:
+    # "`oob_pad_count` alone refuses 24, of which 12 are refusals `blocking`
+    # misses"), and nothing in this file did -- so the same board closed out
+    # clean through the placement door and was refused through the loop.
+    # CLAUDE.md: "A part whose pad copper lies outside the outline is the
+    # top-priority placement defect... Measured, run 10: 11 such parts produced
+    # ALL 13 unrouted nets and most of the 37 broken ones."
+    #
+    # THE CHANNEL MATTERS, and it is not the one the loop uses. l2 reads
+    # `oob_pad_count` out of check_assembly's report, which is a part-level pad
+    # AABB inflated by the grading clearance -- its own `oob_pad_basis` string
+    # says so and points here instead. Measured over the 22 tracked boards:
+    # that count is non-zero on three, and on two of them -- glasgow_revC (SW1,
+    # 0.03mm) and watchy (SW1-SW4, 0.17mm each), both human-designed reference
+    # boards with edge-mounted switches -- this per-PAD measure reports an
+    # EMPTY list. The AABB fires on the bounding box of an edge part; the pads
+    # are on the board. Gating on that count would refuse two human boards on a
+    # measurement artifact, which is why CLAUDE.md names this key and adds "a
+    # whole-board pass/fail verdict is the wrong channel for it".
+    #
+    # So this gate binds on the per-pad list and NAMES THE PARTS, because a
+    # count is not something you can act on and the refusal exists to be acted
+    # on.
+    _oob = (chk.get('a_off_outline') or {}).get('pad_copper')
+    if isinstance(_oob, list) and _oob:
+        _refs = []
+        for _it in _oob:
+            _r = _it.get('reference') if isinstance(_it, dict) else _it
+            if _r and str(_r) not in _refs:
+                _refs.append(str(_r))
+        return False, (
+            f'{len(_oob)} part(s) carry PAD COPPER outside the board outline: '
+            f'{", ".join(_refs) or "see checklist.a_off_outline.pad_copper"}.'
+            f'\n\nThose nets cannot be routed at all, so this converts '
+            f'one-for-one into `unrouted` and `broken` -- measured, run 10: 11 '
+            f'such parts produced ALL 13 unrouted nets and most of the 37 '
+            f'broken ones. It is the top-priority placement defect, ahead of '
+            f'every clearance graze.\n\nMove those parts back inside the '
+            f'outline and re-render. The outline is not yours to change.\n\n'
+            f'This is the per-PAD measure, not check_assembly\'s '
+            f'`oob_pad_count`, which is a part-level AABB inflated by the '
+            f'clearance and reads non-zero on human boards whose pads are '
+            f'fine.')
     d = chk.get('d_moved') or {}
     if d.get('match') is False:
         return False, (
@@ -1871,6 +1917,20 @@ def _refusal_scenarios(tmp):
          + ['--render-json', render(name='r_other.json', of=other)]),
         ('a render with no checklist', with_before
          + ['--render-json', render(name='r_nochk.json', checklist=_DROP)]),
+        ('a render naming parts with pad copper off the outline', with_before
+         + ['--render-json', render(name='r_oob.json', checklist={
+             'a_off_outline': {'pad_copper': [{'reference': 'U7'},
+                                              {'reference': 'J2'}],
+                               'courtyard': []},
+             'd_moved': {'moved': 3, 'expected': None, 'match': None}})]),
+        # ...and the same list carrying no `reference`, which is the arm that
+        # falls back to naming the key. Without this row that fallback is a
+        # branch nothing renders -- exactly what --dump-refusals exists to say.
+        ('a render with off-outline pad copper it cannot attribute', with_before
+         + ['--render-json', render(name='r_oob_anon.json', checklist={
+             'a_off_outline': {'pad_copper': [{'amount_mm': 1.2}],
+                               'courtyard': []},
+             'd_moved': {'moved': 3, 'expected': None, 'match': None}})]),
         ('a render that disagrees on the move count', with_before
          + ['--render-json', render(name='r_moved.json', checklist={
              'd_moved': {'moved': 9, 'expected': 3, 'match': False}})]),

--- a/.claude/skills/plan-pcb-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-routing/SKILL.md
@@ -2650,6 +2650,26 @@ A per-board plan file that ever gets improved (a better recipe found on a
 later pass) should be REGENERATED through this skill, not hand-patched —
 the skill is the tuner; the plan file is its output.
 
+### Then PROVE it, before you run it
+
+```bash
+python3 -X utf8 .claude/skills/plan-pcb-routing/scripts/route_plan_check.py <board>_plan.sh --board board.kicad_pcb
+```
+
+Read-only, no model in the loop. It evaluates the rules of this skill that a
+recorded chain can answer — the chain ends on `route.py`, verification is
+commented rather than executable, no pipes, Step 5b's two net-coverage
+`assert`s, the cap pass after every fanout — and REFUSES BY NAME, citing the
+line here each rule comes from, so you can argue with it at its source.
+
+Exit 0 checked and clean, 2 usage, 3 the plan could not be read, 4 a rule
+failed. A refusal is not a malfunction: fix the plan, do not run it.
+
+It also PRINTS what it cannot decide, with the tool that owns each — nine
+rules need a routed board or a finished run, and an unchecked rule that says
+so is honest where a silently absent one is not. `--list` shows both sets
+without reading a plan.
+
 ### Stop conditions
 
 There are four, they are listed in `.claude/skills/plan-pcb-placement-and-routing/SKILL.md`

--- a/.claude/skills/plan-pcb-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-routing/SKILL.md
@@ -58,25 +58,33 @@ lies outside the outline converts one-for-one into unrouted and broken nets,
 because its nets cannot be routed at all.
 
 ```bash
+mkdir -p wk        # neither tool creates it, and both write into it
 python3 -X utf8 py_tools/check_assembly.py board.kicad_pcb --json wk/assembly0.json
 python3 -X utf8 .claude/skills/plan-pcb-placement-and-routing/scripts/board_score.py board.kicad_pcb --json wk/score0.json --quiet
 ```
 
-Read the VERDICT line, **not** `blocking == 0`: `blocking` is one of five
-conjuncts `check_assembly` decides on, so a board unbuildable through a
+**What each one is for.** `check_assembly` decides this gate: read its
+`VERDICT:` line, **not** `blocking == 0`. `blocking` is one of the five
+conjuncts that verdict is made of, so a board unbuildable through a
 coincident-origin stack or a containment reads `blocking` 0 and is still NOT
-BUILDABLE.
+BUILDABLE. `board_score` decides NOTHING here — record its `unrouted` and
+`broken` counts as the BASELINE you will compare the routed board against at
+the end of the chain.
+
+Classify from the JSON fields, not from exit status: `check_assembly` exits 4
+for any of its five conjuncts and its VERDICT line already says which one.
 
 - **NOT BUILDABLE** -> stop. This is placement work. Use `/plan-pcb-placement`
   for the placement half alone, or `/plan-pcb-placement-and-routing` when the
   board needs both.
 - **buildable** -> go to Step 1.
 
-**Arriving from the loop, this gate is already satisfied -- say so rather than
-re-deriving it.** `/plan-pcb-placement-and-routing` runs these same instruments
-at L2 before it hands the board over, and its placement close-out is the
-evidence. Re-running them costs seconds and is never wrong; skipping the gate
-because "the loop must have done it" is.
+**Run both commands every time.** They cost seconds. When you arrive from
+`/plan-pcb-placement-and-routing`, its L2 stage has already run these same two
+instruments before handing the board over — so ALSO quote that placement
+close-out beside your own reading, and the gate is shown satisfied twice rather
+than assumed once. Never skip the commands on the grounds that the loop must
+have run them.
 
 ## Step 1: Load and Analyze PCB Structure
 
@@ -2656,14 +2664,20 @@ the skill is the tuner; the plan file is its output.
 python3 -X utf8 .claude/skills/plan-pcb-routing/scripts/route_plan_check.py <board>_plan.sh --board board.kicad_pcb
 ```
 
-Read-only, no model in the loop. It evaluates the rules of this skill that a
-recorded chain can answer — the chain ends on `route.py`, verification is
-commented rather than executable, no pipes, Step 5b's two net-coverage
-`assert`s, the cap pass after every fanout — and REFUSES BY NAME, citing the
-line here each rule comes from, so you can argue with it at its source.
+Read-only, no model in the loop. It evaluates **seventeen** rules of this
+skill that a recorded chain can answer, and REFUSES BY NAME, citing the
+SECTION here each rule comes from so you can argue with it at its source.
 
-Exit 0 checked and clean, 2 usage, 3 the plan could not be read, 4 a rule
-failed. A refusal is not a malfunction: fix the plan, do not run it.
+**Run `--list` BEFORE you author the plan**, not after it is refused — it
+prints all seventeen in a few lines. The five that bite most often are: the
+chain ends on `route.py`, verification is commented rather than executable,
+no pipes, Step 5b's two net-coverage `assert`s, and one cap pass after the
+last fanout.
+
+Exit **0** checked and clean — proceed. **1** the checker itself crashed:
+nothing was proved, so fix the crash and do NOT run the plan. **2** usage.
+**3** the plan could not be read. **4** a rule failed. A refusal is not a
+malfunction: fix the plan, do not run it.
 
 It also PRINTS what it cannot decide, with the tool that owns each — nine
 rules need a routed board or a finished run, and an unchecked rule that says
@@ -2726,8 +2740,14 @@ Lessons from a dry-run audit (an agent following this skill end-to-end):
 3. **Fanout `--layers` must EXCLUDE any layer carrying a solid plane**
    (e.g. the In1 GND plane) — escapes on the solid plane shred it, and
    the fanout does not avoid poured layers on its own.
-4. **The route flag is `--no-bga-zones` (plural).** The singular spelling
-   fails argparse.
+4. **Write `--no-bga-zones` (plural) everywhere.** Not because the singular
+   fails — measured, every one of `route.py`, `route_diff.py`,
+   `route_planes.py` and `repair_planes.py` ACCEPTS `--no-bga-zone` too, three
+   by an explicit alias and `route_diff` by argparse prefix matching. This
+   rule used to say the singular "fails argparse", which is false on all four
+   and made the twelve singular spellings in the body below look like bugs.
+   One spelling everywhere is still worth having; it is a consistency rule,
+   not a correctness one.
 5. **No pipes in the emitted plan.sh.** `2>&1 | tee ...` is for
    interactive runs only — `manifest_to_plan.py` tokenizes pipe segments
    into net globs and corrupts the JSON. Plain redirects or nothing.

--- a/.claude/skills/plan-pcb-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-routing/SKILL.md
@@ -7,6 +7,77 @@ description: Analyzes a KiCad PCB file and creates a comprehensive routing plan.
 
 When this skill is invoked with a KiCad PCB file, perform a comprehensive analysis and present a routing plan to the user.
 
+## How to run this skill
+
+**Step 0 first, always.** Then Step 1 onward in order, and Step 9 last: it
+emits the plan as an executable artifact and then PROVES it, with a checker
+that refuses by name rather than a paragraph you are trusted to have read.
+
+There is no driver here, and that is deliberate. The placement half stages its
+work behind one because the AI is deciding there and a refusal is what keeps a
+decision honest. Routing's failure mode is different -- the CHAIN being wrong,
+not a judgement being wrong -- so what this half needs is a checker over the
+plan, and it gets one. Placement stages encode a decision order over levers
+and are stable; routing stages encode the copper chain, which the engine moves
+underneath them.
+
+### Who is in the seat here
+
+**In the routing half, YOU PLAN and the scripts EXECUTE.** You choose the
+chain, the nets and the parameters, and you read the failures; `route.py` and
+its siblings lay the copper. You do not hand-place copper, and you do not work
+around a checker that refuses.
+
+That is the opposite of the placement half, where YOU DECIDE -- which parts
+move, where, and why -- and the scripts legalize and measure. The test for
+which mode you are in: **if the work replays from a recorded command list
+without judgement, it is script work.** Routing passes it, which is why every
+run here leaves a `redo_commands.sh` that replays with no model in the loop.
+Placement cannot, and does not pretend to.
+
+The tools are of two kinds, and the difference decides how you use one:
+
+| | **ACTOR** | **INSTRUMENT** |
+|---|---|---|
+| what it does | changes the board | says what is wrong with it |
+| here | `route.py`, `route_diff.py`, `route_planes.py`, `repair_planes.py`, `bga_fanout.py`, `qfn_fanout.py` | `check_connected.py`, `check_drc.py`, `check_complete.py`, `board_score.py`, `check_weird.py`, `check_cycles.py` |
+| how you use it | name it in the plan and let it run | run it -- never optional |
+
+Every runnable tool in this clone declares which door it serves and which of
+those two kinds it is. The routing door's own view, with each tool's purpose:
+
+```bash
+python3 -X utf8 krt_registry.py --door routing
+```
+
+## Step 0: the placement gate -- is this board ready to route?
+
+**Measure first, then decide.** A board whose parts are in the wrong places is
+not a routing problem and no router setting fixes it: a part whose pad copper
+lies outside the outline converts one-for-one into unrouted and broken nets,
+because its nets cannot be routed at all.
+
+```bash
+python3 -X utf8 py_tools/check_assembly.py board.kicad_pcb --json wk/assembly0.json
+python3 -X utf8 .claude/skills/plan-pcb-placement-and-routing/scripts/board_score.py board.kicad_pcb --json wk/score0.json --quiet
+```
+
+Read the VERDICT line, **not** `blocking == 0`: `blocking` is one of five
+conjuncts `check_assembly` decides on, so a board unbuildable through a
+coincident-origin stack or a containment reads `blocking` 0 and is still NOT
+BUILDABLE.
+
+- **NOT BUILDABLE** -> stop. This is placement work. Use `/plan-pcb-placement`
+  for the placement half alone, or `/plan-pcb-placement-and-routing` when the
+  board needs both.
+- **buildable** -> go to Step 1.
+
+**Arriving from the loop, this gate is already satisfied -- say so rather than
+re-deriving it.** `/plan-pcb-placement-and-routing` runs these same instruments
+at L2 before it hands the board over, and its placement close-out is the
+evidence. Re-running them costs seconds and is never wrong; skipping the gate
+because "the loop must have done it" is.
+
 ## Step 1: Load and Analyze PCB Structure
 
 ```python

--- a/.claude/skills/plan-pcb-routing/scripts/route_plan_check.py
+++ b/.claude/skills/plan-pcb-routing/scripts/route_plan_check.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+"""Prove a routing plan before it runs. Read-only, no model in the loop.
+
+    python3 -X utf8 route_plan_check.py <board>_plan.sh
+    python3 -X utf8 route_plan_check.py <run dir> --board board.kicad_pcb
+    python3 -X utf8 route_plan_check.py <plan> --list
+
+Exit: 0 checked and clean, 1 crash, 2 usage, 3 the plan could not be read,
+4 a rule failed. Deliberately the fail-closed dialect `board_score.py` uses --
+1 is a CRASH, never a finding, so a traceback can never read as a verdict.
+
+WHY A CHECKER AND NOT A DRIVER
+-------------------------------
+The placement half stages its work behind a driver because the AI is DECIDING
+there, and a refusal is the mechanism that keeps a decision honest. Routing's
+failure mode is different: the CHAIN is wrong, not a judgement. A chain is a
+recorded artifact, so it can be PROVED instead of supervised -- which is also
+the only thing that works at the standalone door, where `/plan-pcb-routing`
+runs under `ai_backend.ANALYSIS_CONSTRAINT` ("analysis and planning only: do
+not execute any routing commands and do not modify any files") and a stage
+driver could not run at all.
+
+WHAT IT READS, AND WHY NOT THE CONVERTED PLAN
+----------------------------------------------
+`make_plan.plan_commands` -> `redo_stress_test.parse_manifest`: every recorded
+command, in file order, nothing pruned. NOT `plan_steps_from_manifest`, which
+is the GUI conversion and drops exactly what these rules are about -- measured
+on a skill-compliant plan, the converted steps see 0 of the three verification
+commands, 0 of the `cd`/`cp` lines, and cannot tell `route_planes` from
+`repair_planes` (both become one action). Its pruner can also nominate a
+RETRY as the chain end, which would make the "ends on route.py" rule grade a
+chain the file does not describe.
+
+Two rules need the file TEXT rather than the commands, because they are about
+what appears as a COMMENT, and `parse_manifest` drops comments: a compliant
+plan and a plan with no verification at all are identical to it.
+
+WHAT IT DOES NOT CHECK, AND WHO DOES
+--------------------------------------
+Nine rules in the skill need a routed board or a completed run. They are
+listed by `--list` with the tool that owns each, and printed at the end of
+every run. An unchecked rule that says so is honest; one that is silently
+absent is the failure this whole issue is about.
+"""
+import argparse
+import os
+import re
+import sys
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing', 'combined'], 'kind': 'instrument'}
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(HERE))))
+for _d in (ROOT, os.path.join(ROOT, 'py_router'),
+           os.path.join(ROOT, 'py_tools'), os.path.join(ROOT, 'py_placer')):
+    if os.path.isdir(_d) and _d not in sys.path:
+        sys.path.insert(0, _d)
+
+CLEAN, CRASH, USAGE, UNREADABLE, REFUSED = 0, 1, 2, 3, 4
+
+#: The rules this checker cannot decide, each with the tool that can. Printed
+#: every run. A plan is not "proved" by this exiting 0 -- it is proved as far
+#: as a recorded chain can be, and these are the rest.
+DELEGATED = (
+    ('the final board has no unrouted net',
+     'py_router/check_connected.py'),
+    ('no DRC violation at the clearance the board was routed to',
+     'py_router/check_drc.py'),
+    ('no orphan stub, dead-end antenna or stacked duplicate',
+     'py_tools/check_orphan_stubs.py, py_router/check_weird.py'),
+    ('no redundant copper loop', 'py_tools/check_cycles.py'),
+    ('fanout escaped every ball it was asked to (failed == 0)',
+     "the fanout step's own JSON_SUMMARY.failed"),
+    ('diff pairs did not silently peel to single-ended',
+     'JSON_SUMMARY.failed_diff_pairs / single_ended_diff_pairs'),
+    ('emitted width meets each width-specced net minimum',
+     'board_score.py --net-min-widths'),
+    ('pours kept their promises to carved-off balls',
+     'JSON_SUMMARY.pour_served'),
+    ('the board is DONE, by an aggregate that fails closed',
+     'check_complete.py'),
+)
+
+
+# --------------------------------------------------------------- argv helpers
+
+def tool_of(argv):
+    """The basename of the tool a recorded command runs, or None.
+
+    The FIRST `.py` token, not the last: `python3 -X utf8 route.py in out`
+    has one, but a command carrying a `.py` path as an ARGUMENT would
+    otherwise be misread as running it.
+    """
+    for tok in argv:
+        if tok.endswith('.py'):
+            return os.path.basename(tok)
+    return None
+
+
+def values(argv, flag):
+    """Every token after `flag` up to the next `--option`. [] when absent."""
+    out = []
+    if flag not in argv:
+        return out
+    i = argv.index(flag) + 1
+    while i < len(argv) and not argv[i].startswith('--'):
+        out.append(argv[i])
+        i += 1
+    return out
+
+
+def scalar(argv, flag):
+    """`float(flag's single value)`, or None when absent or not a number."""
+    got = values(argv, flag)
+    try:
+        return float(got[0])
+    except (IndexError, ValueError):
+        return None
+
+
+def is_check(argv):
+    """A read-only grader, by the repo's own convention (`check_*`)."""
+    t = tool_of(argv)
+    return bool(t and t.startswith('check_'))
+
+
+def boards_in(argv):
+    return [a for a in argv if a.endswith('.kicad_pcb')]
+
+
+# --------------------------------------------------------------- the context
+
+class Plan:
+    """Everything a rule may read: the raw text, and the recorded commands."""
+
+    def __init__(self, path, text, cmds, board=None):
+        self.path = path
+        self.text = text
+        self.lines = text.splitlines()
+        self.cmds = cmds                      # [(cwd, argv)], file order
+        self.board = board                    # PCBData, or None
+
+    @property
+    def argvs(self):
+        return [argv for _cwd, argv in self.cmds]
+
+    def by_tool(self, *names):
+        return [a for a in self.argvs if tool_of(a) in names]
+
+    @property
+    def mutating(self):
+        """Commands that write a board: not a check, and naming a board."""
+        return [a for a in self.argvs if not is_check(a) and boards_in(a)
+                and tool_of(a)]
+
+
+# ----------------------------------------------------------------- the rules
+# Each returns a list of failure strings; empty means the rule held. The
+# citation is the line in plan-pcb-routing/SKILL.md the rule comes from, so a
+# refusal can be argued with at its source.
+
+def r_starts_with_cd(p):
+    """SKILL.md :2554 -- begin with an explicit `cd <repo>` line, not just a
+    `# cwd=` comment, so a bare `bash <board>_plan.sh` works at all."""
+    for ln in p.lines:
+        s = ln.strip()
+        if not s or s.startswith('#') or s in ('set -e',):
+            continue
+        if s.split()[0] == 'cd':
+            return []
+        return [f'the first executable line is {s[:70]!r}, not a `cd <repo>`. '
+                f'Relative py_router/ paths fail from any other directory.']
+    return ['the plan has no executable line at all']
+
+
+def r_no_pipes(p):
+    """SKILL.md :2640 -- no pipes. `manifest_to_plan` tokenises pipe segments
+    into NET GLOBS, which is measured, not theoretical: a `2>&1 | tee x.log`
+    tail converts to `nets: ['*', '2>&1', '|', 'tee', 'x.log']`."""
+    bad = []
+    for n, ln in enumerate(p.lines, 1):
+        s = ln.strip()
+        if not s or s.startswith('#'):
+            continue
+        if '|' in s:
+            bad.append(f'line {n} carries a pipe: {s[:70]!r}')
+    return bad
+
+
+def r_verification_is_commented(p):
+    """SKILL.md :2557 -- verification goes in as COMMENTS, never executable
+    lines. The file's exit code is read as the chain verdict, so a trailing
+    read-only check that exits non-zero makes a good board report failed
+    (measured: half of one 15-board wave reported rc != 0 from exactly this).
+
+    Needs the TEXT: `parse_manifest` drops comments, so to it a compliant plan
+    and a plan with no verification are the same file.
+    """
+    bad = []
+    for n, ln in enumerate(p.lines, 1):
+        s = ln.strip()
+        if not s or s.startswith('#'):
+            continue
+        t = tool_of(s.split())
+        if t and t.startswith('check_'):
+            bad.append(f'line {n} runs {t} as an EXECUTABLE line; its exit '
+                       f'code becomes the chain verdict. Comment it out.')
+    return bad
+
+
+def r_ends_on_route(p):
+    """SKILL.md :2282 and :2562 -- the last board-mutating command is
+    `route.py`. Only route.py finalizes planes, so a chain ending on a bare
+    re-pour or a diff step writes a final board no weld/oracle pass ever
+    verified. That is a PLAN ERROR, not a tuning choice."""
+    if not p.mutating:
+        return ['the plan has no board-mutating command at all']
+    last = tool_of(p.mutating[-1])
+    if last != 'route.py':
+        return [f'the last board-mutating command is {last}, not route.py. '
+                f'Only route.py finalizes planes, so this ships a board whose '
+                f'welds and taps nothing verified.']
+    return []
+
+
+def r_checkers_are_present(p):
+    """SKILL.md :1958 -- "Always run DRC, connectivity, and orphan stub
+    checks". Read together with :2557 and :2562 this means the three appear
+    AS COMMENTS after the final route.py, NOT that the plan ends with them:
+    ending on them would break the exit-code rule and the route.py rule at
+    once. Checked on the text, for the same reason."""
+    want = {'check_drc.py': 'DRC', 'check_connected.py': 'connectivity',
+            'check_orphan_stubs.py': 'orphan stubs'}
+    missing = [f'{name} ({tool})' for tool, name in want.items()
+               if tool not in p.text]
+    if missing:
+        return [f'the plan never names {", ".join(sorted(missing))}. The '
+                f'three verification commands belong in the file as '
+                f'COMMENTS after the final route.py.']
+    return []
+
+
+def r_diff_gap_not_below_clearance(p):
+    """SKILL.md :571 -- never set `--diff-pair-gap` below the same command's
+    `--clearance`. KiCad grades the pair's own coupling as a plain clearance
+    violation, so route_diff floors the gap up to clearance anyway."""
+    bad = []
+    for argv in p.by_tool('route_diff.py'):
+        gap, clr = scalar(argv, '--diff-pair-gap'), scalar(argv, '--clearance')
+        if gap is not None and clr is not None and gap < clr - 1e-9:
+            bad.append(f'route_diff --diff-pair-gap {gap} is below the same '
+                       f'command\'s --clearance {clr}')
+    return bad
+
+
+def r_no_teardrops_or_thermal(p):
+    """SKILL.md :1044 -- do not recommend `--add-teardrops` (7% of human
+    boards use them) and do not set `--thermal-relief`."""
+    bad = []
+    for argv in p.argvs:
+        for flag in ('--add-teardrops', '--thermal-relief'):
+            if flag in argv:
+                bad.append(f'{tool_of(argv)} passes {flag}, which the skill '
+                           f'says to leave alone')
+    return bad
+
+
+def r_no_smoothing_off(p):
+    """SKILL.md :1377 -- smoothing is ON by default and the corpus refuted
+    turning it off (#536, then 68db5e3d reverting 97e4443)."""
+    return [f'{tool_of(a)} passes --no-smoothing; the corpus refuted that'
+            for a in p.argvs if '--no-smoothing' in a]
+
+
+def r_no_max_iterations(p):
+    """SKILL.md :1971 -- do not cap iterations on the route step."""
+    return [f'{tool_of(a)} passes --max-iterations, which the skill says not '
+            f'to set' for a in p.argvs if '--max-iterations' in a]
+
+
+def r_max_ripup_within_bounds(p):
+    """SKILL.md :2643 with :1971 -- 5 on dense boards, else the default 3,
+    and "escalate above 5 only as a last resort on a specific failing net".
+
+    Only the UPPER BOUND is decidable from a plan: the dense antecedent (a
+    fine-pitch BGA, or >150 nets) is a fact about the board, and the negative
+    arm is the flag's ABSENCE rather than an explicit 3 -- so neither can be
+    graded here without manufacturing a false refusal.
+    """
+    bad = []
+    for argv in p.argvs:
+        v = scalar(argv, '--max-ripup')
+        if v is not None and v > 5:
+            bad.append(f'{tool_of(argv)} passes --max-ripup {v:g}; above 5 is '
+                       f'a last resort for one failing net, never an opening '
+                       f'move')
+    return bad
+
+
+def r_cp_carries_the_project(p):
+    """SKILL.md :1462 -- never `cp` a board without its `.kicad_pro`. The
+    sibling carries the DRC floor the chain routed to; stranding it makes the
+    next step resolve a looser floor and stamp it over tighter copper.
+
+    A PAIRING rule, not a prohibition: `cp a.kicad_pro b.kicad_pro` beside it
+    is explicitly allowed, and `py_router/copy_board.py` is the recommended
+    form.
+    """
+    bad = []
+    copied_pro = set()
+    for argv in p.argvs:
+        if argv and argv[0] == 'cp' and len(argv) >= 3 \
+                and argv[-1].endswith('.kicad_pro'):
+            copied_pro.add(os.path.basename(argv[-1])[:-len('.kicad_pro')])
+    for argv in p.argvs:
+        if not argv or argv[0] != 'cp':
+            continue
+        pcbs = boards_in(argv)
+        if not pcbs:
+            continue
+        stem = os.path.basename(pcbs[-1])[:-len('.kicad_pcb')]
+        if stem not in copied_pro:
+            bad.append(f'`cp ... {os.path.basename(pcbs[-1])}` strands the '
+                       f'sibling .kicad_pro (the DRC floor). Use '
+                       f'py_router/copy_board.py, or copy the .kicad_pro too.')
+    return bad
+
+
+def r_one_cap_pass_after_fanout(p):
+    """SKILL.md :993 / :1137 -- exactly one `place_fanout_clearance.py`, and
+    it runs after every fanout step."""
+    order = [tool_of(a) for a in p.argvs]
+    caps = [i for i, t in enumerate(order) if t == 'place_fanout_clearance.py']
+    fans = [i for i, t in enumerate(order)
+            if t in ('bga_fanout.py', 'qfn_fanout.py')]
+    if not fans:
+        return []
+    if len(caps) > 1:
+        return [f'{len(caps)} place_fanout_clearance.py steps; the cap pass '
+                f'runs ONCE, after all fanouts']
+    if not caps:
+        return ['the plan fans out but never runs place_fanout_clearance.py']
+    if caps[0] < max(fans):
+        return ['place_fanout_clearance.py runs before a later fanout step; '
+                'it must come after all of them']
+    return []
+
+
+def r_first_pour_has_no_via_tail(p):
+    """SKILL.md :976 -- the Step-1 `route_planes` call carries no
+    `--add-gnd-vias` and no `--stitch-vias`: the bare pour comes first and the
+    via tail is a later, high-speed-tier decision."""
+    pours = p.by_tool('route_planes.py')
+    if not pours:
+        return []
+    bad = []
+    for flag in ('--add-gnd-vias', '--stitch-vias'):
+        if flag in pours[0]:
+            bad.append(f'the first route_planes step passes {flag}; the first '
+                       f'pour is bare (#562)')
+    return bad
+
+
+def _globs(argv, flag):
+    return set(values(argv, flag))
+
+
+def r_net_coverage_reconciles(p):
+    """SKILL.md Step 5b, the two `assert`s at :952 and :954 -- which ship in a
+    fenced block NO TEST RUNS, and whose violation is how `GNDA` ended a run
+    at 0/23 pads connected while the run reported success.
+
+      * the route step's exclusions MUST equal the Step-2b impedance set;
+      * every poured net MUST appear in the route step's `--power-nets`.
+
+    Compared as the LITERAL PATTERNS the plan passes, which is exact only for
+    literal net names: `!+3V3*` against `+3V3` is a glob question and needs
+    the board's net list. A pattern mismatch is therefore reported as one, in
+    the words the skill uses, rather than silently resolved.
+    """
+    routes = [a for a in p.by_tool('route.py') if '--impedance' not in a]
+    imped = [a for a in p.by_tool('route.py') if '--impedance' in a]
+    pours = p.by_tool('route_planes.py')
+    if not routes:
+        return []
+    exclusions, power = set(), set()
+    for argv in routes:
+        exclusions |= {n[1:] for n in _globs(argv, '--nets')
+                       if n.startswith('!')}
+        power |= _globs(argv, '--power-nets')
+    impedance_se = set()
+    for argv in imped:
+        impedance_se |= {n for n in _globs(argv, '--nets')
+                         if not n.startswith('!')}
+    plane_nets = set()
+    for argv in pours:
+        plane_nets |= _globs(argv, '--nets')
+
+    bad = []
+    orphans = exclusions ^ impedance_se
+    if orphans:
+        bad.append(f'Net-coverage gap: {sorted(orphans)} handled by no stage '
+                   f'-- the route step excludes {sorted(exclusions)} and '
+                   f'Step 2b routes {sorted(impedance_se)}')
+    unsized = plane_nets - power
+    if unsized:
+        bad.append(f'Poured but no route-step width: {sorted(unsized)} -- '
+                   f'that is where the finalize\'s taps and welds get their '
+                   f'width')
+    return bad
+
+
+def r_gnd_via_distance(p):
+    """SKILL.md :690 -- `--gnd-via-distance` >= 3x (via size + clearance)."""
+    bad = []
+    for argv in p.argvs:
+        d = scalar(argv, '--gnd-via-distance')
+        vs, clr = scalar(argv, '--via-size'), scalar(argv, '--clearance')
+        if d is None or vs is None or clr is None:
+            continue
+        floor = 3.0 * (vs + clr)
+        if d < floor - 1e-9:
+            bad.append(f'{tool_of(argv)} --gnd-via-distance {d:g} is below '
+                       f'3x(via {vs:g} + clearance {clr:g}) = {floor:.3f}')
+    return bad
+
+
+def r_impedance_needs_a_stackup(p):
+    """SKILL.md :905 / :2600 -- with no real stackup, STATE THE NUMBERS and
+    run no `--impedance` and no `--time-matching` pass. Do NOT author a
+    stackup to make the numbers appear.
+
+    Needs the board, so it is skipped (and said so) without --board.
+    """
+    if p.board is None:
+        return []
+    stack = getattr(p.board.board_info, 'stackup', None) or []
+    if [s for s in stack if getattr(s, 'thickness', None)]:
+        return []
+    bad = []
+    for argv in p.argvs:
+        for flag in ('--impedance', '--time-matching'):
+            if flag in argv:
+                bad.append(f'{tool_of(argv)} passes {flag}, but the board '
+                           f'declares no stackup thickness -- the numbers '
+                           f'would be computed from a default that is not '
+                           f'this board')
+    return bad
+
+
+def r_fanout_layers_exclude_planes(p):
+    """SKILL.md :2635 / Step 10 rule 3 -- fanout `--layers` must EXCLUDE any
+    layer carrying a solid plane, or the escape routes into the pour."""
+    plane_layers = set()
+    for argv in p.by_tool('route_planes.py', 'repair_planes.py'):
+        plane_layers |= set(values(argv, '--plane-layers'))
+    if not plane_layers:
+        return []
+    bad = []
+    for argv in p.by_tool('bga_fanout.py', 'qfn_fanout.py'):
+        clash = set(values(argv, '--layers')) & plane_layers
+        if clash:
+            bad.append(f'{tool_of(argv)} --layers includes {sorted(clash)}, '
+                       f'which the plan pours a solid plane on')
+    return bad
+
+
+#: (id, what it checks, SKILL.md citation, fn). Order is the order printed.
+RULES = (
+    ('R01', 'the plan begins with an explicit cd', ':2554', r_starts_with_cd),
+    ('R02', 'no pipes', ':2640', r_no_pipes),
+    ('R03', 'verification is commented, not executable', ':2557',
+     r_verification_is_commented),
+    ('R04', 'the chain ends on route.py', ':2282 :2562', r_ends_on_route),
+    ('R05', 'the three verification commands are present', ':1958',
+     r_checkers_are_present),
+    ('R06', 'diff-pair gap is not below clearance', ':571',
+     r_diff_gap_not_below_clearance),
+    ('R07', 'no teardrops, no thermal relief', ':1044',
+     r_no_teardrops_or_thermal),
+    ('R08', 'smoothing is left on', ':1377', r_no_smoothing_off),
+    ('R09', 'iterations are not capped', ':1971', r_no_max_iterations),
+    ('R10', 'max-ripup stays within bounds', ':2643',
+     r_max_ripup_within_bounds),
+    ('R11', 'a cp carries the .kicad_pro', ':1462', r_cp_carries_the_project),
+    ('R12', 'one cap pass, after every fanout', ':993 :1137',
+     r_one_cap_pass_after_fanout),
+    ('R13', 'the first pour is bare', ':976', r_first_pour_has_no_via_tail),
+    ('R14', 'net coverage reconciles (Step 5b)', ':952 :954',
+     r_net_coverage_reconciles),
+    ('R15', 'gnd-via distance clears 3x(via+clearance)', ':690',
+     r_gnd_via_distance),
+    ('R16', 'no impedance pass without a stackup [needs --board]', ':905',
+     r_impedance_needs_a_stackup),
+    ('R17', 'fanout layers exclude poured layers [needs --board]', ':2635',
+     r_fanout_layers_exclude_planes),
+)
+
+
+def check(path, board_path=None):
+    """(failures, skipped) -- failures is [(id, what, cite, [reasons])]."""
+    sys.path.insert(0, os.path.join(ROOT, 'py_router'))
+    from make_plan import plan_commands, resolve_manifest
+    manifest = resolve_manifest(path)
+    with open(manifest, encoding='utf-8', errors='replace') as fh:
+        text = fh.read()
+    cmds = plan_commands(path)
+    board = None
+    if board_path:
+        from kicad_parser import parse_kicad_pcb
+        board = parse_kicad_pcb(board_path)
+    plan = Plan(manifest, text, cmds, board)
+
+    failures, skipped = [], []
+    for rid, what, cite, fn in RULES:
+        if board is None and 'needs --board' in what:
+            skipped.append((rid, what, cite))
+            continue
+        reasons = fn(plan)
+        if reasons:
+            failures.append((rid, what, cite, reasons))
+    return plan, failures, skipped
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('plan', nargs='?',
+                    help='the <board>_plan.sh / redo_commands.sh, or the run '
+                         'directory holding one')
+    ap.add_argument('--board', default=None,
+                    help='the board the plan is about; enables the rules '
+                         'whose antecedent is a fact about the board')
+    ap.add_argument('--list', action='store_true',
+                    help='every rule and every DELEGATED check, then exit')
+    a = ap.parse_args(argv)
+
+    if a.list:
+        print('rules checked here:')
+        for rid, what, cite, _fn in RULES:
+            print(f'  {rid}  {what:<52} SKILL.md {cite}')
+        print('\nNOT checked here -- a plan cannot answer these; the tool '
+              'that can:')
+        for what, who in DELEGATED:
+            print(f'       {what:<52} {who}')
+        return CLEAN
+    if not a.plan:
+        ap.print_help()
+        return USAGE
+
+    try:
+        plan, failures, skipped = check(a.plan, a.board)
+    except FileNotFoundError as exc:
+        print(f'route_plan_check: {exc}', file=sys.stderr)
+        return UNREADABLE
+    except ValueError as exc:               # an unterminated quote, say
+        print(f'route_plan_check: {plan_err(exc)}', file=sys.stderr)
+        return UNREADABLE
+
+    print(f'{os.path.relpath(plan.path)}: {len(plan.cmds)} recorded '
+          f'command(s), {len(plan.mutating)} of them board-mutating')
+    for rid, what, cite, _fn in RULES:
+        hit = next((f for f in failures if f[0] == rid), None)
+        if (rid, what, cite) in [(s[0], s[1], s[2]) for s in skipped]:
+            print(f'  SKIP  {rid}  {what}  -- pass --board to check it')
+        elif hit:
+            print(f'  FAIL  {rid}  {what}   [SKILL.md {cite}]')
+            for reason in hit[3]:
+                print(f'          {reason}')
+        else:
+            print(f'  ok    {rid}  {what}')
+
+    print('\nNOT checked here -- a recorded plan cannot answer these:')
+    for what, who in DELEGATED:
+        print(f'       {what}  ->  {who}')
+
+    if failures:
+        print(f'\nREFUSED: {len(failures)} rule(s) failed. Fix the plan; do '
+              f'not run it.')
+        return REFUSED
+    print(f'\nOK: {len(RULES) - len(skipped)} rule(s) checked, '
+          f'{len(skipped)} skipped, {len(DELEGATED)} delegated.')
+    return CLEAN
+
+
+def plan_err(exc):
+    return f'the plan could not be read: {exc}'
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(CRASH)

--- a/.claude/skills/plan-pcb-routing/scripts/route_plan_check.py
+++ b/.claude/skills/plan-pcb-routing/scripts/route_plan_check.py
@@ -470,32 +470,34 @@ def r_fanout_layers_exclude_planes(p):
 
 #: (id, what it checks, SKILL.md citation, fn). Order is the order printed.
 RULES = (
-    ('R01', 'the plan begins with an explicit cd', ':2554', r_starts_with_cd),
-    ('R02', 'no pipes', ':2640', r_no_pipes),
-    ('R03', 'verification is commented, not executable', ':2557',
+    ('R01', 'the plan begins with an explicit cd', 'Step 9', r_starts_with_cd),
+    ('R02', 'no pipes', 'Step 10 rule 5', r_no_pipes),
+    ('R03', 'verification is commented, not executable', 'Step 9',
      r_verification_is_commented),
-    ('R04', 'the chain ends on route.py', ':2282 :2562', r_ends_on_route),
-    ('R05', 'the three verification commands are present', ':1958',
+    ('R04', 'the chain ends on route.py', 'End every chain on route.py', r_ends_on_route),
+    ('R05', 'the three verification commands are present', 'Important Notes 4',
      r_checkers_are_present),
-    ('R06', 'diff-pair gap is not below clearance', ':571',
+    ('R06', 'diff-pair gap is not below clearance', 'Step 4 diff pairs',
      r_diff_gap_not_below_clearance),
-    ('R07', 'no teardrops, no thermal relief', ':1044',
+    ('R07', 'no teardrops, no thermal relief', 'Important Notes',
      r_no_teardrops_or_thermal),
-    ('R08', 'smoothing is left on', ':1377', r_no_smoothing_off),
-    ('R09', 'iterations are not capped', ':1971', r_no_max_iterations),
-    ('R10', 'max-ripup stays within bounds', ':2643',
+    ('R08', 'smoothing is left on', 'Octolinear smoothing is ON', r_no_smoothing_off),
+    ('R09', 'iterations are not capped', 'Important Notes 15', r_no_max_iterations),
+    ('R10', 'max-ripup stays within bounds', 'Step 10 rule 6',
      r_max_ripup_within_bounds),
-    ('R11', 'a cp carries the .kicad_pro', ':1462', r_cp_carries_the_project),
-    ('R12', 'one cap pass, after every fanout', ':993 :1137',
+    ('R11', 'a cp carries the .kicad_pro', 'Never cp a board without its .kicad_pro', r_cp_carries_the_project),
+    ('R12', 'one cap pass, after every fanout', 'Step 1c',
      r_one_cap_pass_after_fanout),
-    ('R13', 'the first pour is bare', ':976', r_first_pour_has_no_via_tail),
-    ('R14', 'net coverage reconciles (Step 5b)', ':952 :954',
+    ('R13', 'the first pour is bare', 'Step 1 bare pour', r_first_pour_has_no_via_tail),
+    ('R14', 'net coverage reconciles (Step 5b)', 'Step 5b',
      r_net_coverage_reconciles),
-    ('R15', 'gnd-via distance clears 3x(via+clearance)', ':690',
+    ('R15', 'gnd-via distance clears 3x(via+clearance)', 'Step 4 GND vias',
      r_gnd_via_distance),
-    ('R16', 'no impedance pass without a stackup [needs --board]', ':905',
+    ('R16', 'no impedance pass without a stackup [needs --board]',
+     'Step 10 rule 1',
      r_impedance_needs_a_stackup),
-    ('R17', 'fanout layers exclude poured layers [needs --board]', ':2635',
+    ('R17', 'fanout layers exclude poured layers [needs --board]',
+     'Step 10 rule 3',
      r_fanout_layers_exclude_planes),
 )
 
@@ -542,7 +544,7 @@ def main(argv=None):
     if a.list:
         print('rules checked here:')
         for rid, what, cite, _fn in RULES:
-            print(f'  {rid}  {what:<52} SKILL.md {cite}')
+            print(f'  {rid}  {what:<52} SKILL.md, {cite}')
         print('\nNOT checked here -- a plan cannot answer these; the tool '
               'that can:')
         for what, who in DELEGATED:
@@ -568,7 +570,7 @@ def main(argv=None):
         if (rid, what, cite) in [(s[0], s[1], s[2]) for s in skipped]:
             print(f'  SKIP  {rid}  {what}  -- pass --board to check it')
         elif hit:
-            print(f'  FAIL  {rid}  {what}   [SKILL.md {cite}]')
+            print(f'  FAIL  {rid}  {what}   [SKILL.md, {cite}]')
             for reason in hit[3]:
                 print(f'          {reason}')
         else:

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,15 @@ Thumbs.db
 rust_*/target/
 *.pyd
 
+# render_placement writes <board>_placement.png (and _B/_F on a two-sided
+# board) BESIDE THE BOARD when -o is omitted -- render_placement.py:2220. So
+# grading the corpus leaves 31 PNGs in kicad_files/, and a `git add -A` ships
+# ~14 MB of generated renders into the commit. Measured: it did, into a #936
+# follow-up branch, and only reading the diffstat before pushing caught it.
+/kicad_files/*_placement.png
+/kicad_files/*_placement_B.png
+/kicad_files/*_placement_F.png
+
 # KiCad outputs (routed files, backups, project files)
 /kicad_files/test_diffpair*kicad_pcb
 /kicad_files/fanout_output*.kicad_pcb

--- a/build_router.py
+++ b/build_router.py
@@ -15,6 +15,10 @@ binary can agree on the version string yet carry a different ABI (#615 -- the
 take it). An explicit --tag overrides this and is honored as-given.
 """
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': [], 'kind': 'utility'}
+
 import sys
 if sys.version_info[0] < 3:
     print("ERROR: Python 3 is required. You are running Python %d.%d." % sys.version_info[:2])

--- a/check_complete.py
+++ b/check_complete.py
@@ -40,6 +40,11 @@ because a component nothing examined is UNEXAMINED and never clean.
 
 Exit: 0 done, 2 usage, 3 board state, 4 incomplete, 5 unsound floors.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing', 'combined'], 'kind': 'instrument'}
+
 import argparse
 import json
 import os

--- a/check_release_version.py
+++ b/check_release_version.py
@@ -19,6 +19,10 @@ version is bumped only when the crate changes and legitimately differs from
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': [], 'kind': 'utility'}
+
 import argparse
 import json
 import subprocess

--- a/check_rigid_consistency.py
+++ b/check_rigid_consistency.py
@@ -36,6 +36,11 @@ Usage:
 
 Exit: 0 consistent, 2 usage/load error, 4 inconsistent pairs found.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement'], 'kind': 'instrument'}
+
 import argparse
 import json
 import math

--- a/install_plugin.py
+++ b/install_plugin.py
@@ -20,6 +20,10 @@ Content Manager is detected (it sits next to the local install in
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': [], 'kind': 'utility'}
+
 import os
 import sys
 import json

--- a/krt_capabilities.py
+++ b/krt_capabilities.py
@@ -19,6 +19,11 @@ So: publish the capability set and let the consumer assert against it.
 everything missing, so a consumer's check is one line and its failure message
 names the gap instead of the symptom.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['combined'], 'kind': 'utility'}
+
 import argparse
 import ast
 import functools

--- a/krt_capabilities.py
+++ b/krt_capabilities.py
@@ -18,6 +18,15 @@ So: publish the capability set and let the consumer assert against it.
 `--require` takes `module` or `module:--flag` tokens and exits non-zero listing
 everything missing, so a consumer's check is one line and its failure message
 names the gap instead of the symptom.
+
+NOT THE CATALOGUE. `KNOWN_MODULES` is the pinnable set -- the modules a
+consumer is likely to assert on -- and it is deliberately short and
+hand-maintained, because every name in it is answered on every call and this
+has to stay fast enough for `route.py --capabilities` to run before argparse.
+For "what tools exist in this clone at all, what is each for, and which door
+serves it", see `krt_registry.py`: it enumerates by BEHAVIOUR (`--help`
+answers with a usage line), covers every runnable tool rather than a chosen
+few, and is gated for completeness by `tests/test_937_tool_registry.py`.
 """
 
 #: #937 registry: which door(s) show this tool, and whether it changes
@@ -445,9 +454,10 @@ def capabilities(root=ROOT):
         'flags': flags,
     }
     try:                                    # best-effort, never fatal
-        _eng = os.path.join(root, 'py_router')
-        if os.path.isdir(_eng) and _eng not in sys.path:
-            sys.path.insert(0, _eng)        # #522 layout: the engine dir
+        # (This used to insert py_router/ on sys.path so `routing_defaults`
+        # could be imported for its VERSION. Nothing here imports any more, so
+        # the insert was dead residue that still mutated the CALLER's sys.path
+        # as a side effect of asking a read-only question.)
         # /VERSION is the release triple's own file (Cargo.toml +
         # /VERSION + metadata.json). This used to read
         # `routing_defaults.VERSION`, which that module has never

--- a/krt_capabilities.py
+++ b/krt_capabilities.py
@@ -443,8 +443,15 @@ def capabilities(root=ROOT):
         _eng = os.path.join(root, 'py_router')
         if os.path.isdir(_eng) and _eng not in sys.path:
             sys.path.insert(0, _eng)        # #522 layout: the engine dir
-        import routing_defaults as _d
-        out['version'] = getattr(_d, 'VERSION', None)
+        # /VERSION is the release triple's own file (Cargo.toml +
+        # /VERSION + metadata.json). This used to read
+        # `routing_defaults.VERSION`, which that module has never
+        # defined -- so `capabilities()['version']` was None on every
+        # call this function has ever made, while /VERSION said 0.22.0.
+        # A capability report whose version is always None cannot
+        # answer the one question it exists for: can THIS clone do X.
+        with open(os.path.join(root, 'VERSION'), encoding='utf-8') as _vf:
+            out['version'] = _vf.read().strip() or None
     except Exception:
         out['version'] = None
     return out

--- a/krt_registry.py
+++ b/krt_registry.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Every runnable tool in this clone, what it is for, and which door it serves.
+
+    python3 -X utf8 krt_registry.py --door routing
+    python3 -X utf8 krt_registry.py --list
+    python3 -X utf8 krt_registry.py --json
+    python3 -X utf8 krt_registry.py --check
+
+#937's anti-deletion guarantee: a restructure cannot quietly drop a tool,
+because `tests/test_937_tool_registry.py` fails when a runnable tool has no
+entry. The three catalogues that existed before this one each answered a
+different question and none was complete -- `krt_capabilities.KNOWN_MODULES`
+is a hand-written tuple of 29 (one of which is not a CLI), `FLAG_SCRIPTS`
+covers 8, and `test_431.discovered_tools()` finds the 49 the skills happen to
+invoke. Nothing asserted the reverse direction: that every CLI in the tree is
+in the catalogue.
+
+WHAT IS DERIVED, AND WHY EACH IS DERIVED RATHER THAN DECLARED
+-------------------------------------------------------------
+`purpose`  the module docstring's first line. All runnable tools have one
+           (median body ~1.2 kB, no two first lines alike), so copying them
+           into a table would create a second copy to drift. Reading is a
+           stronger guarantee than any gate over a copy.
+`doc`      a `## Name (`tool.py`)` heading in docs/utilities.md. An absent
+           pointer is a recorded FACT and the backlog, never a gate failure --
+           23 of 71 have one today, and failing on the other 48 would only
+           get the gate deleted.
+`flags`    left to `krt_capabilities.script_flags`, unchanged. One resolver.
+
+WHAT IS DECLARED, AND WHY IT CANNOT BE DERIVED
+-----------------------------------------------
+`scope`    which door(s) the tool serves. NOT DERIVABLE, and that claim is
+           not frozen here -- `tests/test_937_tool_registry.py` RE-MEASURES
+           the two candidate rules every run and fails if either ever became
+           complete and they agreed, because then this field should be
+           retired rather than maintained. The rules measure different
+           questions: the directory is a PROVENANCE fact (the #522 reorg) and
+           the skills are a USAGE fact. One hard contradiction:
+           py_placer/place_fanout_clearance.py lives in py_placer/ and is
+           named only by plan-pcb-routing -- it is declared for BOTH doors,
+           wider than either rule, because a routing chain runs it and it is
+           the one placement step that lays copper.
+`kind`     The best derivation available -- the union of `record_invocation`,
+           a writer-symbol grep and an output argument -- has false positives
+           and misses, and two of the misses are invisible to ANY scan of the
+           file itself: py_router/place_fanout_clearance.py is a `runpy`
+           forwarder, and py_router/fix_kicad_drc_settings.py rewrites the
+           board IN PLACE and so has no output argument by construction.
+           `record_invocation` alone is the precise half -- 17 call sites, 17
+           of them actors -- so it is kept as a CROSS-CHECK (see
+           `self_records`) rather than promoted to a derivation.
+
+A MISSING DECLARATION IS A GATE FAILURE, NOT AN EXEMPTION. That is the whole
+inversion: this repo's recorded failure mode is that the exempted names are
+where the bug hides, so the registry has no allowlist. A tool that should not
+be in a door's view says so -- `'scope': []` -- rather than being omitted.
+
+Declarations are read BY AST, NEVER BY IMPORT, for the reason
+`krt_capabilities.script_flags` gives for doing the same with flags: a
+consumer asking "can this clone do X" must not be able to trigger a side
+effect by asking.
+
+THE PREDICATE IS BEHAVIOURAL, AND IT NAMES ITS OWN BUGS
+--------------------------------------------------------
+A tool is runnable when `python3 <file> --help` exits 0 and prints a line
+starting with `usage:`. It costs ~11 s over the 240 tracked non-test files at
+8 workers (~86 s of subprocess time) and yields 71.
+
+It is a strict superset of the 49 tools `test_431.discovered_tools()` finds
+by scanning what the skills invoke -- `discovered-only` is empty -- so nothing
+that gate already covers is lost by adopting this one.
+
+`grep __main__` is wrong in both directions and an allowlist would be needed
+to patch it: four modules mention it only in a docstring or have a non-CLI
+`__main__`, two package `__init__.py` files fail on sys.path when run
+directly but are real CLIs through their shims -- and three tools FAILED the
+predicate for reasons that were real bugs, fixed in the commit before this
+one rather than exempted. That is the property being bought: the predicate
+names its own false negatives instead of needing a list of them.
+"""
+import argparse
+import ast
+import concurrent.futures
+import json
+import os
+import re
+import subprocess
+import sys
+
+#: This module is itself a runnable tool, so it declares like every other one.
+KRT_TOOL = {'scope': [], 'kind': 'utility'}
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+
+#: Every door a `scope` may name. A declaration naming anything else is a gate
+#: failure -- a typo'd door is a tool that silently appears in no view, which
+#: is the failure this registry exists to prevent.
+DOORS = ('placement', 'routing', 'combined')
+
+#: Every value `kind` may take.
+#:
+#: `actor` / `instrument` is the repo owner's split and the one that decides
+#: how a tool is used: an actor changes the board and must be SCOPED to what
+#: you already measured; an instrument says what is wrong and running it is
+#: never optional.
+#:
+#: The other three exist because forcing every tool into that pair would make
+#: the registry lie, and a catalogue that lies is worse than none:
+#:   `conditional` -- writes a board only under an opt-in flag
+#:                    (`check_drc --debug-lines`, `check_join --keep-staged`)
+#:                    or only to a scratch copy (`plane_score`). Calling these
+#:                    actors tells a reader to scope something that reports.
+#:   `driver`      -- emits workflow instructions and touches no board. The
+#:                    two tape heads. `instrument` would be true of the board
+#:                    and false of the thing.
+#:   `utility`     -- not board work at all: build, release, packaging, clone
+#:                    hygiene. These carry `scope: []` and that is a
+#:                    DECLARATION, not an omission.
+KINDS = ('actor', 'instrument', 'conditional', 'driver', 'utility')
+
+#: docs/utilities.md's heading form, which is formulaic and is the only
+#: per-tool documentation index in the repo. Anchored at line start so a `#`
+#: inside a fenced block cannot match, and `$`-anchored so the two
+#: non-tool sections (`## Test Scripts`, `## Common Workflows`) cannot.
+_DOC_HEADING = re.compile(
+    r'^## (?P<title>.+) \(`(?P<tool>[A-Za-z0-9_]+\.py)`\)$', re.M)
+
+_USAGE_PROBE_TIMEOUT = 40
+_PROBE_WORKERS = 8
+
+
+def tracked_python(root=ROOT):
+    """Every tracked .py outside tests/, repo-relative, sorted.
+
+    `git ls-files`, not a walk: an untracked scratch file in the tree is not
+    part of this clone's catalogue, and a walk would put one there.
+    """
+    r = subprocess.run(['git', 'ls-files', '*.py'], cwd=root,
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        raise RuntimeError(f'git ls-files failed in {root}: {r.stderr}')
+    return sorted(p.strip() for p in r.stdout.splitlines()
+                  if p.strip() and not p.strip().startswith('tests/'))
+
+
+def _probe(args):
+    """(rel, ok, detail) -- does `python3 <rel> --help` answer like a tool?"""
+    root, rel = args
+    try:
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8', os.path.join(root, rel), '--help'],
+            cwd=root, capture_output=True, text=True, encoding='utf-8',
+            errors='replace', timeout=_USAGE_PROBE_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        return rel, False, f'no answer in {_USAGE_PROBE_TIMEOUT}s'
+    except OSError as exc:                                    # noqa: BLE001
+        return rel, False, f'could not launch: {exc}'
+    if r.returncode != 0:
+        tail = (r.stderr or r.stdout or '').strip().splitlines()
+        return rel, False, (f'exit {r.returncode}: '
+                            + (tail[-1][:120] if tail else 'no output'))
+    # A LINE starting with `usage:`, not the FIRST line: 24 tools print a
+    # banner (`CMD: ...`, `ENV KNOBS: ...`) before argparse gets to speak, and
+    # requiring line 1 would report every one of them as not a tool.
+    if not any(ln.startswith('usage:')
+               for ln in (r.stdout or '').splitlines()):
+        return rel, False, 'exit 0 but no `usage:` line -- not an argparse CLI'
+    return rel, True, ''
+
+
+def runnable_tools(root=ROOT, files=None):
+    """({rel: ''} for tools, {rel: why} for the rest) over tracked_python."""
+    files = list(files if files is not None else tracked_python(root))
+    ok, no = {}, {}
+    with concurrent.futures.ThreadPoolExecutor(
+            max_workers=_PROBE_WORKERS) as ex:
+        for rel, good, why in ex.map(_probe, ((root, f) for f in files)):
+            (ok if good else no)[rel] = why
+    return ok, no
+
+
+def _module_ast(root, rel):
+    with open(os.path.join(root, rel), encoding='utf-8',
+              errors='replace') as fh:
+        return ast.parse(fh.read(), filename=rel)
+
+
+def declaration(root, rel):
+    """The module-level KRT_TOOL literal, or None. AST, never an import."""
+    try:
+        tree = _module_ast(root, rel)
+    except SyntaxError:
+        return None
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if 'KRT_TOOL' not in names:
+            continue
+        try:
+            got = ast.literal_eval(node.value)
+        except (ValueError, SyntaxError):
+            return None
+        return got if isinstance(got, dict) else None
+    return None
+
+
+def purpose(root, rel):
+    """The docstring's first non-empty line, or '' when there is none."""
+    try:
+        doc = ast.get_docstring(_module_ast(root, rel))
+    except SyntaxError:
+        return ''
+    for line in (doc or '').splitlines():
+        if line.strip():
+            return line.strip()
+    return ''
+
+
+def doc_pointers(root=ROOT):
+    """{basename: heading title} from docs/utilities.md's tool sections."""
+    path = os.path.join(root, 'docs', 'utilities.md')
+    if not os.path.isfile(path):
+        return {}
+    with open(path, encoding='utf-8', errors='replace') as fh:
+        text = fh.read()
+    return {m.group('tool'): m.group('title')
+            for m in _DOC_HEADING.finditer(text)}
+
+
+def self_records(root, rel):
+    """Does the tool CALL record_invocation -- i.e. self-record into the redo
+    manifest?
+
+    The cross-check for `kind`, and the cleanest single signal there is: 17
+    call sites, 17 of them actors, no false positive. It does NOT decide --
+    it has 7 misses, including two structurally invisible ones (a `runpy`
+    forwarder and an in-place rewriter) -- so a disagreement with the
+    declaration is DISCLOSED BY NAME rather than resolved. A signal that
+    silently overrode a declaration would be a derivation wearing a
+    declaration's clothes.
+
+    A CALL, found by AST, not the string. The substring version reported this
+    very module as a self-recorder, because it is the one that explains the
+    signal -- prose satisfying a source-grep is a recorded failure here, and
+    a cross-check that fires on any file DISCUSSING the thing it checks is
+    worse than no cross-check.
+    """
+    try:
+        tree = _module_ast(root, rel)
+    except (OSError, SyntaxError):
+        return False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        name = (fn.id if isinstance(fn, ast.Name)
+                else fn.attr if isinstance(fn, ast.Attribute) else None)
+        if name == 'record_invocation':
+            return True
+    return False
+
+
+def registry(root=ROOT, files=None):
+    """[row] for every runnable tool, sorted by path.
+
+    A row always carries `path`, `purpose`, `doc`, `self_records`; `kind` and
+    `scope` are None/None when the tool declares nothing, which is what the
+    gate refuses on. Nothing here raises on a missing declaration: reporting
+    is this function's job and refusing is the gate's.
+    """
+    ok, _no = runnable_tools(root, files)
+    docs = doc_pointers(root)
+    rows = []
+    for rel in sorted(ok):
+        decl = declaration(root, rel) or {}
+        scope = decl.get('scope')
+        rows.append({
+            'path': rel,
+            'purpose': purpose(root, rel),
+            'kind': decl.get('kind'),
+            'scope': list(scope) if isinstance(scope, (list, tuple)) else None,
+            'declared': bool(decl),
+            'doc': docs.get(os.path.basename(rel)),
+            'self_records': self_records(root, rel),
+        })
+    return rows
+
+
+def door_view(rows, door):
+    """The rows one door should see. A tool with no declaration is EXCLUDED
+    here and caught by the gate -- a view must not quietly widen to cover a
+    registration hole, because then the hole never gets fixed."""
+    return [r for r in rows if r['scope'] and door in r['scope']]
+
+
+def _fmt(row, width):
+    kind = row['kind'] or '?'
+    return (f"  {row['path']:<{width}}  {kind:<11}  {row['purpose'][:70]}")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--door', choices=DOORS,
+                    help='only the tools this door serves')
+    ap.add_argument('--list', action='store_true',
+                    help='one line per tool (the default when no --json)')
+    ap.add_argument('--json', dest='as_json', action='store_true',
+                    help='the whole registry as a JSON document')
+    ap.add_argument('--check', action='store_true',
+                    help='report undeclared tools and declaration/signal '
+                         'disagreements; exit 4 if any tool is undeclared')
+    ap.add_argument('--root', default=ROOT,
+                    help='the clone to inventory (default: this one)')
+    a = ap.parse_args(argv)
+
+    rows = registry(a.root)
+    if a.door:
+        rows = door_view(rows, a.door)
+
+    if a.as_json:
+        json.dump({'schema': 1, 'door': a.door, 'tools': rows},
+                  sys.stdout, indent=2, sort_keys=True)
+        print()
+        return 0
+
+    if a.check:
+        undeclared = [r for r in rows if not r['declared']]
+        badkind = [r for r in rows if r['declared']
+                   and r['kind'] not in KINDS]
+        badscope = [r for r in rows if r['declared']
+                    and (r['scope'] is None
+                         or any(s not in DOORS for s in r['scope']))]
+        # The disagreement is REPORTED, never resolved: see self_records().
+        # `not in (actor, conditional)` rather than `== instrument`: adding
+        # `driver` and `utility` to KINDS would otherwise have opened two new
+        # places for a board-writing tool to hide from this check, which is
+        # the shape of every whitelist defect in this repo's notes.
+        disagree = [r for r in rows if r['self_records']
+                    and r['kind'] not in ('actor', 'conditional')]
+        for label, bad in (('undeclared', undeclared),
+                           ('kind not in ' + repr(KINDS), badkind),
+                           ('scope not a list of ' + repr(DOORS), badscope)):
+            print(f'{label}: {len(bad)}')
+            for r in bad:
+                print(f'    {r["path"]}')
+        print(f'self-records but declared neither actor nor conditional: {len(disagree)}'
+              '  [reported, not resolved]')
+        for r in disagree:
+            print(f'    {r["path"]}')
+        print(f'\n{len(rows)} runnable tool(s); '
+              f'{sum(1 for r in rows if r["doc"])} with a docs/utilities.md '
+              f'section')
+        return 4 if (undeclared or badkind or badscope) else 0
+
+    width = max((len(r['path']) for r in rows), default=4)
+    for row in rows:
+        print(_fmt(row, width))
+    print(f'\n{len(rows)} tool(s)'
+          + (f' at the {a.door} door' if a.door else ''))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/package_pcm.py
+++ b/package_pcm.py
@@ -34,6 +34,10 @@ containing sha256/download_size/install_size for metadata.json patching.
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': [], 'kind': 'utility'}
+
 import argparse
 import copy
 import hashlib

--- a/py_placer/beautify_labels.py
+++ b/py_placer/beautify_labels.py
@@ -12,6 +12,11 @@ and reported with a reason.
 
 See placement/labels.py for the obstacle model and degradation ladder.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement'], 'kind': 'actor'}
+
 import _path  # noqa: F401  (py_placer -> py_router/py_tools on sys.path)
 
 import json

--- a/py_placer/compare_seeds.py
+++ b/py_placer/compare_seeds.py
@@ -23,6 +23,11 @@ produces no verdict carries a `status` naming why. Output: a ranked table, seeds
 Exit 0 when at least one seed was probed; 4 when every seed failed its
 intent gate (nothing rankable); 2 for usage errors.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement'], 'kind': 'actor'}
+
 import _path  # noqa: F401  (py_placer -> py_router/py_tools on sys.path)
 import argparse
 import json

--- a/py_placer/converge.py
+++ b/py_placer/converge.py
@@ -1086,8 +1086,13 @@ def cmd_record(a):
         _miss = sorted(_need - _seen)
         if _miss:
             # The old text said "routing_driver --stage V5 fans them out".
-            # There is no routing_driver.py in this repo and there never has
-            # been; V1-V5 survive only as prose. This is a REFUSAL, i.e. the
+            # There is no routing_driver.py on main, and V1-V5 survive here
+            # only as prose. (It DID exist -- created at 255af97d, grown to
+            # 19 stages, on 10 commits, none of them on main; the maintainer
+            # removed it twice by name because it forked before #562 and went
+            # on emitting two steps main had deleted. "Never has been" was
+            # wrong, and a refusal is the worst place to be wrong about what
+            # exists.) This is a REFUSAL, i.e. the
             # one message whose entire job is to say what to do next, so it
             # names a file the reader can open instead of a tool they cannot
             # find.

--- a/py_placer/converge.py
+++ b/py_placer/converge.py
@@ -43,6 +43,11 @@ VERBS
         Iterations spent, split completion vs systemic. A budget going to the
         instrument rather than the board is the failure this makes visible.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'routing', 'combined'], 'kind': 'actor'}
+
 import _path  # noqa: F401  (py_placer -> py_router/py_tools on sys.path)
 import argparse
 import json

--- a/py_placer/converge.py
+++ b/py_placer/converge.py
@@ -2147,6 +2147,41 @@ def row_label(row):
     return '(no lever recorded)'
 
 
+def lever_identity(entry):
+    """WHICH LEVER a ledger row pulled, or None when the row records none.
+
+    The basename of `lever_argv[0]` -- the command that produced the board.
+    Never `lever`, which is free prose: `run_watch.py` is explicit that the
+    prose field is "NEVER matched", because a gate that reads a disclosure
+    punishes disclosing.
+
+    None is a first-class answer and is REPORTED rather than guessed at. Most
+    rows without one have no command to record: an L2 freeze stamp, an
+    `--exhausted` declaration and an L5 close-out all change no board and say
+    so. `board_store.replay_command` takes the same line for the same reason
+    -- it raises rather than reconstructing, because "pretending otherwise is
+    how a ledger becomes prose".
+    """
+    argv = entry.get('lever_argv') if isinstance(entry, dict) else None
+    if not argv or not isinstance(argv, (list, tuple)):
+        return None
+    for tok in argv:
+        if isinstance(tok, str) and tok.endswith('.py'):
+            return os.path.basename(tok)
+    first = argv[0] if isinstance(argv[0], str) else None
+    return os.path.basename(first) if first else None
+
+
+def _lever_histogram(rows):
+    """{lever: n} over the rows that name one, sorted for a stable document."""
+    out = {}
+    for e in rows:
+        name = lever_identity(e)
+        if name:
+            out[name] = out.get(name, 0) + 1
+    return dict(sorted(out.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
 def cmd_status(a):
     from board_store import Ledger
     lg = Ledger(a.ledger)
@@ -2158,6 +2193,30 @@ def cmd_status(a):
     # where the systemic NOTE already lives.
     _unlevered = [e for e in rows if not str(e.get('lever') or '').strip()]
     c['unlevered'] = len(_unlevered)
+    # THE STRUCTURED LEVER CHANNEL, beside the free-text one (#937).
+    #
+    # `loop_driver.py:4-9` records the ONE documented reason the two drivers
+    # are separate: "placement accepts a lap when the named finding it aimed
+    # at is gone, routing accepts an iteration when `blocking` strictly
+    # decreased... The driver never emits both." That is an argument for an
+    # accept rule stated PER LEVER rather than per half -- and the first thing
+    # such a rule needs is to know which lever a row pulled.
+    #
+    # `lever` cannot answer that: it is free prose by design, and
+    # run_watch.py:544 is explicit that it is "NEVER matched" because
+    # reporting on a disclosure punishes the disclosure. `lever_argv` can, and
+    # this reports how far it reaches. Measured over the 28 recorded ledgers
+    # in this tree: 411 of 450 rows carry one (91%), by kind completion 98%,
+    # placement 86%, systemic 79% -- and the 39 that do not are almost all
+    # rows with NO COMMAND to record (L2 freeze stamps, `--exhausted`
+    # declarations, L5 close-outs), with 4 genuinely undocumented.
+    #
+    # REPORTED, NOT YET GATED. Making the accept rule per-lever moves DONE and
+    # STUCK verdicts, and this repo grades a verdict-moving change by a corpus
+    # A/B, never by reasoning -- so the identity ships first and the rule that
+    # would consume it is a separate, measured change.
+    c['lever_identities'] = _lever_histogram(rows)
+    c['unreplayable'] = sum(1 for e in rows if lever_identity(e) is None)
     # #894: the placement terms per lap, and each lap's movement against the
     # row it was recorded against. Additive, inside the one JSON document --
     # this stdout is an API that callers json.loads() whole, which is why

--- a/py_placer/place_fanout_clearance.py
+++ b/py_placer/place_fanout_clearance.py
@@ -31,6 +31,11 @@ in the escape router's obstacle map.
 Pipeline: bga_fanout.py (all of them) -> place_fanout_clearance.py -> (gnd/power
 vias, route)
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'routing'], 'kind': 'actor'}
+
 import _path  # noqa: F401  (py_placer -> py_router/py_tools on sys.path)
 
 import math

--- a/py_placer/place_optimize.py
+++ b/py_placer/place_optimize.py
@@ -15,6 +15,11 @@ footprints never move.
 
 See docs/placement-optimization.md for the background research.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'combined'], 'kind': 'actor'}
+
 import _path  # noqa: F401  (py_placer -> py_router/py_tools on sys.path)
 
 import json

--- a/py_placer/place_portfolio.py
+++ b/py_placer/place_portfolio.py
@@ -22,6 +22,11 @@ not in a state placement may touch (unplaced, or already carries copper);
 
 See docs/placement-optimization.md (Portfolio section) for the background.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement'], 'kind': 'actor'}
+
 import _path  # noqa: F401  (py_placer -> py_router/py_tools on sys.path)
 import argparse
 import json

--- a/py_placer/place_pose.py
+++ b/py_placer/place_pose.py
@@ -55,6 +55,11 @@ There is no `--allow-unplaced`: this tool has no unplaced gate, because placing
 the parts of a pile one decision at a time is what it is for. An unplaced board
 is NOTED, not refused.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'combined'], 'kind': 'actor'}
+
 import _path  # noqa: F401  (py_placer -> py_router/py_tools on sys.path)
 import argparse
 import json

--- a/py_placer/place_reconstruct.py
+++ b/py_placer/place_reconstruct.py
@@ -20,6 +20,11 @@ no residual pad conflicts; 3 the board cannot be reconstructed here (no
 outline / carries copper); 4 residual violations remain (board still written
 for inspection).
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement'], 'kind': 'actor'}
+
 import _path  # noqa: F401  (py_placer -> py_router/py_tools on sys.path)
 import argparse
 import json

--- a/py_placer/place_route_loop.py
+++ b/py_placer/place_route_loop.py
@@ -26,6 +26,11 @@ Usage:
       [quench options]
 """
 from __future__ import annotations
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'combined'], 'kind': 'actor'}
+
 import _path  # noqa: F401  (py_placer -> py_router/py_tools on sys.path)
 
 import argparse

--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -22,6 +22,11 @@ seeded (no Edge.Cuts outline -- the outline is spec-owned and will not be
 invented -- or the board is already placed / carries copper); 4 the seed was
 written but parts could not be seated or the intent grade has errors.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement'], 'kind': 'actor'}
+
 import _path  # noqa: F401  (py_placer -> py_router/py_tools on sys.path)
 import argparse
 import json

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -3531,6 +3531,9 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
     # ("N part(s) with pad copper off-board") could not say WHICH part -- one
     # run deduced the single ref by elimination.
     oob_refs = []
+    #: The PER-PAD census beside the AABB one (#937). See its basis string
+    #: below for why both travel and neither replaces the other.
+    oob_copper_refs = []
     board_info = getattr(pcb_data, 'board_info', None)
     if board_info is not None and getattr(board_info, 'board_bounds', None):
         gate = BoardOutlineGate(board_info,
@@ -3552,6 +3555,41 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
                 oob_count += 1
                 oob_amount += amt
                 oob_refs.append([ref, round(amt, 4)])
+        # ...and the PER-PAD census beside it, at margin 0 (#937).
+        #
+        # The count above is an AABB over the whole part inflated by the
+        # GRADING CLEARANCE, which makes it unusable for the question a
+        # consumer actually has -- WHICH PART DO I MOVE. Measured over the
+        # tracked corpus it is non-zero on three boards, and on two of them
+        # (human reference boards carrying edge-mounted switches, at 0.03mm
+        # and 0.17mm) no pad crosses the real outline at all.
+        #
+        # BOTH TRAVEL; neither replaces the other. The coarse one keeps its
+        # meaning and its consumers: loop_driver's L2 gate is justified over
+        # 119 graded rows, where it refuses 24 boards of which 12 are refusals
+        # `blocking` does not make, and the two censuses are disjoint by
+        # construction -- a part off the outline collides with nothing. What
+        # this one adds is WHICH PADS, so a refusal is actionable and a coarse
+        # hit with an empty precise list reads as the artifact it is instead
+        # of as a silent defect.
+        pad_gate = BoardOutlineGate(board_info, 0.0)
+        for ref, pp in parts.items():
+            fp = fps[ref]
+            try:
+                rects = pp.pad_rects(fp.x, fp.y, fp.rotation or 0.0)
+            except Exception:                             # noqa: BLE001
+                continue
+            if not rects:
+                continue
+            # The same #628 ownership exemption the AABB pass takes: a part
+            # whose own pads ring a milled relief OWNS that ring and must not
+            # be graded as hanging off it.
+            own = pad_gate.rings_enclosing(
+                [(p.global_x, p.global_y) for p in pads_by_ref.get(ref, ())])
+            amt = max((pad_gate.rect_outside_amount(r[:4], skip_rings=own)
+                       for r in rects), default=0.0)
+            if amt > EPS:
+                oob_copper_refs.append([ref, round(amt, 4)])
     worst.sort(key=lambda t: -t[2])
     return {'pad_conflicts': pad_conflicts,
             'pad_shortfall': round(pad_shortfall, 4),
@@ -3559,6 +3597,19 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
             'oob_pad_count': oob_count,
             'oob_pad_amount': round(oob_amount, 4),
             'oob_pad_refs': sorted(oob_refs),
+            # The PER-PAD channel (#937), margin 0, same #628 ring ownership.
+            # This is the one CLAUDE.md designates for the top-priority
+            # placement defect ("read it off render_placement's
+            # checklist.a_off_outline.pad_copper") -- carried here too so a
+            # consumer holding only the assembly report can act on it without
+            # also rendering, and so the two numbers can be read side by side.
+            'oob_pad_copper_count': len(oob_copper_refs),
+            'oob_pad_copper_refs': sorted(oob_copper_refs),
+            'oob_pad_copper_basis': ('per-PAD copper rects against the real '
+                                     'outline at margin 0 (the authoritative '
+                                     'measure; the same question '
+                                     'render_placement answers in '
+                                     'checklist.a_off_outline.pad_copper)'),
             # WHICH QUANTITY THIS IS. Three tools print "pad copper
             # off-board" for three different measurements. This one is the
             # part's pad AABB against an outline inflated by the GRADING

--- a/py_placer/placement/portfolio.py
+++ b/py_placer/placement/portfolio.py
@@ -916,7 +916,15 @@ def rank_static(cands: Sequence[Candidate], q: int = 0) -> List[int]:
 
 def rule1_check(cand: Candidate, baseline: Candidate) -> List[str]:
     """Rule 1 of the Step-0c acceptance conjunction, applied K-way (run-7
-    S6): crossings and hpwl must be NO WORSE than the baseline row.
+    S6): **hpwl** must be NO WORSE than the baseline row.
+
+    HPWL ALONE. This sentence said "crossings and hpwl" while the code has
+    checked only hpwl since #789 withdrew the crossings clause -- so the
+    operative sentence of the rule stated a rule the function does not apply,
+    and a reader who acts on the first sentence is wrong while believing they
+    followed it. That is the defect family #936 catalogued, in the docstring
+    of the acceptance rule itself. The withdrawal is explained three
+    paragraphs down; it now also appears where the rule is defined (#937).
 
     The hard gates in score_candidate are legality + intent (rule 2). This
     metric clause was DOCUMENTED as pre-applied but never was, so a

--- a/py_placer/placement_score.py
+++ b/py_placer/placement_score.py
@@ -51,6 +51,11 @@ Exit codes
     3  board state (missing file, unparseable board)
 This tool grades nothing and gates nothing, so there is no "4".
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'combined'], 'kind': 'instrument'}
+
 import argparse
 import contextlib
 import json

--- a/py_placer/plane_score.py
+++ b/py_placer/plane_score.py
@@ -24,6 +24,11 @@ KiCad python exists for the refill (the score is then honestly unavailable,
 never guessed from drawn outlines).
 """
 from __future__ import annotations
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement'], 'kind': 'conditional'}
+
 import _path  # noqa: F401  (py_placer -> py_router/py_tools on sys.path)
 
 import math

--- a/py_router/animate_route.py
+++ b/py_router/animate_route.py
@@ -23,6 +23,10 @@ dumps raw frames for external encoding.
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'instrument'}
+
 import argparse
 import glob
 import os

--- a/py_router/bga_fanout.py
+++ b/py_router/bga_fanout.py
@@ -5,6 +5,10 @@ BGA Fanout Strategy - Creates escape routing for BGA packages.
 This is a wrapper script that imports from the bga_fanout package.
 """
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'actor'}
+
 from bga_fanout import main
 
 if __name__ == '__main__':

--- a/py_router/check_connected.py
+++ b/py_router/check_connected.py
@@ -3,6 +3,10 @@ Connectivity Checker - Verify that tracks form fully connected routes from sourc
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing', 'combined'], 'kind': 'instrument'}
+
 import sys
 import os
 import argparse

--- a/py_router/check_drc.py
+++ b/py_router/check_drc.py
@@ -3,6 +3,10 @@ DRC Checker - Find overlapping tracks and vias between different nets.
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'routing', 'combined'], 'kind': 'conditional'}
+
 import sys
 import argparse
 import math

--- a/py_router/check_pads.py
+++ b/py_router/check_pads.py
@@ -18,6 +18,10 @@ Exit code is the number of overlapping pairs (0 = clean), so it gates a pipeline
 
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'routing'], 'kind': 'instrument'}
+
 import argparse
 import math
 import sys

--- a/py_router/check_weird.py
+++ b/py_router/check_weird.py
@@ -74,6 +74,11 @@ Usage:
 
 Exit code 0 when clean, 1 when any findings.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'instrument'}
+
 import argparse
 import math
 import sys

--- a/py_router/cmd_timing.py
+++ b/py_router/cmd_timing.py
@@ -38,6 +38,10 @@ way ``py_tools/make_film._badge`` does.
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['combined'], 'kind': 'instrument'}
+
 import argparse
 import collections
 import json

--- a/py_router/copy_board.py
+++ b/py_router/copy_board.py
@@ -19,6 +19,11 @@ It copies ``.kicad_pcb`` and every sibling in ``SIBLING_EXTS``
 the stress redo manifest (``REDO_MANIFEST``) like the routing tools, so a replayed
 manifest reproduces the full copy (not just the board) -- no more floor drop.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'routing', 'combined'], 'kind': 'actor'}
+
 import os
 import shutil
 import sys

--- a/py_router/fix_kicad_drc_settings.py
+++ b/py_router/fix_kicad_drc_settings.py
@@ -73,6 +73,10 @@ Usage:
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'actor'}
+
 import argparse
 import json
 import os

--- a/py_router/kicad_iso_render.py
+++ b/py_router/kicad_iso_render.py
@@ -42,6 +42,10 @@ machine's KiCad. It resolves the binary through ``kicad_oracle.find_kicad_cli``
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'instrument'}
+
 import os
 import re
 import subprocess

--- a/py_router/kicad_parser.py
+++ b/py_router/kicad_parser.py
@@ -7073,14 +7073,26 @@ def auto_detect_bga_exclusion_zones(pcb_data: 'PCBData', margin: float = 0.0) ->
 
 
 if __name__ == "__main__":
-    import sys
+    import argparse
 
-    if len(sys.argv) < 2:
-        print("Usage: python py_router/kicad_parser.py <input.kicad_pcb> [output.json]")
-        sys.exit(1)
+    # A REAL parser, not a hand-rolled `Usage:` print. `--help` used to be read
+    # as the input FILENAME here, so a capability probe got
+    # `FileNotFoundError: '--help'` -- and this module, the one every other
+    # tool parses boards with, was invisible to any catalogue that asks a tool
+    # what it is (#937). `krt_registry.py` enumerates the catalogue by exactly
+    # that question, so a tool that cannot answer it is a tool nobody finds.
+    _ap = argparse.ArgumentParser(
+        description="Parse a KiCad PCB file and save the extracted data as "
+                    "JSON.")
+    _ap.add_argument('input_file', help='the .kicad_pcb to parse')
+    _ap.add_argument('output_file', nargs='?', default=None,
+                     help='where to write the JSON '
+                          '(default: <input>_extracted.json)')
+    _a = _ap.parse_args()
 
-    input_file = sys.argv[1]
-    output_file = sys.argv[2] if len(sys.argv) > 2 else input_file.replace('.kicad_pcb', '_extracted.json')
+    input_file = _a.input_file
+    output_file = _a.output_file or input_file.replace('.kicad_pcb',
+                                                       '_extracted.json')
 
     print(f"Parsing {input_file}...")
     pcb_data = parse_kicad_pcb(input_file)

--- a/py_router/kicad_parser.py
+++ b/py_router/kicad_parser.py
@@ -3,6 +3,10 @@ KiCad PCB Parser - Extracts pads, nets, tracks, vias, and board info from .kicad
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': [], 'kind': 'instrument'}
+
 import functools
 import os
 import re

--- a/py_router/list_nets.py
+++ b/py_router/list_nets.py
@@ -19,6 +19,10 @@ Examples:
     python list_nets.py board.kicad_pcb --diff-pairs --power
 """
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'routing'], 'kind': 'instrument'}
+
 import argparse
 import json
 import math

--- a/py_router/make_movie.py
+++ b/py_router/make_movie.py
@@ -25,6 +25,10 @@ re-implementing it, so all three produce the same movie.
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing', 'combined'], 'kind': 'instrument'}
+
 import argparse
 import os
 import sys

--- a/py_router/make_plan.py
+++ b/py_router/make_plan.py
@@ -85,6 +85,29 @@ def make_plan(source, out=None):
     return out, steps, skipped
 
 
+def plan_commands(source):
+    """[(cwd, argv)] for a manifest or run dir -- EVERY recorded command, in
+    file order, with nothing pruned.
+
+    `make_plan` above converts to GUI steps, and that conversion deliberately
+    DROPS what the GUI cannot execute: every `check_*` command, `cd`, `cp`,
+    superseded retries and dead-end branches, and any tool with no plan
+    action. It also loses the tool NAME (`route_planes` and `repair_planes`
+    both become `repair_planes`), the argv, and any index back into the file.
+
+    A checker of the plan needs precisely what that drops -- whether the chain
+    ends on route.py, whether a `cp` carried its `.kicad_pro`, whether a pipe
+    got in -- so it gets the raw list, and `plan_steps_from_manifest` stays
+    the one conversion.
+
+    Note what even this cannot see: `parse_manifest` drops COMMENTS, and the
+    routing skill requires verification commands to BE comments. A rule about
+    those has to read the file text.
+    """
+    from redo_stress_test import parse_manifest
+    return parse_manifest(resolve_manifest(source))
+
+
 def describe(step, index):
     """One human-readable line for a step (no wx needed, unlike the GUI's
     step_label, so --list works under any python)."""

--- a/py_router/make_plan.py
+++ b/py_router/make_plan.py
@@ -28,6 +28,10 @@ plugin package, so this script needs a git checkout.)
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'instrument'}
+
 import argparse
 import json
 import os

--- a/py_router/movie_panels.py
+++ b/py_router/movie_panels.py
@@ -362,7 +362,7 @@ def iso_panel(box_wh, png_path, caption, error='', scale=None):
     An earlier version returned only the image, so a panel that had "could not
     read the render" written across it still counted as a success.
 
-    Same contract as ``make_film._card_frame`` (``py_tools/make_film.py:231``),
+    Same contract as ``make_film._card_frame`` (``py_tools/make_film.py:236``),
     and deliberately so -- fitting an image of untrusted size into a fixed frame
     is the same problem, and it has been solved once here already.
 

--- a/py_router/pack_river.py
+++ b/py_router/pack_river.py
@@ -13,6 +13,11 @@ is a pure coordinate rewrite of existing segments (no adds/removes).
 
 Usage: pack_river.py IN.kicad_pcb OUT.kicad_pcb [--clearance C] [--min-run L]
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'actor'}
+
 import argparse
 import math
 import re

--- a/py_router/place_fanout_clearance.py
+++ b/py_router/place_fanout_clearance.py
@@ -27,6 +27,11 @@ Do not delete this without rewriting the recorded corpus -- and note that
 rewriting it would make those chains replayable ONLY on branches that carry the
 #522 layout, so main and placement could no longer be A/B'd on the same corpus.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'routing'], 'kind': 'actor'}
+
 import os
 import runpy
 import sys

--- a/py_router/qfn_fanout.py
+++ b/py_router/qfn_fanout.py
@@ -6,6 +6,10 @@ This is a thin wrapper that calls the qfn_fanout package.
 See qfn_fanout/README.md for documentation.
 """
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'actor'}
+
 from qfn_fanout import main
 
 if __name__ == '__main__':

--- a/py_router/repair_planes.py
+++ b/py_router/repair_planes.py
@@ -25,6 +25,10 @@ Usage:
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing', 'combined'], 'kind': 'actor'}
+
 import env_knobs
 import sys
 import os

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -13,6 +13,10 @@ verifies the version; see CLAUDE.md).
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing', 'combined'], 'kind': 'actor'}
+
 import env_knobs
 import sys
 import os

--- a/py_router/route_diff.py
+++ b/py_router/route_diff.py
@@ -16,6 +16,10 @@ verifies the version; see CLAUDE.md).
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing', 'combined'], 'kind': 'actor'}
+
 import env_knobs
 import sys
 import os

--- a/py_router/route_planes.py
+++ b/py_router/route_planes.py
@@ -15,6 +15,10 @@ Usage:
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing', 'combined'], 'kind': 'actor'}
+
 import env_knobs
 import re
 import sys

--- a/py_router/route_render.py
+++ b/py_router/route_render.py
@@ -35,6 +35,10 @@ Library:
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'instrument'}
+
 import argparse
 import math
 import os

--- a/py_router/run_plan.py
+++ b/py_router/run_plan.py
@@ -22,6 +22,10 @@ automatically, so plain ``python3 run_plan.py ...`` works.
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'actor'}
+
 import argparse
 import os
 import sys

--- a/py_tools/analyze_power_paths.py
+++ b/py_tools/analyze_power_paths.py
@@ -574,12 +574,19 @@ def analyze_pcb(filepath: str) -> Tuple[Dict[str, ComponentInfo], PCBData]:
 
 
 if __name__ == "__main__":
-    import sys
-    if len(sys.argv) < 2:
-        print("Usage: python analyze_power_paths.py <pcb_file>")
-        sys.exit(1)
+    import argparse
 
-    components, pcb_data = analyze_pcb(sys.argv[1])
+    # A REAL parser, not a hand-rolled `Usage:` print: `--help` used to be read
+    # as the board FILENAME, so this answered a capability probe with
+    # `FileNotFoundError: '--help'` (#937). See kicad_parser.py's `__main__`
+    # for the same fix and why it matters.
+    _ap = argparse.ArgumentParser(
+        description="Classify components by power role and report the ones "
+                    "that still need analysis.")
+    _ap.add_argument('pcb_file', help='the .kicad_pcb to analyze')
+    _a = _ap.parse_args()
+
+    components, pcb_data = analyze_pcb(_a.pcb_file)
 
     # Show components needing analysis
     unknown = get_components_needing_analysis(components)

--- a/py_tools/analyze_power_paths.py
+++ b/py_tools/analyze_power_paths.py
@@ -18,6 +18,11 @@ Usage:
 """
 
 from __future__ import annotations
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (#522: makes ../py_router importable)
 
 from dataclasses import dataclass, field

--- a/py_tools/animate_fanout_clearance.py
+++ b/py_tools/animate_fanout_clearance.py
@@ -17,6 +17,11 @@ encoding through animate_route.save_movie (#431), so this file no longer
 carries its own transform, GIF writer or font handling. Both are already used by
 this repo's tooling. No matplotlib / ffmpeg needed.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (#522: makes ../py_router importable)
 
 

--- a/py_tools/board_brief.py
+++ b/py_tools/board_brief.py
@@ -39,6 +39,11 @@ A brief that silently omitted a measurement would read as "nothing to report".
 Exit codes: 0 = a brief was written, 2 = usage/load error, 3 = no outline
 (there is nothing to place against).
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'combined'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
 
 import argparse

--- a/py_tools/board_context.py
+++ b/py_tools/board_context.py
@@ -53,6 +53,10 @@ is flagged when the two disagree.
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'combined'], 'kind': 'instrument'}
+
 import _path  # noqa: F401
 import argparse
 import contextlib

--- a/py_tools/check_assembly.py
+++ b/py_tools/check_assembly.py
@@ -324,6 +324,25 @@ def main():
           f"{leg['hole_conflicts']} hole conflict(s), "
           f"{leg['oob_pad_count']} part(s) with pad copper off-board"
           + (": " + _clause if _clause else ""))
+    # BOTH off-outline channels, side by side, whenever either fires (#937).
+    # The line above is the part AABB inflated by the grading clearance; this
+    # is the per-PAD measure at margin 0, which is the one CLAUDE.md
+    # designates for the top-priority placement defect. Printed together
+    # because their DISAGREEMENT is the useful signal: a coarse hit with an
+    # empty precise list is the bounding box of an edge-mounted part, not
+    # copper in the air, and a reader who sees only the count cannot tell.
+    _exact = leg.get('oob_pad_copper_refs') or []
+    if leg['oob_pad_count'] or _exact:
+        if _exact:
+            print("    pad copper genuinely off the outline (per-pad, "
+                  "margin 0): "
+                  + ', '.join(f'{r} ({a}mm)' for r, a in _exact))
+        else:
+            print("    ...but NO PAD crosses the real outline (per-pad, "
+                  "margin 0, is empty). The count above is the part's "
+                  "bounding box against an outline inflated by the grading "
+                  "clearance -- an edge-mounted part reports a breach its "
+                  "copper does not make.")
     # ONE predicate, used verbatim at all three sites (verdict, JSON
     # `buildable`, exit code). Three re-derivations of `blocking or
     # locked_contact` is how the coincident-origin channel would have reached
@@ -596,6 +615,16 @@ def main():
             # as copper in the air. Both facts now travel with the number.
             'oob_pad_refs': leg.get('oob_pad_refs') or [],
             'oob_pad_basis': leg.get('oob_pad_basis'),
+            # The PER-PAD channel beside the AABB one (#937). The gate in
+            # loop_driver's L2 reads `oob_pad_count` and is right to -- it is
+            # justified over 119 graded rows -- but a consumer holding only
+            # this document could not tell a real off-outline pad from the
+            # bounding box of an edge part, and the refusal it writes says
+            # "their nets cannot be routed at all", which is true of one and
+            # not the other. Both keys travel; neither replaces the other.
+            'oob_pad_copper_count': leg.get('oob_pad_copper_count', 0),
+            'oob_pad_copper_refs': leg.get('oob_pad_copper_refs') or [],
+            'oob_pad_copper_basis': leg.get('oob_pad_copper_basis'),
             'locked_contact_pairs': [q._asdict() for q in locked_contact],
             # run-19: parts stacked at one origin, marker classes exonerated.
             # Groups, not fake N*(N-1)/2 pair entries -- a stack is one

--- a/py_tools/check_assembly.py
+++ b/py_tools/check_assembly.py
@@ -25,6 +25,11 @@ landing on a KiCad-locked part (see LOCKED-PART CONTACT) OR a coincident-
 origin stack (see COINCIDENT ORIGINS) OR a containment OR a moved-vs-
 baseline courtyard interpenetration (see COURTYARD BLOCKING).
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'combined'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
 
 import argparse

--- a/py_tools/check_capacity.py
+++ b/py_tools/check_capacity.py
@@ -28,6 +28,11 @@ There is deliberately NO exit code for "the board is too small". A gate that
 refuses on this would refuse boards that route fine -- the area test is a
 necessary condition, not a sufficient one -- and the executor decides.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
 
 import argparse

--- a/py_tools/check_channels.py
+++ b/py_tools/check_channels.py
@@ -25,6 +25,11 @@ having lanes to spare. `--json` keeps them apart (`starved_faces`,
 
 V1 limitation, stated: supply-tap/via lane consumption is not modeled.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'combined'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
 
 import argparse

--- a/py_tools/check_cycles.py
+++ b/py_tools/check_cycles.py
@@ -19,6 +19,11 @@ Usage:
     python3 check_cycles.py board.kicad_pcb [--net NAME | --nets PATTERN]
                                             [--all] [--verbose]
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (#522: makes ../py_router importable)
 
 import argparse

--- a/py_tools/check_floorplan.py
+++ b/py_tools/check_floorplan.py
@@ -38,6 +38,11 @@ broken", and that distinction is the entire product. (`check_drc.py` uses 1 for
 its violations; this diverges knowingly.)
 """
 from __future__ import annotations
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'combined'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
 
 import argparse

--- a/py_tools/check_impedance.py
+++ b/py_tools/check_impedance.py
@@ -31,6 +31,11 @@ build the way check_drc.py does), 0 otherwise. ``--exit-zero`` suppresses that.
 """
 
 from __future__ import annotations
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing', 'combined'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (#522: makes ../py_router importable)
 
 import argparse

--- a/py_tools/check_join.py
+++ b/py_tools/check_join.py
@@ -21,6 +21,11 @@ Track width and via geometry default from the board's own Default netclass.
 
 Exit 0 clean, 1 violations, 2 usage errors.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing', 'combined'], 'kind': 'conditional'}
+
 import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
 import argparse
 import json

--- a/py_tools/check_orphan_stubs.py
+++ b/py_tools/check_orphan_stubs.py
@@ -19,6 +19,11 @@ Examples:
 """
 
 from __future__ import annotations
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (#522: makes ../py_router importable)
 
 import argparse

--- a/py_tools/check_orthonormal.py
+++ b/py_tools/check_orthonormal.py
@@ -9,6 +9,11 @@ merged terminal that spanned many cells (it can cut straight across foreign
 copper -- see issues #157 / #159). This check finds them directly in the
 output, independent of DRC.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (#522: makes ../py_router importable)
 
 import argparse

--- a/py_tools/check_pockets.py
+++ b/py_tools/check_pockets.py
@@ -49,6 +49,11 @@ or refuse the handoff itself.
 
 Exit codes: 0 always (report), 2 usage/load error.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'combined'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
 
 import argparse

--- a/py_tools/check_reachability.py
+++ b/py_tools/check_reachability.py
@@ -34,6 +34,11 @@ an unreadable board file -- exits 2 with what it could not resolve. It used to
 exit 1, because `raise SystemExit(msg)` does, and a caller acting on exit 1
 re-enters placement and throws away every routed board.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'combined'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
 import argparse
 import json

--- a/py_tools/clean_ignored.py
+++ b/py_tools/clean_ignored.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 """List and optionally delete all git-ignored files in the repository."""
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': [], 'kind': 'utility'}
+
 import _path  # noqa: F401  (#522: makes ../py_router importable)
 
 

--- a/py_tools/extract_pcb_geometry.py
+++ b/py_tools/extract_pcb_geometry.py
@@ -14,6 +14,11 @@ Examples:
 """
 
 from __future__ import annotations
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': [], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (#522: makes ../py_router importable)
 
 import sys

--- a/py_tools/fill_for_delivery.py
+++ b/py_tools/fill_for_delivery.py
@@ -31,6 +31,10 @@ graded against rules it no longer carries is worse than no board.
 """
 from __future__ import annotations
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing'], 'kind': 'actor'}
+
 import _path  # noqa: F401  (#522: puts ../py_router on sys.path)
 
 import argparse

--- a/py_tools/kicad_unconnected.py
+++ b/py_tools/kicad_unconnected.py
@@ -36,6 +36,11 @@ Two caller contracts on --pairs-json worth stating (both verified):
 """
 
 from __future__ import annotations
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing', 'combined'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (#522: makes ../py_router importable)
 
 import argparse

--- a/py_tools/make_film.py
+++ b/py_tools/make_film.py
@@ -39,6 +39,11 @@ looks like the board redrawing itself between beats.
     python3 make_film.py seed.kicad_pcb \\
         'delta.png=what moved, and by how much' placed.kicad_pcb -o film.gif
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'combined'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
 import argparse
 import fnmatch

--- a/py_tools/net_forensics.py
+++ b/py_tools/net_forensics.py
@@ -25,6 +25,11 @@ destination traffic; this tool automates that diagnosis.
 """
 
 from __future__ import annotations
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['routing', 'combined'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (#522: makes ../py_router importable)
 
 import argparse

--- a/py_tools/render_placement.py
+++ b/py_tools/render_placement.py
@@ -27,6 +27,11 @@ never why it helped. The caption strip carries the verdict, and a render without
 it invites exactly the wrong review heuristic.
 """
 from __future__ import annotations
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': ['placement', 'combined'], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
 
 import argparse

--- a/py_tools/validate_pcb_data.py
+++ b/py_tools/validate_pcb_data.py
@@ -17,6 +17,11 @@ default install paths); pass boards as arguments:
 
 Exit status: 0 = all boards match, 1 = differences found, 2 = error.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': [], 'kind': 'instrument'}
+
 import _path  # noqa: F401  (#522: makes ../py_router importable)
 
 import argparse

--- a/py_tools/validate_pcb_data.py
+++ b/py_tools/validate_pcb_data.py
@@ -19,6 +19,7 @@ Exit status: 0 = all boards match, 1 = differences found, 2 = error.
 """
 import _path  # noqa: F401  (#522: makes ../py_router importable)
 
+import argparse
 import os
 import sys
 
@@ -45,9 +46,21 @@ def _reexec_with_kicad_python():
 
 
 def main() -> int:
-    boards = [a for a in sys.argv[1:] if not a.startswith('-')]
+    # A REAL parser. This printed its docstring and exited 2 on `--help`, so a
+    # capability probe could not tell it from a tool that had crashed (#937) --
+    # and it is the parser-parity gate, the one tool whose absence from a
+    # catalogue would be least noticed. Parsed BEFORE the pcbnew re-exec, so
+    # `--help` answers under a plain python3 as well as KiCad's.
+    ap = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='Exit status: 0 = all boards match, 1 = differences found, '
+               '2 = error.')
+    ap.add_argument('boards', nargs='*',
+                    help='the .kicad_pcb file(s) to compare, both ways')
+    boards = ap.parse_args().boards
     if not boards:
-        print(__doc__)
+        ap.print_help()
         return 2
 
     try:

--- a/rust_router/microbench.py
+++ b/rust_router/microbench.py
@@ -22,6 +22,11 @@ Usage:
 The printed `iterations` must be IDENTICAL across binaries for the
 byte-identical 0.18.0 items (S1, S2, C1); only the time may change.
 """
+
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': [], 'kind': 'utility'}
+
 import argparse
 import os
 import sys

--- a/tests/mutate_936.py
+++ b/tests/mutate_936.py
@@ -140,6 +140,25 @@ ROWS = [
      '            out |= set()\n',
      (T_DFL,), KILLED),
 
+    # ---- the placement door gates off-outline pad copper --------------------
+    # The top-priority placement defect, checked at one door of three until now.
+    # Deliberately on the PER-PAD channel: check_assembly's `oob_pad_count` is a
+    # part-level AABB that reads non-zero on two HUMAN boards whose pads are
+    # fine (glasgow_revC 0.03mm, watchy 0.17mm), so gating on that count would
+    # refuse them. Blinding the read must redden the driver's own self-test.
+    ('off-outline-gate-blinded', 'pd',
+     "    _oob = (chk.get('a_off_outline') or {}).get('pad_copper')\n",
+     "    _oob = None\n",
+     (T_DRIVERS,), KILLED),
+
+    # ---- test_431's exit-code scanner, its only live half -------------------
+    # The corpus has 0 annotated commands, so a scanner that stopped matching
+    # reports the same 0. The positive control is what tells those apart.
+    ('exit3-scanner-blinded', 't431',
+     "            blk = '\\n'.join(ls[i + 1:i + 4])\n",
+     "            blk = ''\n",
+     (T_431,), KILLED),
+
     # ---- B6: a gate must not pin the citation it exists to keep correct -----
     # `def better` moved from 358 to 564. The gate hardcoded 358, so correcting
     # the skill FAILED the test whose job is keeping the skill correct.

--- a/tests/mutate_937.py
+++ b/tests/mutate_937.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Mutation battery for #937 -- each acceptance criterion, proved to kill.
+
+#937 asks for a catalogue nothing can silently drop a tool from, an entry gate
+at the door that had none, a checker that proves a routing plan, and thresholds
+that report instead of deciding. Every one of those is a GATE, and this repo's
+recurring failure is a new gate that asserts nothing while printing PASS --
+three of the arms added for #936 did exactly that before a verifier broke
+them, and three more in this PR were caught the same way. So every row below
+reverts one fix and names the test that must go red.
+
+    python3 tests/mutate_937.py            # every row
+    python3 tests/mutate_937.py --list
+    python3 tests/mutate_937.py --row scope-collapsed
+
+A row is KILLED by a FAILURE or an ERROR. An anchor that does not match
+EXACTLY ONCE is reported BROKEN, never skipped: a mutation that edited nothing
+would otherwise be recorded as a surviving row, which is the opposite of what
+it means. Read the EXIT CODE of a killed row, not just the verdict --
+3221225794 (0xC000013A) is an interrupt, not a mutation, and a battery
+interrupted mid-run prints a wall of meaningless `KILLED ok`.
+
+Refuses to start on a dirty target tree, because it restores the ORIGINAL text
+from disk and would write committed text over uncommitted work.
+
+`scope-collapsed` is the anti-vacuity row and the one worth reading twice: it
+sets every tool's scope to ONE door, leaving the global count untouched at 72.
+A registry gate with only a global floor passes that mutation while every
+routing reader is stranded -- which is exactly the failure the per-door floors
+exist for.
+
+`arm-ceiling-undeclared` runs `test_431_skill_commands.py`, which costs ~110 s.
+It is the one slow row and it earns it: nothing else asserts that
+`loop_driver --dump-all` exits 0, and that exit code is what holds the twelve
+populated-arm ceilings down.
+"""
+import argparse
+import io
+import os
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+KILLED, SURVIVED, BROKEN = 'KILLED', 'SURVIVED', 'BROKEN'
+
+TARGETS = {
+    'reg': os.path.join(REPO, 'krt_registry.py'),
+    'cyc': os.path.join(REPO, 'py_tools', 'check_cycles.py'),
+    'chk': os.path.join(REPO, '.claude', 'skills', 'plan-pcb-routing',
+                        'scripts', 'route_plan_check.py'),
+    'leg': os.path.join(REPO, 'py_placer', 'placement', 'legality.py'),
+    'pd': os.path.join(REPO, '.claude', 'skills', 'plan-pcb-placement',
+                       'scripts', 'placement_driver.py'),
+    'ld': os.path.join(REPO, '.claude', 'skills',
+                       'plan-pcb-placement-and-routing', 'scripts',
+                       'loop_driver.py'),
+    'rt': os.path.join(REPO, '.claude', 'skills', 'plan-pcb-routing',
+                       'SKILL.md'),
+    'cv': os.path.join(REPO, 'py_placer', 'converge.py'),
+}
+
+T_REG = 'tests/test_937_tool_registry.py'
+T_CHK = 'tests/test_937_route_plan_check.py'
+T_OOB = 'tests/test_937_off_outline_channels.py'
+T_GATE = 'tests/test_937_entry_gates.py'
+T_LEV = 'tests/test_937_lever_identity.py'
+T_DRV = 'tests/test_run8_skill_drivers.py'
+T_431 = 'tests/test_431_skill_commands.py'
+
+#: (name, target, old, new, tests that must notice, expectation)
+ROWS = [
+    # ---- the catalogue is complete, and gated ------------------------------
+    ('declaration-dropped', 'cyc',
+     "KRT_TOOL = {'scope': ['routing'], 'kind': 'instrument'}",
+     "_KRT_TOOL_WAS_HERE = None",
+     (T_REG,), KILLED),
+    # THE ANTI-VACUITY ROW. The global count does not move; the routing and
+    # combined doors empty out. Only a PER-DOOR floor can see this.
+    ('scope-collapsed', 'reg',
+     "            'scope': list(scope) if isinstance(scope, (list, tuple)) else None,",
+     "            'scope': ['placement'],",
+     (T_REG,), KILLED),
+    # The cross-check that caught itself: a substring scan reports the module
+    # that EXPLAINS record_invocation as a caller of it.
+    ('self-records-by-substring', 'reg',
+     "    for node in ast.walk(tree):\n        if not isinstance(node, ast.Call):\n            continue",
+     "    for node in ast.walk(tree):\n        if 'record_invocation' in ast.dump(tree):\n            return True\n        if not isinstance(node, ast.Call):\n            continue",
+     (T_REG,), KILLED),
+
+    # ---- the routing door has an entry gate --------------------------------
+    ('routing-step0-deleted', 'rt',
+     '## Step 0: the placement gate -- is this board ready to route?',
+     '## Notes on placement (informational)',
+     (T_GATE,), KILLED),
+    ('routing-howto-deleted', 'rt',
+     '## How to run this skill',
+     '## Some background',
+     (T_GATE,), KILLED),
+
+    # ---- P2/P3 read the VERDICT, not one of its five conjuncts -------------
+    ('guard-damage-reads-blocking', 'pd',
+     "        undamaged = (not blocking) if buildable is None else bool(buildable)",
+     "        undamaged = not blocking",
+     (T_GATE,), KILLED),
+
+    # ---- the plan checker --------------------------------------------------
+    # A raw-text rule: invisible to the converted plan steps, which is the
+    # design decision this row regression-tests.
+    ('checker-verification-rule-blinded', 'chk',
+     "        t = tool_of(s.split())\n        if t and t.startswith('check_'):",
+     "        t = tool_of(s.split())\n        if False:",
+     (T_CHK,), KILLED),
+    # Step 5b's two asserts, which shipped in a fenced block no test ran.
+    ('checker-net-coverage-blinded', 'chk',
+     "    orphans = exclusions ^ impedance_se",
+     "    orphans = set()",
+     (T_CHK,), KILLED),
+    # A refusal that exits 0 is a checker nobody has to obey.
+    ('checker-refusal-exits-clean', 'chk',
+     "CLEAN, CRASH, USAGE, UNREADABLE, REFUSED = 0, 1, 2, 3, 4",
+     "CLEAN, CRASH, USAGE, UNREADABLE, REFUSED = 0, 1, 2, 3, 0",
+     (T_CHK,), KILLED),
+
+    # ---- both off-outline channels travel ----------------------------------
+    ('per-pad-channel-dropped', 'leg',
+     "            if amt > EPS:\n                oob_copper_refs.append([ref, round(amt, 4)])",
+     "            if False:\n                oob_copper_refs.append([ref, round(amt, 4)])",
+     (T_OOB,), KILLED),
+
+    # ---- the threshold reports, the model disposes -------------------------
+    ('congestion-silent-above-the-cut', 'ld',
+     "        return True, (\n            f'  CONGESTION READ: hpwl {b:.1f} -> {n:.1f} '",
+     "        return True, None\n        return True, (\n            f'  CONGESTION READ: hpwl {b:.1f} -> {n:.1f} '",
+     (T_DRV,), KILLED),
+
+    # ---- every populated arm is measured -----------------------------------
+    # Drops one arm from the ceiling table; the dump must refuse an arm it
+    # cannot hold, and test_431 asserts that dump exits 0. ~110 s.
+    ('arm-ceiling-undeclared', 'ld',
+     "    'L3': 75, 'L4': 45, 'L5': 40,",
+     "    'L4': 45, 'L5': 40,",
+     (T_431,), KILLED),
+
+    # ---- the lever identity is structured, never the prose -----------------
+    ('lever-read-from-the-prose', 'cv',
+     "    argv = entry.get('lever_argv') if isinstance(entry, dict) else None",
+     "    argv = (entry.get('lever_argv') or [entry.get('lever')]) \\\n        if isinstance(entry, dict) else None",
+     (T_LEV,), KILLED),
+]
+
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from mutation_anchors import preflight                       # noqa: E402
+preflight(__file__)
+
+
+def _dirty():
+    r = subprocess.run(['git', 'status', '--porcelain']
+                       + sorted(set(TARGETS.values())),
+                       cwd=REPO, capture_output=True, text=True)
+    return [ln for ln in r.stdout.splitlines() if ln.strip()]
+
+
+def run_row(row, keep=False):
+    name, target, old, new, tests, _expect = row
+    path = TARGETS[target]
+    # newline='' on BOTH sides: read with universal newlines and write with
+    # none and every CRLF file comes back LF, so a row that RESTORED its
+    # target still left the tree dirty.
+    with io.open(path, encoding='utf-8', newline='') as fh:
+        original = fh.read()
+    if '\r\n' in original:
+        old = old.replace('\n', '\r\n')
+        new = new.replace('\n', '\r\n')
+    if original.count(old) != 1:
+        return BROKEN, f'anchor matched {original.count(old)} time(s)'
+    try:
+        with io.open(path, 'w', encoding='utf-8', newline='') as fh:
+            fh.write(original.replace(old, new, 1))
+        for t in tests:
+            r = subprocess.run([sys.executable, '-X', 'utf8',
+                                os.path.join(REPO, t)],
+                               cwd=REPO, capture_output=True, text=True,
+                               encoding='utf-8', errors='replace')
+            if r.returncode != 0:
+                return KILLED, f'{t} exit {r.returncode}'
+        return SURVIVED, ''
+    finally:
+        if not keep:
+            with io.open(path, 'w', encoding='utf-8', newline='') as fh:
+                fh.write(original)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--list', action='store_true')
+    ap.add_argument('--row', action='append', default=[])
+    a = ap.parse_args()
+
+    if a.list:
+        for name, target, _o, _n, tests, expect in ROWS:
+            print(f"  {name:34} {target:5} {expect:8} {' '.join(tests)}")
+        return 0
+
+    dirty = _dirty()
+    if dirty:
+        print('REFUSING: the target tree is dirty. This restores the ORIGINAL '
+              'text from disk and would write committed text over uncommitted '
+              'work.')
+        for ln in dirty:
+            print(f'  {ln}')
+        return 2
+
+    rows = [r for r in ROWS if not a.row or r[0] in a.row]
+    if a.row and not rows:
+        print(f'no row matches {a.row}')
+        return 2
+    counts = {KILLED: 0, SURVIVED: 0, BROKEN: 0}
+    disagreed = 0
+    for row in rows:
+        got, detail = run_row(row)
+        counts[got] += 1
+        flag = 'ok  ' if got == row[5] else 'DISAGREES'
+        if got != row[5]:
+            disagreed += 1
+        print(f'  {row[0]:34} {got:9} {flag} {detail}')
+    print(f"\n{len(rows)} rows: {counts[KILLED]} killed, "
+          f"{counts[SURVIVED]} survived, {counts[BROKEN]} broken, "
+          f"{disagreed} disagreeing with expectation")
+    return 1 if (counts[BROKEN] or disagreed) else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/stress/perturb_batch.py
+++ b/tests/stress/perturb_batch.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """First-batch runner for the #411 perturbed-corpus rig.
 
-Walks the `plan-pcb-routing` skill's Step 0 ladder on a PERTURBED board and
+Walks the `plan-pcb-placement` skill's Step 0 ladder on a PERTURBED board and
 scores the result against the original, which is free ground truth.
 
     Step 0    decision table -- a perturbed board is the "rough / imported /

--- a/tests/test_431_skill_commands.py
+++ b/tests/test_431_skill_commands.py
@@ -875,6 +875,7 @@ def test_the_defaults_the_skills_quote_are_the_real_defaults():
 def test_every_documented_flag_exists():
     problems = []
     checked = 0
+    uncited = []
     for tool in TOOLS:
         # Collect the citations FIRST, and only then go looking for a parser.
         # A tool invoked without flags has no contract to check, and resolving
@@ -887,6 +888,13 @@ def test_every_documented_flag_exists():
                 for flag in _cited_flags(block, tool):
                     cites.append((src, flag))
         if not cites:
+            # DISCLOSED, not silently skipped (#937). A tool the skills invoke
+            # and pass no flag to is legitimate -- but it is also exactly what
+            # a tool going dark looks like, and the 900-odd aggregate below
+            # absorbs it either way. Naming the population turns an invisible
+            # zero into a number somebody can argue with, which is the shape
+            # #939 used for the 13 value-unchecked spans.
+            uncited.append(tool)
             continue
         try:
             valid = _parser_for(tool)
@@ -912,7 +920,18 @@ def test_every_documented_flag_exists():
     # instruction branch alone yields 574, so 400 could not see the refusal
     # half disappear. Measured after: 862.
     assert checked >= 650, f"only {checked} flag citations found -- scanner broken?"
-    print(f"  PASS: {checked} flag citations, all real")
+    # ...and the population this aggregate CANNOT see. A per-tool floor was
+    # considered and rejected: test_doc_flag_liveness gives the reason in its
+    # own words -- "a gate that cries wolf gets deleted" -- and most of these
+    # are tools the skills legitimately invoke bare. A CEILING is the right
+    # shape: legitimate to have, illegitimate to grow.
+    assert len(uncited) <= 10, (
+        f"{len(uncited)} of the {len(TOOLS)} discovered tools are invoked "
+        f"with no flag at all, so this gate checks nothing about them: "
+        f"{sorted(uncited)}")
+    print(f"  PASS: {checked} flag citations, all real "
+          f"({len(uncited)} tool(s) invoked with no flag: "
+          f"{', '.join(sorted(os.path.basename(t) for t in uncited))})")
 
 
 def test_the_placement_tools_are_actually_mentioned():

--- a/tests/test_431_skill_commands.py
+++ b/tests/test_431_skill_commands.py
@@ -497,6 +497,7 @@ def test_driver_commands_supply_required_options_and_values():
     """
     problems = []
     checked = 0
+    unparsed = {}
     for src in DRIVERS:
         text = source_text(src)
         for tool in TOOLS:
@@ -507,7 +508,20 @@ def test_driver_commands_supply_required_options_and_values():
             try:
                 parser = _parser_obj(tool)
             except Exception:
-                continue          # covered by the flag test's own <parser> row
+                # DECLARED, not dropped. `_parser_obj` builds the parser by
+                # importing the tool and calling `main()` with --help
+                # intercepted; a tool that parses its args anywhere else has no
+                # `main` to call, and this arm used to `continue` in silence --
+                # 13 emitted command spans went unchecked while the gate
+                # printed a clean count. The flag NAMES in them are still
+                # covered, by the flag test's `--help` reader; what is not
+                # covered is whether each flag was given a VALUE.
+                #
+                # Counted and held to no growth, the shape test_923 uses for
+                # its skipped sections: a population that is legitimate to have
+                # and illegitimate to grow.
+                unparsed[tool] = unparsed.get(tool, 0) + len(spans)
+                continue
             import argparse as _ap
             # store_true/store_false/count/help consume nothing; every other
             # action stores a value and argparse errors without one -- EXCEPT
@@ -550,7 +564,21 @@ def test_driver_commands_supply_required_options_and_values():
     # with the refusal half gone -- measured, as a battery row that SURVIVED.
     # Measured after: 154.
     assert checked >= 90, f'only {checked} driver command(s) scanned'
-    print(f'  PASS: {checked} driver command spans, all runnable')
+    # The population this arm cannot value-check, named and capped. 13 today:
+    # check_drc.py 10, check_connected.py 3 -- both parse their args outside a
+    # `main()`, so `_parser_obj` has nothing to call. Giving either one a
+    # `main()` moves its spans into `checked` and this number DOWN, which is
+    # why the guard is a ceiling and not an equality.
+    _unp = sum(unparsed.values())
+    assert _unp <= 13, (
+        f'{_unp} driver command span(s) are value-unchecked, up from 13:\n'
+        + '\n'.join(f'  {t}: {n}' for t, n in sorted(unparsed.items()))
+        + '\n\nA tool whose parser cannot be built has its flag NAMES checked '
+          'by the --help reader but not whether each was given a VALUE. Give '
+          'it a main(), or raise this ceiling deliberately and say why.')
+    print(f'  PASS: {checked} driver command spans, all runnable '
+          f'({_unp} value-unchecked: '
+          f'{", ".join(f"{os.path.basename(t)} {n}" for t, n in sorted(unparsed.items())) or "none"})')
 
 
 def test_the_refusal_branches_are_scanned():
@@ -985,10 +1013,44 @@ def test_exit_code_contract_is_documented():
         'commands annotated "exits 3" whose flag returns before the board-state '
         'gate:\n' + '\n'.join(f'  {w}: {t} {f} answers and returns 0'
                               for w, t, f in sorted(set(problems))))
+    # POSITIVE CONTROL on the SCANNER, because `checked == 0` today and a
+    # scanner that has stopped matching reports exactly the same zero. The two
+    # `_returns_before_gate` assertions above hold the ANALYSER down; nothing
+    # held down the thing that feeds it. Synthetic text in the shape the scan
+    # looks for -- a `#` comment carrying "exits 3", a command within the next
+    # three lines -- must produce exactly one row, and the same text with the
+    # annotation as prose rather than a comment must produce none.
+    def _scan(sample):
+        n = 0
+        ls = sample.splitlines()
+        for i, line in enumerate(ls):
+            if 'exits 3' not in line and 'exit 3' not in line:
+                continue
+            if not line.lstrip().startswith('#'):
+                continue
+            blk = '\n'.join(ls[i + 1:i + 4])
+            for tool in TOOLS:
+                for b in _continued_blocks(blk, tool):
+                    n += len(_cited_flags(b, tool))
+        return n
+
+    _hit = ('# --suggest-locks exits 3 when the board is unplaced\n'
+            'python3 -X utf8 py_placer/place_optimize.py b.kicad_pcb '
+            '--suggest-locks\n')
+    _miss = ('The tool exits 3 when the board is unplaced.\n'
+             'python3 -X utf8 py_placer/place_optimize.py b.kicad_pcb '
+             '--suggest-locks\n')
+    assert _scan(_hit) == 1, (
+        'the exit-code scanner no longer finds an annotated command -- so its '
+        f'{checked} is a claim about the scanner, not about the skills')
+    assert _scan(_miss) == 0, (
+        'the exit-code scanner reads PROSE as an annotation; an "exits 3" in a '
+        'sentence is not a claim attached to a command')
     print(f'  PASS: exit-3 contract; {checked} annotated flag(s) reach the gate'
           if checked else
-          '  PASS: exit-3 contract; no command in the skills is annotated with '
-          'an exit code today, so the analyser control above is the live half')
+          '  PASS: exit-3 contract; 0 commands in the skills are annotated with '
+          'an exit code today -- the analyser controls and the scanner control '
+          'are what is live')
 
 
 def test_skill_decides_placement_by_measurement_not_by_default():

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -964,7 +964,7 @@ _UNRESOLVABLE = {}
 #: exact shape of the defect #877 is about, reproduced in its own gate.
 #: 42 before #902 added `mutate_902.py`; 43 before #892 added `mutate_892.py`;
 #: 45 before #893/#916 added `mutate_893_916.py`.
-_BATTERY_COUNT = 48
+_BATTERY_COUNT = 49
 
 #: A floor well under today's 831, not a target. Same purpose as
 #: `test_the_scanners_still_match_something`: prove the corpus is populated.

--- a/tests/test_718_static_test_hygiene.py
+++ b/tests/test_718_static_test_hygiene.py
@@ -145,6 +145,14 @@ _ROOT_JOIN_ARGV_OK = {
         'module-level T_WORKLIST/T_DRIVERS/T_RUN/T_CONVERGE/T_DFL/T_923/'
         'T_431 constants, every one a directory-qualified literal, so the '
         'join is over a relative path rather than a bare basename.',
+    'mutate_937.py':
+        'same shape and same reason: its `tests` values are the module-level '
+        'T_REG/T_CHK/T_OOB/T_GATE/T_LEV/T_DRV/T_431 constants, every one a '
+        'directory-qualified literal ("tests/test_937_tool_registry.py"), so '
+        'the join is over a relative path rather than a bare basename. '
+        '`run_utils.tool()` is the wrong resolver here for the reason the '
+        'three rows above give: these are TEST files rather than shipped '
+        'CLIs, and it looks only in the four tool directories #522 created.',
 }
 
 

--- a/tests/test_798_registrar_flags.py
+++ b/tests/test_798_registrar_flags.py
@@ -160,7 +160,7 @@ def t_a_script_still_does_NOT_inherit_another_CLIs_flags():
 
 def t_a_computed_flag_name_is_a_known_limit_not_a_silent_gap():
     """`render_placement.py` builds 18 toggles as `f'--{name}'`
-    (py_tools/render_placement.py:1571-1573), so no source scan can see them.
+    (py_tools/render_placement.py:1576-1578), so no source scan can see them.
 
     That is why it is NOT in FLAG_SCRIPTS, and this pins the reason: if
     someone adds it, the exact-match test above would fail with a list of 18

--- a/tests/test_937_entry_gates.py
+++ b/tests/test_937_entry_gates.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""#937: the routing door's entry gate exists, and P2/P3 read the verdict.
+
+Two acceptance criteria that nothing else pins.
+
+FIRST, the citations. Eight sites sent a reader to a routing "Step 0", a "How
+to run this skill" section or a "V1-V5 loop", and none of the three existed in
+`plan-pcb-routing/SKILL.md`. Five are now true by construction and three were
+re-pointed. A citation is only worth writing if something checks it still
+resolves -- otherwise the next edit silently re-creates the defect this PR
+exists to remove.
+
+SECOND, `_guard_damage`. It gated P2/P3 on `blocking`, which since #918 is ONE
+of check_assembly's five not_buildable conjuncts -- so a board unbuildable
+through a coincident-origin stack or a containment reads `blocking` 0, and the
+guard told the reader there was "no damage for this stage to repair" about a
+board its own instrument had graded NOT BUILDABLE. Checked behaviourally, by
+running the stage, not by reading the source: a source grep passes on a
+comment.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SKILLS = os.path.join(ROOT, '.claude', 'skills')
+ROUTING = os.path.join(SKILLS, 'plan-pcb-routing', 'SKILL.md')
+LOOP = os.path.join(SKILLS, 'plan-pcb-placement-and-routing', 'scripts',
+                    'loop_driver.py')
+COMBINED = os.path.join(SKILLS, 'plan-pcb-placement-and-routing', 'SKILL.md')
+DRIVER = os.path.join(SKILLS, 'plan-pcb-placement', 'scripts',
+                      'placement_driver.py')
+
+RUN_ALL_TIMEOUT = 180
+
+
+def _read(path):
+    with open(path, encoding='utf-8', errors='replace') as fh:
+        return fh.read()
+
+
+def t_the_routing_skill_has_the_sections_eight_sites_cite():
+    rt = _read(ROUTING)
+    for needed in ('## How to run this skill', '## Step 0'):
+        assert needed in rt, (
+            f'plan-pcb-routing/SKILL.md has no {needed!r}. Six sites in '
+            f'loop_driver.py and the combined skill send a reader there.')
+    # Step 0 must be the PLACEMENT gate the citers describe ("its Step 0
+    # placement gate will pass, because you just did that work"), not merely a
+    # heading with the right number.
+    step0 = rt.split('## Step 0', 1)[1].split('\n## ', 1)[0]
+    for instrument in ('check_assembly.py', 'board_score.py'):
+        assert instrument in step0, (
+            f'routing Step 0 does not run {instrument}, so the loop\'s claim '
+            f'that it "will pass, you just did that work" is not true by '
+            f'construction -- L2 runs exactly these.')
+    print('  PASS: both sections exist, and Step 0 is the placement gate')
+
+
+def t_no_site_still_cites_a_routing_V1_V5_loop():
+    """The three genuinely stale citations. The convergence loop those stages
+    came from lives in the combined skill's references/, and `converge.py`
+    already records that no routing_driver ever reached main."""
+    live = []
+    for path in (LOOP, COMBINED):
+        for n, line in enumerate(_read(path).splitlines(), 1):
+            if 'V1-V5' not in line and 'V1–V5' not in line:
+                continue
+            # A line EXPLAINING the retraction is not a citation to it.
+            if any(w in line for w in ('said', 'used to', 'never reached',
+                                       'removed', '#937')):
+                continue
+            live.append(f'{os.path.basename(path)}:{n}: {line.strip()[:90]}')
+    assert not live, (
+        'these still send a reader to a routing V1-V5 loop that does not '
+        'exist:\n  ' + '\n  '.join(live))
+    print('  PASS: no live citation to a routing V1-V5 loop remains')
+
+
+def _p2(tmp, drc, asm=None):
+    """Run P2 with the given evidence; return (rc, text)."""
+    import json
+    board = os.path.join(tmp, 'b.kicad_pcb')
+    open(board, 'w').write('(kicad_pcb)')
+    argv = [sys.executable, '-X', 'utf8', DRIVER, '--stage', 'P2',
+            '--board', board]
+    for flag, doc, name in (('--drc-json', drc, 'd.json'),
+                            ('--assembly-json', asm, 'a.json')):
+        if doc is None:
+            continue
+        p = os.path.join(tmp, name)
+        with open(p, 'w', encoding='utf-8') as fh:
+            json.dump(doc, fh)
+        argv += [flag, p]
+    r = subprocess.run(argv, capture_output=True, text=True,
+                       encoding='utf-8', errors='replace', cwd=ROOT,
+                       timeout=120)
+    return r.returncode, r.stdout
+
+
+def t_a_board_that_is_not_buildable_at_blocking_zero_reaches_the_repair():
+    """The defect, behaviourally. `blocking` 0 with `buildable` false is a
+    real tracked board (rp2350_fpga_eensy_prePlane: 0 blocking pairs, NOT
+    BUILDABLE through a coincident-origin stack)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        rc, out = _p2(tmp, {'violations': 0},
+                      {'blocking': 0, 'buildable': False,
+                       'verdict': 'NOT BUILDABLE'})
+    assert rc != 4, (
+        'P2 refused a board its own instrument graded NOT BUILDABLE, because '
+        'the guard read `blocking` -- 1 of 5 not_buildable conjuncts since '
+        f'#918 -- instead of the verdict.\n{out[:600]}')
+    assert 'no damage for this stage to repair' not in out, out[:400]
+    print('  PASS: NOT BUILDABLE at blocking 0 reaches the repair stage')
+
+
+def t_a_genuinely_clean_board_is_still_refused():
+    """The control. Without it the case above passes on a guard that refuses
+    nothing at all."""
+    with tempfile.TemporaryDirectory() as tmp:
+        rc, out = _p2(tmp, {'violations': 0},
+                      {'blocking': 0, 'buildable': True,
+                       'verdict': 'buildable (blocking 0)'})
+    assert rc == 4 and 'no damage for this stage to repair' in out, (
+        f'a clean board must still be refused by P2 (rc={rc})\n{out[:600]}')
+    print('  PASS: a buildable, violation-free board is still refused')
+
+
+def t_p0_reads_the_documents_it_makes_you_produce():
+    """P0 had both flags and opened neither."""
+    import json
+    with tempfile.TemporaryDirectory() as tmp:
+        board = os.path.join(tmp, 'b.kicad_pcb')
+        open(board, 'w').write('(kicad_pcb)')
+        d = os.path.join(tmp, 'd.json')
+        a = os.path.join(tmp, 'a.json')
+        json.dump({'violations': 7}, open(d, 'w'))
+        json.dump({'blocking': 0, 'buildable': False,
+                   'verdict': 'NOT BUILDABLE',
+                   'oob_pad_copper_count': 2}, open(a, 'w'))
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8', DRIVER, '--stage', 'P0',
+             '--board', board, '--drc-json', d, '--assembly-json', a],
+            capture_output=True, text=True, encoding='utf-8',
+            errors='replace', cwd=ROOT, timeout=120)
+    for needed in ('7 violation(s)', 'NOT BUILDABLE',
+                   'PAD COPPER OFF THE OUTLINE on 2'):
+        assert needed in r.stdout, (
+            f'P0 did not report {needed!r} from the documents it was given\n'
+            f'{r.stdout[:800]}')
+    assert 'THE TWO DISAGREE' not in r.stdout, (
+        'both instruments read dirty here; there is no disagreement to flag')
+    print('  PASS: P0 reports both instruments and the off-outline count')
+
+
+def t_p0_without_evidence_still_just_asks_for_it():
+    """First entry: nothing to read yet, and the stage must not pretend."""
+    with tempfile.TemporaryDirectory() as tmp:
+        board = os.path.join(tmp, 'b.kicad_pcb')
+        open(board, 'w').write('(kicad_pcb)')
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8', DRIVER, '--stage', 'P0',
+             '--board', board],
+            capture_output=True, text=True, encoding='utf-8',
+            errors='replace', cwd=ROOT, timeout=120)
+    assert r.returncode == 0, r.stdout[:400]
+    assert 'WHAT THE INSTRUMENTS SAY' not in r.stdout, (
+        'P0 printed a reading with no documents to read')
+    assert 'check_assembly.py' in r.stdout, 'P0 must still ask for them'
+    print('  PASS: with no evidence, P0 asks for it and reports nothing')
+
+
+TESTS = (t_the_routing_skill_has_the_sections_eight_sites_cite,
+         t_no_site_still_cites_a_routing_V1_V5_loop,
+         t_a_board_that_is_not_buildable_at_blocking_zero_reaches_the_repair,
+         t_a_genuinely_clean_board_is_still_refused,
+         t_p0_reads_the_documents_it_makes_you_produce,
+         t_p0_without_evidence_still_just_asks_for_it)
+
+
+def _every_case_is_registered():
+    defined = {n for n in globals() if n.startswith('t_')}
+    listed = {f.__name__ for f in TESTS}
+    assert defined == listed, f'not registered: {sorted(defined - listed)}'
+
+
+if __name__ == '__main__':
+    _every_case_is_registered()
+    for fn in TESTS:
+        print(f'--- {fn.__name__}')
+        fn()
+    print('\nALL PASS')

--- a/tests/test_937_entry_gates.py
+++ b/tests/test_937_entry_gates.py
@@ -171,7 +171,49 @@ def t_p0_without_evidence_still_just_asks_for_it():
     print('  PASS: with no evidence, P0 asks for it and reports nothing')
 
 
+def t_an_off_outline_crossing_by_design_has_a_way_past_the_gate():
+    """A castellated row, a card edge and a declared `edge_connectors` part
+    are MEANT to cross the outline, and the per-pad census has no exemption
+    for one -- so without an escape the refusal ordered a reader to drag a
+    mating connector inboard, and no flag could clear it.
+
+    Three arms, because the escape must not become a flag that makes the gate
+    disappear: refused with no waiver, refused with a REASONLESS waiver, and
+    cleared only by one carrying a reason.
+    """
+    import json
+    with tempfile.TemporaryDirectory() as tmp:
+        board = os.path.join(tmp, 'b.kicad_pcb')
+        before = os.path.join(tmp, 'a.kicad_pcb')
+        for p in (board, before):
+            open(p, 'w').write('(kicad_pcb)')
+        rj = os.path.join(tmp, 'r.json')
+        json.dump({'instrument': {'board': board},
+                   'checklist': {
+                       'a_off_outline': {'pad_copper': [{'reference': 'J9'}],
+                                         'courtyard': []},
+                       'd_moved': {'moved': 1, 'expected': None,
+                                   'match': None}},
+                   'metrics': {'hpwl': 1.0}}, open(rj, 'w'))
+        base = [sys.executable, '-X', 'utf8', DRIVER, '--stage', 'P6',
+                '--board', board, '--before', before, '--render-json', rj]
+        for extra, want, label in (
+                ([], 4, 'no waiver'),
+                (['--waive', 'off-outline:'], 4, 'a waiver with no reason'),
+                (['--waive', 'off-outline:castellated carrier, SMD-1.27 '
+                  'half-holes'], 0, 'a waiver with a reason')):
+            r = subprocess.run(base + extra, capture_output=True, text=True,
+                               encoding='utf-8', errors='replace', cwd=ROOT,
+                               timeout=120)
+            assert r.returncode == want, (
+                f'{label}: expected exit {want}, got {r.returncode}: '
+                f'{r.stdout[:500]}')
+        print('  PASS: refused bare, refused reasonless, cleared with a '
+              'reason')
+
+
 TESTS = (t_the_routing_skill_has_the_sections_eight_sites_cite,
+         t_an_off_outline_crossing_by_design_has_a_way_past_the_gate,
          t_no_site_still_cites_a_routing_V1_V5_loop,
          t_a_board_that_is_not_buildable_at_blocking_zero_reaches_the_repair,
          t_a_genuinely_clean_board_is_still_refused,

--- a/tests/test_937_lever_identity.py
+++ b/tests/test_937_lever_identity.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""#937: which LEVER a ledger row pulled, derived rather than guessed.
+
+`loop_driver.py:4-9` records the one documented reason the two drivers are
+separate: "placement accepts a lap when the named finding it aimed at is gone,
+routing accepts an iteration when `blocking` strictly decreased... The driver
+never emits both." That argues for an accept rule stated PER LEVER rather than
+per half -- and the first thing such a rule needs is to know which lever a row
+pulled.
+
+`_HALF` keys on `kind`, which is the half. `lever` is free prose and cannot be
+read by a gate: `run_watch.py` is explicit that it is "NEVER matched", because
+a gate that reads a disclosure punishes disclosing. `lever_argv` is the
+structured channel, and this pins what it can and cannot answer.
+
+REPORTED, NOT GATED, and these cases say so. Making the accept rule per-lever
+moves DONE and STUCK verdicts, and this repo grades a verdict-moving change by
+a corpus A/B rather than by reasoning about it.
+"""
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _d in ('py_placer', 'py_router', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _d))
+sys.path.insert(0, ROOT)
+
+import converge as C                                        # noqa: E402
+
+RUN_ALL_TIMEOUT = 120
+RUN_ALL_FAST_OK = True
+
+
+def t_a_recorded_command_yields_its_tool():
+    cases = [
+        (['python3', '-X', 'utf8', 'py_placer/place_optimize.py', 'b.kicad_pcb'],
+         'place_optimize.py'),
+        (['python3', 'py_router/route.py', 'a', 'b'], 'route.py'),
+        # The tool, not the interpreter: a bare argv[0] of `python3` names the
+        # language, which is true of every row and therefore useless.
+        (['python3', 'py_tools/render_placement.py', 'b'],
+         'render_placement.py'),
+        # ...and when no .py token exists at all, the command itself. 31 of
+        # the recorded rows in this tree are `bash <script>`, which IS the
+        # honest answer for them.
+        (['bash', 'wk/run19/arrange.sh'], 'bash'),
+        (['cp', 'a.kicad_pcb', 'b.kicad_pcb'], 'cp'),
+    ]
+    for argv, want in cases:
+        got = C.lever_identity({'lever_argv': argv})
+        assert got == want, f'{argv} -> {got!r}, expected {want!r}'
+    print(f'  PASS: {len(cases)} argv shapes resolve to their tool')
+
+
+def t_a_row_with_no_command_is_None_not_a_guess():
+    """None is a first-class answer. Most rows without a lever_argv have NO
+    COMMAND to record -- an L2 freeze stamp, an `--exhausted` declaration, an
+    L5 close-out -- and inventing one for them is how a ledger becomes prose.
+    `board_store.replay_command` raises for the same reason."""
+    for row in ({'lever': 'moved R12 off the edge'},
+                {'lever_argv': None},
+                {'lever_argv': []},
+                {},
+                {'lever_argv': 'not a list'}):
+        got = C.lever_identity(row)
+        assert got is None, f'{row} -> {got!r}, expected None'
+    print('  PASS: a row recording no command answers None, never a guess')
+
+
+def t_the_prose_field_is_never_read():
+    """The prose field must not become a second, weaker identity channel: a
+    gate that matched on `lever` would punish the row that described itself
+    best."""
+    rich = {'lever': 'ran place_optimize.py on R12 with --max-displacement 3'}
+    assert C.lever_identity(rich) is None, (
+        'lever_identity read the free-text `lever` field. That field exists '
+        'for a human, and matching on it penalises disclosure.')
+    print('  PASS: a richly-worded `lever` still yields no identity')
+
+
+def t_the_histogram_is_stable_and_counts_only_identified_rows():
+    rows = [{'lever_argv': ['python3', 'py_placer/place_seed.py', 'b']},
+            {'lever_argv': ['python3', 'py_placer/place_seed.py', 'b']},
+            {'lever_argv': ['python3', 'py_router/route.py', 'b']},
+            {'lever': 'no argv here'}]
+    h = C._lever_histogram(rows)
+    assert h == {'place_seed.py': 2, 'route.py': 1}, h
+    assert list(h) == ['place_seed.py', 'route.py'], (
+        f'the histogram must be ordered for a stable document, got {list(h)}')
+    print('  PASS: histogram counts identified rows only, in a stable order')
+
+
+def t_status_publishes_both_the_histogram_and_what_it_could_not_read():
+    """The coverage number has to travel with the histogram. A histogram
+    alone reads as complete."""
+    import tempfile
+    import json
+    import subprocess
+    with tempfile.TemporaryDirectory() as tmp:
+        led = os.path.join(tmp, 'ledger.jsonl')
+        with open(led, 'w', encoding='utf-8') as fh:
+            for row in ({'iteration': 0, 'kind': 'placement',
+                         'lever': 'seeded',
+                         'lever_argv': ['python3', 'py_placer/place_seed.py',
+                                        'b.kicad_pcb']},
+                        {'iteration': 1, 'kind': 'placement',
+                         'lever': 'froze the poses'}):
+                fh.write(json.dumps(row) + '\n')
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8',
+             os.path.join(ROOT, 'py_placer', 'converge.py'), 'status',
+             '--ledger', led],
+            capture_output=True, text=True, encoding='utf-8',
+            errors='replace', cwd=ROOT, timeout=120)
+    assert r.returncode == 0, f'status exited {r.returncode}\n{r.stderr[-600:]}'
+    doc = json.loads(r.stdout)
+    assert doc.get('lever_identities') == {'place_seed.py': 1}, doc.get(
+        'lever_identities')
+    assert doc.get('unreplayable') == 1, (
+        f'unreplayable is {doc.get("unreplayable")!r}; one of the two rows '
+        f'records no command and the document must say so')
+    print('  PASS: status carries the histogram AND the unreadable count')
+
+
+TESTS = (t_a_recorded_command_yields_its_tool,
+         t_a_row_with_no_command_is_None_not_a_guess,
+         t_the_prose_field_is_never_read,
+         t_the_histogram_is_stable_and_counts_only_identified_rows,
+         t_status_publishes_both_the_histogram_and_what_it_could_not_read)
+
+
+def _every_case_is_registered():
+    defined = {n for n in globals() if n.startswith('t_')}
+    listed = {f.__name__ for f in TESTS}
+    assert defined == listed, f'not registered: {sorted(defined - listed)}'
+
+
+if __name__ == '__main__':
+    _every_case_is_registered()
+    for fn in TESTS:
+        print(f'--- {fn.__name__}')
+        fn()
+    print('\nALL PASS')

--- a/tests/test_937_off_outline_channels.py
+++ b/tests/test_937_off_outline_channels.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""#937: check_assembly carries BOTH off-outline channels, and they agree.
+
+`oob_pad_count` is a part-level AABB inflated by the grading clearance;
+`oob_pad_copper_*` is the per-PAD measure against the real outline at margin
+0, which is the one CLAUDE.md designates for the top-priority placement defect
+("a part whose pad copper lies outside the outline... read it off
+render_placement's checklist.a_off_outline.pad_copper").
+
+WHY THIS GATE EXISTS AT ALL. The per-pad measure is now computed in TWO
+places: `render_placement` computes it from its own proposed-state model, and
+`grade_pad_legality` computes it from the file's own poses. They are genuinely
+different call sites over different data paths, so one cannot simply call the
+other -- and this repo's recorded failure is exactly that shape ("call the
+grader, do not mirror it": a re-implementation disagreed 83 times, worst
+0.234mm). Where a call is impossible, the AGREEMENT has to be measured instead
+of assumed, and that is what the last case does.
+
+The verdict must not move. `check_assembly`'s five `not_buildable` conjuncts
+do not include either channel and this change does not add one -- gating on
+the coarse count would flip two human reference boards on a measurement
+artifact, which is the finding that produced this split in the first place.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+RUN_ALL_TIMEOUT = 1200
+
+#: The discriminating pair, plus a control. `rp2350` is the board where both
+#: channels fire; `watchy` is the one where the AABB fires on four
+#: edge-mounted switches and NO pad crosses the real outline; `tigard` fires
+#: neither. A gate that only looked at agreeing boards would pass with the
+#: per-pad channel hard-coded to copy the coarse one.
+DISCRIMINATING = ('rp2350_fpga_eensy_prePlane', 'watchy', 'tigard')
+
+
+def _boards():
+    r = subprocess.run(['git', 'ls-files', 'kicad_files/*.kicad_pcb'],
+                       cwd=ROOT, capture_output=True, text=True)
+    return sorted(p for p in r.stdout.split() if p)
+
+
+def _assembly(board, tmp):
+    out = os.path.join(tmp, os.path.basename(board) + '.assembly.json')
+    r = subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(ROOT, 'py_tools', 'check_assembly.py'), board,
+         '--json', out],
+        cwd=ROOT, capture_output=True, text=True, encoding='utf-8',
+        errors='replace', timeout=600)
+    assert os.path.isfile(out), (
+        f'check_assembly wrote no document for {board} (rc={r.returncode})\n'
+        f'{r.stderr[-800:]}')
+    with open(out, encoding='utf-8') as fh:
+        return json.load(fh), r
+
+
+def t_both_channels_are_published_and_well_formed():
+    with tempfile.TemporaryDirectory() as tmp:
+        doc, _r = _assembly('kicad_files/tigard.kicad_pcb', tmp)
+    for key in ('oob_pad_count', 'oob_pad_refs', 'oob_pad_basis',
+                'oob_pad_copper_count', 'oob_pad_copper_refs',
+                'oob_pad_copper_basis'):
+        assert key in doc, f'{key} is missing from the assembly document'
+    assert isinstance(doc['oob_pad_copper_refs'], list)
+    assert doc['oob_pad_copper_count'] == len(doc['oob_pad_copper_refs']), \
+        'the per-pad count and its ref list disagree'
+    assert 'margin 0' in (doc['oob_pad_copper_basis'] or ''), \
+        'the per-pad basis string must say which measure it is'
+    print('  PASS: both channels published, counts consistent, basis stated')
+
+
+def t_the_precise_channel_never_names_a_part_the_coarse_one_misses():
+    """An invariant, not a coincidence: the coarse outline is the real one
+    INFLATED, so copper outside the real outline is necessarily outside the
+    inflated one too. If this ever fails, one of the two is wrong."""
+    with tempfile.TemporaryDirectory() as tmp:
+        bad = []
+        for board in _boards():
+            doc, _r = _assembly(board, tmp)
+            coarse = {r[0] for r in doc.get('oob_pad_refs') or []}
+            exact = {r[0] for r in doc.get('oob_pad_copper_refs') or []}
+            if exact - coarse:
+                bad.append(f'{board}: per-pad names {sorted(exact - coarse)} '
+                           f'which the inflated-outline census does not')
+    assert not bad, '\n'.join(bad)
+    print('  PASS: the per-pad channel is a subset of the coarse one on every '
+          'tracked board')
+
+
+def t_the_verdict_does_not_move():
+    """The whole point of splitting the channels rather than gating the
+    coarse one. Pinned as an exact census, so a future change that DID make
+    an off-outline channel gate has to come here and say so."""
+    with tempfile.TemporaryDirectory() as tmp:
+        verdicts = {}
+        for board in _boards():
+            doc, r = _assembly(board, tmp)
+            name = os.path.basename(board)[:-len('.kicad_pcb')]
+            verdicts[name] = (doc.get('verdict'), r.returncode)
+    nb = sorted(n for n, (v, _c) in verdicts.items() if v != 'buildable '
+                '(blocking 0)')
+    assert nb == ['rp2350_fpga_eensy_prePlane'], (
+        f'the NOT BUILDABLE set moved to {nb}. Neither off-outline channel is '
+        f'a not_buildable conjunct, and making one would flip human reference '
+        f'boards on a measurement artifact -- if that is intended, it is a '
+        f'decision to argue for here.')
+    for name, (_v, code) in verdicts.items():
+        assert code in (0, 4), f'{name} exited {code}'
+    print(f'  PASS: {len(verdicts)} boards, 1 NOT BUILDABLE '
+          f'({nb[0]}), unchanged')
+
+
+def t_the_two_implementations_agree():
+    """The mirroring guard -- see the module docstring.
+
+    Compared against `render_placement`'s `checklist.a_off_outline.pad_copper`
+    on the discriminating pair: a board where both channels fire, one where
+    only the coarse one does, and a control where neither does. Amounts are
+    compared, not just membership, because a per-pad measure that named the
+    right part with the wrong distance would still be wrong.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        for name in DISCRIMINATING:
+            board = f'kicad_files/{name}.kicad_pcb'
+            doc, _r = _assembly(board, tmp)
+            js = os.path.join(tmp, f'{name}.render.json')
+            png = os.path.join(tmp, f'{name}.render.png')
+            r = subprocess.run(
+                [sys.executable, '-X', 'utf8',
+                 os.path.join(ROOT, 'py_tools', 'render_placement.py'),
+                 board, '--json-out', js, '-o', png],
+                cwd=ROOT, capture_output=True, text=True, encoding='utf-8',
+                errors='replace', timeout=900)
+            assert os.path.isfile(js), (
+                f'render_placement wrote no json for {name} '
+                f'(rc={r.returncode})\n{r.stderr[-600:]}')
+            with open(js, encoding='utf-8') as fh:
+                rendered = json.load(fh)
+            theirs = ((rendered.get('checklist') or {})
+                      .get('a_off_outline') or {}).get('pad_copper') or []
+            mine = doc.get('oob_pad_copper_refs') or []
+            norm = sorted((str(a), round(float(b), 3)) for a, b in theirs)
+            ours = sorted((str(a), round(float(b), 3)) for a, b in mine)
+            assert ours == norm, (
+                f'{name}: grade_pad_legality says {ours}, render_placement '
+                f'says {norm}. These are two implementations of one measure '
+                f'and they have diverged.')
+            print(f'    {name}: {ours or "[]"} -- both agree')
+    print('  PASS: the two implementations agree on the discriminating set')
+
+
+TESTS = (t_both_channels_are_published_and_well_formed,
+         t_the_precise_channel_never_names_a_part_the_coarse_one_misses,
+         t_the_verdict_does_not_move,
+         t_the_two_implementations_agree)
+
+
+def _every_case_is_registered():
+    defined = {n for n in globals() if n.startswith('t_')}
+    listed = {f.__name__ for f in TESTS}
+    assert defined == listed, f'not registered: {sorted(defined - listed)}'
+
+
+if __name__ == '__main__':
+    _every_case_is_registered()
+    for fn in TESTS:
+        print(f'--- {fn.__name__}')
+        fn()
+    print('\nALL PASS')

--- a/tests/test_937_route_plan_check.py
+++ b/tests/test_937_route_plan_check.py
@@ -104,6 +104,14 @@ BREAKS = [
       '--nets GND +3V3 --plane-layers In1.Cu In2.Cu --add-gnd-vias')),
     ('R14', 'a poured net with no route-step width',
      ('--power-nets GND +3V3', '--power-nets GND')),
+    # Step 5b is TWO asserts and they fail on different things. The row above
+    # breaks `unsized` (poured, no route-step width); this breaks `orphans`
+    # (excluded from the route step, claimed by no Step-2b impedance route) --
+    # which is the GNDA failure itself: a net excluded as "power" and never
+    # picked up, ending at 0/23 pads connected while the run reported success.
+    # tests/mutate_937.py found this gap by blinding `orphans` and SURVIVING.
+    ('R14', 'a net excluded from the route step and claimed by nothing',
+     ("--nets '*' --power-nets GND +3V3", "--nets '*' '!RF' --power-nets GND +3V3")),
     ('R15', 'gnd-via distance under the floor',
      ('--power-nets GND +3V3 --clearance 0.09',
       '--power-nets GND +3V3 --clearance 0.09 --via-size 0.45 '

--- a/tests/test_937_route_plan_check.py
+++ b/tests/test_937_route_plan_check.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""#937: the routing plan checker refuses the right plan, for the right rule.
+
+A checker that refuses everything is worth nothing, and a checker that refuses
+nothing is worth less. So this is built as a CONTROL plus one targeted break
+per rule:
+
+  * the compliant plan must exit 0 with every rule `ok` -- without that, every
+    refusal below is just a checker that says no;
+  * each break must exit 4 AND NAME ITS OWN RULE. `assert rc == 4` alone would
+    pass on a plan that failed for a different reason, which is how a gate
+    ends up testing nothing. CLAUDE.md states this directly: a non-zero exit
+    is not evidence, assert the REASON.
+  * and a break must not redden OTHER rules, or the naming is a coincidence.
+
+It also pins what this checker reads. `plan_steps_from_manifest` -- the GUI
+conversion -- drops `cd`, `cp`, pipes and every `check_*` command, so a
+checker built on it could not see six of these rules AT ALL and would report
+the broken plans clean. The cases that break those six are the regression
+test for that design choice.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CHECKER = os.path.join(ROOT, '.claude', 'skills', 'plan-pcb-routing',
+                       'scripts', 'route_plan_check.py')
+
+RUN_ALL_TIMEOUT = 300
+
+#: A plan that satisfies every rule. Every break below is this file with ONE
+#: line changed, so a reddened rule is attributable to that change.
+COMPLIANT = """#!/bin/bash
+set -e
+cd /repo
+# cwd=/repo
+python3 -u -X utf8 py_router/bga_fanout.py b.kicad_pcb s1.kicad_pcb \
+--component U1 --nets '*' --clearance 0.09 --layers F.Cu B.Cu
+# cwd=/repo
+python3 -u -X utf8 py_placer/place_fanout_clearance.py s1.kicad_pcb \
+s2.kicad_pcb --clearance 0.09
+# cwd=/repo
+python3 -u -X utf8 py_router/route_planes.py s2.kicad_pcb s3.kicad_pcb \
+--nets GND +3V3 --plane-layers In1.Cu In2.Cu
+# cwd=/repo
+python3 -u -X utf8 py_router/route.py s3.kicad_pcb final.kicad_pcb \
+--nets '*' --power-nets GND +3V3 --clearance 0.09
+# Verification -- COMMENTS, never executable lines: this file's exit code is
+# read as the chain verdict.
+#   python3 -X utf8 py_router/check_drc.py final.kicad_pcb
+#   python3 -X utf8 py_router/check_connected.py final.kicad_pcb
+#   python3 -X utf8 py_tools/check_orphan_stubs.py final.kicad_pcb
+"""
+
+#: (rule, what the break is, the edit as (old, new)). `old` must appear in
+#: COMPLIANT exactly once -- asserted, because a break that edited nothing
+#: would be recorded as "the checker missed it".
+BREAKS = [
+    ('R01', 'no cd line', ('cd /repo\n', '')),
+    ('R02', 'a pipe on the route step',
+     ('--clearance 0.09\n# Verification',
+      "--clearance 0.09 2>&1 | tee route.log\n# Verification")),
+    ('R03', 'a checker as an executable line',
+     ('#   python3 -X utf8 py_router/check_drc.py final.kicad_pcb',
+      'python3 -X utf8 py_router/check_drc.py final.kicad_pcb')),
+    ('R04', 'the chain ends on a re-pour',
+     ('# Verification',
+      '# cwd=/repo\npython3 -u -X utf8 py_router/route_planes.py '
+      'final.kicad_pcb after.kicad_pcb --nets GND --plane-layers In1.Cu\n'
+      '# Verification')),
+    ('R05', 'connectivity never named',
+     ('#   python3 -X utf8 py_router/check_connected.py final.kicad_pcb\n',
+      '')),
+    ('R06', 'diff gap below clearance',
+     ('# Verification',
+      '# cwd=/repo\npython3 -u -X utf8 py_router/route_diff.py '
+      'final.kicad_pcb d.kicad_pcb --nets /D+ /D- --clearance 0.1 '
+      '--diff-pair-gap 0.08\n# cwd=/repo\npython3 -u -X utf8 '
+      'py_router/route.py d.kicad_pcb final2.kicad_pcb --nets "*" '
+      '--power-nets GND +3V3\n# Verification')),
+    ('R07', 'teardrops requested',
+     ('--power-nets GND +3V3 --clearance 0.09',
+      '--power-nets GND +3V3 --clearance 0.09 --add-teardrops')),
+    ('R08', 'smoothing turned off',
+     ('--power-nets GND +3V3 --clearance 0.09',
+      '--power-nets GND +3V3 --clearance 0.09 --no-smoothing')),
+    ('R09', 'iterations capped',
+     ('--power-nets GND +3V3 --clearance 0.09',
+      '--power-nets GND +3V3 --clearance 0.09 --max-iterations 1000')),
+    ('R10', 'max-ripup above the ceiling',
+     ('--power-nets GND +3V3 --clearance 0.09',
+      '--power-nets GND +3V3 --clearance 0.09 --max-ripup 10')),
+    ('R11', 'a bare cp of a board',
+     ('# cwd=/repo\npython3 -u -X utf8 py_router/route_planes.py',
+      '# cwd=/repo\ncp s2.kicad_pcb copy.kicad_pcb\n'
+      '# cwd=/repo\npython3 -u -X utf8 py_router/route_planes.py')),
+    ('R12', 'no cap pass after fanout',
+     ('# cwd=/repo\npython3 -u -X utf8 py_placer/place_fanout_clearance.py '
+      's1.kicad_pcb s2.kicad_pcb --clearance 0.09\n', '')),
+    ('R13', 'the first pour carries a via tail',
+     ('--nets GND +3V3 --plane-layers In1.Cu In2.Cu',
+      '--nets GND +3V3 --plane-layers In1.Cu In2.Cu --add-gnd-vias')),
+    ('R14', 'a poured net with no route-step width',
+     ('--power-nets GND +3V3', '--power-nets GND')),
+    ('R15', 'gnd-via distance under the floor',
+     ('--power-nets GND +3V3 --clearance 0.09',
+      '--power-nets GND +3V3 --clearance 0.09 --via-size 0.45 '
+      '--gnd-via-distance 0.5')),
+]
+
+
+def _run(path, *extra):
+    return subprocess.run(
+        [sys.executable, '-X', 'utf8', CHECKER, path] + list(extra),
+        capture_output=True, text=True, encoding='utf-8', errors='replace',
+        cwd=ROOT, timeout=120)
+
+
+def _write(tmp, name, text):
+    path = os.path.join(tmp, name)
+    with open(path, 'w', encoding='utf-8', newline='\n') as fh:
+        fh.write(text)
+    return path
+
+
+def t_the_compliant_plan_passes():
+    """The control. Without it every refusal below proves nothing."""
+    with tempfile.TemporaryDirectory() as tmp:
+        r = _run(_write(tmp, 'ok_plan.sh', COMPLIANT))
+        assert r.returncode == 0, (
+            f'the compliant plan was refused (rc={r.returncode}). A checker '
+            f'that cannot pass a good plan only ever says no.\n{r.stdout}')
+        assert 'FAIL' not in r.stdout, f'rules reddened:\n{r.stdout}'
+        print('  PASS: the compliant plan exits 0 with every rule ok')
+
+
+def t_each_break_is_refused_by_its_own_rule():
+    """Exit 4 AND the rule's own id -- see the module docstring."""
+    with tempfile.TemporaryDirectory() as tmp:
+        for rid, what, (old, new) in BREAKS:
+            assert COMPLIANT.count(old) == 1, (
+                f'{rid}: the break anchor matches {COMPLIANT.count(old)} '
+                f'times, so this row edits nothing and would be recorded as '
+                f'a checker miss')
+            r = _run(_write(tmp, f'broken_{rid}.sh',
+                            COMPLIANT.replace(old, new, 1)))
+            assert r.returncode == 4, (
+                f'{rid} ({what}): expected exit 4, got {r.returncode}\n'
+                f'{r.stdout}')
+            failed = {ln.split()[1] for ln in r.stdout.splitlines()
+                      if ln.strip().startswith('FAIL')}
+            assert rid in failed, (
+                f'{rid} ({what}) was refused, but by {sorted(failed)} -- not '
+                f'by its own rule. Asserting only on the exit code would have '
+                f'passed this.\n{r.stdout}')
+        print(f'  PASS: {len(BREAKS)} break(s), each refused by its own rule')
+
+
+def t_a_break_does_not_redden_unrelated_rules():
+    """Attribution. If one bad line reddens four rules, naming one of them is
+    a coincidence rather than a diagnosis."""
+    noisy = []
+    with tempfile.TemporaryDirectory() as tmp:
+        for rid, what, (old, new) in BREAKS:
+            r = _run(_write(tmp, f'n_{rid}.sh', COMPLIANT.replace(old, new, 1)))
+            failed = {ln.split()[1] for ln in r.stdout.splitlines()
+                      if ln.strip().startswith('FAIL')}
+            if failed - {rid}:
+                noisy.append(f'{rid} ({what}) also reddened '
+                             f'{sorted(failed - {rid})}')
+    # NO exemptions, and that is measured rather than hoped for: every one of
+    # the 15 breaks reddens exactly its own rule. An allowlist was written
+    # here first, for a case that turned out not to happen -- and an exempted
+    # name is where this repo's guards have failed before, so it is gone.
+    assert not noisy, (
+        'a single broken line reddened rules it should not have, so naming '
+        'one of them is a coincidence rather than a diagnosis:\n  '
+        + '\n  '.join(noisy))
+    print(f'  PASS: all {len(BREAKS)} breaks are attributable to exactly one '
+          f'rule')
+
+
+def t_the_checker_writes_nothing():
+    """Read-only, because the standalone door runs under an analysis-only
+    constraint that forbids modifying any file."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write(tmp, 'ro_plan.sh', COMPLIANT)
+        before = {n: os.stat(os.path.join(tmp, n)).st_mtime_ns
+                  for n in os.listdir(tmp)}
+        _run(path)
+        after = {n: os.stat(os.path.join(tmp, n)).st_mtime_ns
+                 for n in os.listdir(tmp)}
+        assert before == after, (
+            f'the checker touched its input directory: '
+            f'{set(after) ^ set(before) or "mtime changed"}')
+        print('  PASS: no file created, changed or removed')
+
+
+def t_an_unreadable_plan_is_exit_3_not_a_crash():
+    """The dialect: 3 is "the plan could not be read", 1 is a crash. A
+    traceback must never be able to read as a verdict."""
+    with tempfile.TemporaryDirectory() as tmp:
+        r = _run(os.path.join(tmp, 'nope.sh'))
+        assert r.returncode == 3, (
+            f'a missing plan gave {r.returncode}, not 3\n{r.stderr}')
+        assert 'Traceback' not in r.stderr, r.stderr
+        print('  PASS: a missing plan is exit 3, with no traceback')
+
+
+def t_every_rule_and_every_delegation_is_listed():
+    """`--list` is the honesty surface: what is checked, and what is not with
+    the tool that owns it."""
+    r = subprocess.run(
+        [sys.executable, '-X', 'utf8', CHECKER, '--list'],
+        capture_output=True, text=True, encoding='utf-8', errors='replace',
+        cwd=ROOT, timeout=60)
+    assert r.returncode == 0, r.stderr
+    sys.path.insert(0, os.path.dirname(CHECKER))
+    import route_plan_check as rpc
+    for rid, _what, _cite, _fn in rpc.RULES:
+        assert rid in r.stdout, f'{rid} is not in --list'
+    for _what, who in rpc.DELEGATED:
+        assert who.split(',')[0].strip() in r.stdout, f'{who} not in --list'
+    assert len(rpc.DELEGATED) >= 9, (
+        f'only {len(rpc.DELEGATED)} delegated checks declared; the skill has '
+        f'at least nine rules a recorded plan cannot answer, and dropping one '
+        f'from this list is how it stops being anybody\'s job')
+    print(f'  PASS: --list names {len(rpc.RULES)} rules and '
+          f'{len(rpc.DELEGATED)} delegations')
+
+
+TESTS = (t_the_compliant_plan_passes,
+         t_each_break_is_refused_by_its_own_rule,
+         t_a_break_does_not_redden_unrelated_rules,
+         t_the_checker_writes_nothing,
+         t_an_unreadable_plan_is_exit_3_not_a_crash,
+         t_every_rule_and_every_delegation_is_listed)
+
+
+def _every_case_is_registered():
+    defined = {n for n in globals() if n.startswith('t_')}
+    listed = {f.__name__ for f in TESTS}
+    assert defined == listed, f'not registered: {sorted(defined - listed)}'
+
+
+if __name__ == '__main__':
+    _every_case_is_registered()
+    for fn in TESTS:
+        print(f'--- {fn.__name__}')
+        fn()
+    print('\nALL PASS')

--- a/tests/test_937_tool_registry.py
+++ b/tests/test_937_tool_registry.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""#937: every runnable tool is in the catalogue, and the catalogue is gated.
+
+This is the anti-deletion guarantee. A restructure cannot quietly drop a tool,
+because the completeness case below fails when a runnable tool has no
+`KRT_TOOL` declaration -- and it fails on the tool that was dropped, by name.
+
+Before this gate the repo had three catalogues and no completeness check in
+the direction that matters. `krt_capabilities.KNOWN_MODULES` is a
+hand-maintained tuple of 29 (one member, `route_summary.py`, is not a CLI at
+all); `FLAG_SCRIPTS` covers 8; `test_431.discovered_tools()` finds the 49 the
+skills happen to invoke. Every one of them asks "does this named thing
+exist?"; none asks "is every thing that exists named?".
+
+THE FLOORS ARE PER DOOR, AND THAT IS THE WHOLE POINT. A registry that is
+complete overall but omits every routing tool from the routing view passes any
+global count, and the reader at the routing door is exactly as stranded as
+before. `tests/mutate_937.py` proves the floors bind by setting every row's
+scope to `['placement']`: the routing and combined floors must redden while
+the total does not move.
+
+Floors, not pins, and deliberately well under today's numbers: their job is to
+catch the PREDICATE going dark. A sweep that suddenly finds nothing would
+otherwise report "all 0 tools declared" as a pass, which is this repo's
+recorded vacuity failure and the reason `test_803` carries `MIN_RESOLVED` and
+`test_718` carries `_BATTERY_COUNT`. The exact-membership job belongs to the
+completeness case, which needs no number.
+"""
+import ast
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+import krt_registry as R                                     # noqa: E402
+
+#: The probe launches one subprocess per tracked non-test .py (240 of them,
+#: ~11 s at 8 workers) and the registry is built once and shared. 300 gives
+#: the same headroom test_798 takes for a far smaller sweep.
+RUN_ALL_TIMEOUT = 300
+
+#: Measured at the commit that added this gate: 71 tools, 31 placement,
+#: 34 routing, 31 combined. These are FLOORS well under those, not targets --
+#: see the module docstring. Raising one is a deliberate decision, here.
+_MIN_TOOLS = 60
+_MIN_PER_DOOR = {'placement': 25, 'routing': 28, 'combined': 25}
+
+#: Built once: every case below reads it, and rebuilding per case would pay
+#: the 11 s probe five times over.
+ROWS = R.registry(ROOT)
+
+
+def t_every_runnable_tool_is_declared():
+    """The completeness direction, and the reason this file exists."""
+    undeclared = sorted(r['path'] for r in ROWS if not r['declared'])
+    assert not undeclared, (
+        f'{len(undeclared)} runnable tool(s) carry no KRT_TOOL declaration, '
+        f'so no door view can show them and a restructure could drop them '
+        f'unnoticed: {undeclared}')
+    print(f'  PASS: {len(ROWS)} runnable tool(s), all declared')
+
+
+def t_no_declaration_invents_its_own_vocabulary():
+    """A typo'd door is a tool that silently appears in NO view, which is the
+    failure this registry exists to prevent -- so it is a hard error, not a
+    warning."""
+    bad_kind = sorted(r['path'] for r in ROWS if r['kind'] not in R.KINDS)
+    assert not bad_kind, f'kind not one of {R.KINDS}: {bad_kind}'
+    bad_scope = sorted(
+        r['path'] for r in ROWS
+        if r['scope'] is None or any(s not in R.DOORS for s in r['scope']))
+    assert not bad_scope, f'scope not a list of {R.DOORS}: {bad_scope}'
+    print(f'  PASS: every kind in {R.KINDS}, every scope within {R.DOORS}')
+
+
+def t_no_declaration_outlives_the_tool_it_describes():
+    """The REVERSE direction. A file that stops answering `--help` -- a CLI
+    demoted to a library, say -- keeps its declaration and would go on being
+    counted in a door's floor while no reader can run it. Nothing else in the
+    repo would notice."""
+    runnable = {r['path'] for r in ROWS}
+    stale = []
+    for rel in R.tracked_python(ROOT):
+        if rel in runnable:
+            continue
+        if R.declaration(ROOT, rel) is not None:
+            stale.append(rel)
+    assert not stale, (
+        f'{len(stale)} file(s) declare KRT_TOOL but no longer answer --help '
+        f'with a usage line, so they are counted by the registry and runnable '
+        f'by nobody: {sorted(stale)}')
+    print(f'  PASS: no declaration outlives its tool')
+
+
+def t_each_door_view_is_populated():
+    """The anti-vacuity floor, PER DOOR. See the module docstring."""
+    assert len(ROWS) >= _MIN_TOOLS, (
+        f'only {len(ROWS)} runnable tools found (floor {_MIN_TOOLS}) -- the '
+        f'--help probe has probably stopped working, and a probe that finds '
+        f'nothing reports every door as complete')
+    counts = {}
+    for door in R.DOORS:
+        counts[door] = len(R.door_view(ROWS, door))
+        assert counts[door] >= _MIN_PER_DOOR[door], (
+            f'the {door} door shows {counts[door]} tool(s), floor '
+            f'{_MIN_PER_DOOR[door]}. A registry complete overall but empty at '
+            f'one door leaves that reader exactly as stranded as before.')
+    scopeless = sum(1 for r in ROWS if not r['scope'])
+    print(f'  PASS: {len(ROWS)} tools; ' +
+          ', '.join(f'{d} {counts[d]}' for d in R.DOORS) +
+          f'; {scopeless} declared into no door')
+
+
+def t_every_self_recorder_is_declared_an_actor():
+    """The cross-check, and it is a CROSS-CHECK: `record_invocation` is the
+    precise half of the derivation (17 call sites, 17 actors) but it has
+    misses, so a disagreement is reported by name rather than used to
+    overwrite the declaration."""
+    wrong = sorted(r['path'] for r in ROWS if r['self_records']
+                   and r['kind'] not in ('actor', 'conditional'))
+    assert not wrong, (
+        f'{len(wrong)} tool(s) call record_invocation -- they write a board '
+        f'and self-record it -- but are declared neither actor nor '
+        f'conditional: {wrong}')
+    n = sum(1 for r in ROWS if r['self_records'])
+    print(f'  PASS: {n} self-recorder(s), all declared actor or conditional')
+
+
+def t_every_tool_carries_its_own_purpose_text():
+    """`purpose` is DERIVED from the docstring rather than copied into the
+    registry, which is only sound while every tool has one."""
+    mute = sorted(r['path'] for r in ROWS if not r['purpose'])
+    assert not mute, (
+        f'{len(mute)} tool(s) have no module docstring, so the registry has '
+        f'no purpose text to derive and would need a second copy that can '
+        f'drift: {mute}')
+    shortest = min(ROWS, key=lambda r: len(r['purpose']))
+    print(f'  PASS: all {len(ROWS)} carry purpose text; shortest is '
+          f'{len(shortest["purpose"])} chars ({os.path.basename(shortest["path"])})')
+
+
+def t_scope_is_still_not_derivable():
+    """Re-measure the claim the `scope` field rests on, every run.
+
+    `scope` is declared because the two candidate derivations disagree and
+    neither is complete. That is a fact about the tree, not a law, and a
+    declared field nobody can retire is how a registry becomes make-work -- so
+    if the directory rule and the usage rule ever BOTH decide for every tool
+    AND agree, this fails and says to delete the field.
+
+    The two rules measure different questions, which is why they differ: a
+    directory is a PROVENANCE fact (the #522 reorg moved these files) and a
+    skill naming a tool is a USAGE fact.
+    """
+    skill_door = {'plan-pcb-placement': 'placement',
+                  'plan-pcb-placement-and-routing': 'combined'}
+    texts = {}
+    r = subprocess.run(['git', 'ls-files', '.claude/skills'],
+                       cwd=ROOT, capture_output=True, text=True)
+    for rel in r.stdout.split():
+        if not rel.endswith('.md'):
+            continue
+        with open(os.path.join(ROOT, rel), encoding='utf-8',
+                  errors='replace') as fh:
+            texts[rel] = fh.read()
+
+    undecided_dir = undecided_use = disagree = 0
+    for row in ROWS:
+        top = row['path'].split('/')[0]
+        by_dir = {'py_placer': {'placement'},
+                  'py_router': {'routing'}}.get(top)
+        by_use = set()
+        pat = re.compile(r'(?<![A-Za-z0-9_])'
+                         + re.escape(os.path.basename(row['path'])))
+        for rel, text in texts.items():
+            if pat.search(text):
+                by_use.add(skill_door.get(rel.split('/')[2], 'routing'))
+        if by_dir is None:
+            undecided_dir += 1
+        if not by_use:
+            undecided_use += 1
+        if by_dir and by_use and by_dir != by_use:
+            disagree += 1
+
+    assert undecided_dir or undecided_use or disagree, (
+        'the directory rule and the usage rule now decide for every tool and '
+        'agree everywhere. `scope` has become derivable -- retire the '
+        'declared field rather than going on maintaining it.')
+    print(f'  PASS: scope stays declared -- directory rule undecided for '
+          f'{undecided_dir}, usage rule empty for {undecided_use}, '
+          f'{disagree} disagreement(s)')
+
+
+def t_the_predicate_covers_everything_test_431_discovers():
+    """No coverage is lost by adopting this catalogue: it must be a superset
+    of what the skills-scanning gate already finds."""
+    sys.path.insert(0, os.path.join(ROOT, 'tests'))
+    import test_431_skill_commands as t431              # noqa: E402
+    discovered = {os.path.basename(t) for t in t431.TOOLS}
+    ours = {os.path.basename(r['path']) for r in ROWS}
+    missing = sorted(discovered - ours)
+    assert not missing, (
+        f'test_431 invokes {len(missing)} tool(s) this registry does not '
+        f'list, so adopting it would LOSE coverage: {missing}')
+    print(f'  PASS: all {len(discovered)} tools test_431 discovers are in the '
+          f'registry ({len(ours) - len(discovered)} more besides)')
+
+
+TESTS = (t_every_runnable_tool_is_declared,
+         t_no_declaration_invents_its_own_vocabulary,
+         t_no_declaration_outlives_the_tool_it_describes,
+         t_each_door_view_is_populated,
+         t_every_self_recorder_is_declared_an_actor,
+         t_every_tool_carries_its_own_purpose_text,
+         t_scope_is_still_not_derivable,
+         t_the_predicate_covers_everything_test_431_discovers)
+
+
+def _every_case_is_registered():
+    defined = {n for n in globals() if n.startswith('t_')}
+    listed = {f.__name__ for f in TESTS}
+    assert defined == listed, f'not registered: {sorted(defined - listed)}'
+
+
+if __name__ == '__main__':
+    _every_case_is_registered()
+    for fn in TESTS:
+        print(f'--- {fn.__name__}')
+        fn()
+    print('\nALL PASS')

--- a/tests/test_krt_capabilities.py
+++ b/tests/test_krt_capabilities.py
@@ -154,6 +154,72 @@ def test_a_script_does_NOT_inherit_another_CLIs_flags():
     print("  PASS: registrars are followed, other CLIs are not")
 
 
+def test_the_reported_version_is_the_real_one():
+    """`version` was `None` on every call this function ever made.
+
+    It read `routing_defaults.VERSION`, which that module has never defined,
+    inside a try/except that turned the AttributeError into the same `None`.
+    It shipped that way from the commit that introduced the module until #936
+    -- and the reason it survived is exactly this: eight test functions here,
+    and not one read the key. A capability report exists to answer "can THIS
+    clone do X", and a version that is always None answers nothing.
+
+    Asserted against /VERSION rather than a literal: pinning the number here
+    would make every release edit this test.
+    """
+    caps = capabilities()
+    with open(os.path.join(ROOT, 'VERSION'), encoding='utf-8') as fh:
+        want = fh.read().strip()
+    assert want, '/VERSION is empty -- the release triple is broken'
+    assert caps.get('version') == want, (
+        f"capabilities()['version'] is {caps.get('version')!r}, /VERSION "
+        f"says {want!r}")
+    print(f"  PASS: version reports {want}, the string /VERSION carries")
+
+
+def test_asking_what_this_clone_can_do_changes_nothing():
+    """A read-only question must not have a side effect on the asker.
+
+    `capabilities()` used to insert py_router/ on the CALLER's `sys.path` so
+    it could import `routing_defaults` for the version. The import is gone;
+    the insert outlived it. This module's own rule for flags -- "a consumer
+    asking 'can this clone do X' must not be able to trigger a side effect by
+    asking" -- is the same rule, and sys.path is a side effect.
+    """
+    before = list(sys.path)
+    capabilities()
+    assert sys.path == before, (
+        f'capabilities() mutated sys.path: '
+        f'{[p for p in sys.path if p not in before]}')
+    print("  PASS: capabilities() leaves sys.path alone")
+
+
+def test_the_pinnable_set_is_a_subset_of_the_real_catalogue():
+    """KNOWN_MODULES is the PINNABLE set; krt_registry is the catalogue.
+
+    What must hold between them: a name here that is neither a runnable tool
+    nor a real file is a name a consumer can pin and never get an answer
+    about. `route_summary.py` is the one member that is a library rather than
+    a CLI -- legitimate, since `modules` reports FILE PRESENCE -- and it is
+    asserted by name rather than left as a surprise for the next reader.
+    """
+    import krt_capabilities as kc
+    import krt_registry as reg
+    runnable = {os.path.basename(r['path']) for r in reg.registry(ROOT)}
+    known = set(kc.KNOWN_MODULES)
+    not_tools = sorted(known - runnable)
+    for name in not_tools:
+        assert os.path.isfile(_tool_path(ROOT, name)), (
+            f'{name} is pinnable but is neither a runnable tool nor a file '
+            f'in this clone')
+    assert not_tools == ['route_summary.py'], (
+        f'the set of pinnable non-CLI modules moved: {not_tools}. Each is a '
+        f'name a consumer can pin and get only file-presence for, so a new '
+        f'member is a deliberate decision, here.')
+    print(f"  PASS: {len(known)} pinnable, {len(known & runnable)} of them "
+          f"runnable tools; non-CLI: {not_tools}")
+
+
 if __name__ == '__main__':
     for k, v in sorted(globals().items()):
         if k.startswith('test_'):

--- a/tests/test_run8_skill_drivers.py
+++ b/tests/test_run8_skill_drivers.py
@@ -179,6 +179,27 @@ def test_loop_driver():
     check('...and says delegation is now a correctness decision',
           'CORRECTNESS one' in text)
 
+    # THE ROUTING SKILL, which this file declared and never read. `ROUTING_SKILL`
+    # was assigned and referenced nowhere else, so of this file's checks 0 were
+    # about the routing half -- the door with no driver, and therefore the one
+    # whose contract lives entirely in prose. A declared-but-unused path is a
+    # gate that looks present in a grep and asserts nothing.
+    #
+    # These pin what the LOOP relies on being true over there. They are
+    # deliberately not a driver contract: routing has no driver, and #937 is
+    # where whether it should have one is being decided.
+    rtext = open(ROUTING_SKILL, encoding='utf-8').read()
+    check('the routing skill ships', os.path.isfile(ROUTING_SKILL))
+    check('the routing skill still opens at the step the loop hands off to',
+          'Step 1: Load and Analyze PCB Structure' in rtext)
+    check('...and still ends its chain on route.py, which the loop assumes',
+          'route.py' in rtext)
+    # The handback the loop reads. L2 tells a delegate to follow this skill and
+    # then reads a close-out; if the reconciliation section is renamed away, the
+    # loop's instruction points at nothing and only a run would find out.
+    check('...and keeps the net-coverage reconciliation the loop cites',
+          'Net-Coverage Reconciliation' in rtext)
+
 
 def main():
     check('the driver ships with the skill', os.path.isfile(DRIVER))

--- a/update_metadata.py
+++ b/update_metadata.py
@@ -9,6 +9,10 @@ Usage:
         --repo drandyhaas/KiCadRoutingTools
 """
 
+#: #937 registry: which door(s) show this tool, and whether it changes
+#: the board. Read by krt_registry.py -- by AST, never imported.
+KRT_TOOL = {'scope': [], 'kind': 'utility'}
+
 import argparse
 import json
 import sys


### PR DESCRIPTION
Closes #937.

`Refs #924` (closed NOT_PLANNED as superseded by this one), `Refs #936 #919
#920 #921 #922 #923` — all already closed; #937 is the only open issue in the
family and so the only link that can autoclose.

**Stacks on #939**, which should merge first. This branch is based on its head,
and #939 carries a fix this PR's verification found: `test_run8_skills_generic`
forbids naming corpus boards inside a skill, and the off-outline gate's comment
named two. The suite was red on that branch.

---

## The flow now

```
 THE THREE DOORS                                    refusals  stages  scripts/
 ─────────────────────────────────────────────────────────────────────────────
 /plan-pcb-placement          SKILL.md      1576         44       9      yes
                              placement_driver 2727
 /plan-pcb-placement-and-routing SKILL.md   1425         69       5      yes
                              loop_driver    4857     ──────
                              references/     976        113   ← all of it here
 /plan-pcb-routing            SKILL.md      2660          0       0      NO
                              (largest file in the set; no driver, no Step 0)

   8 SITES sent a reader to a routing "Step 0", a "How to run this skill"
   section, or a "V1-V5 loop". NONE of the three existed.

   36 rules in plan-pcb-routing/SKILL.md are decidable by a script.
   TWO already shipped AS `assert` STATEMENTS in a fenced block no test ran.
   -> 0 enforced.

   67 runnable tools; 29 in a hand-written catalogue, 8 with flag coverage,
   22 named in no skill file, and NO gate asserting the reverse direction:
   that every CLI in the tree is in the catalogue at all.
```

## The flow this makes

```
 ONE FLOW OF VERBS, both halves, the seat occupied differently
   declare -> measure -> decide -> act -> prove -> record -> loop or ship

 PLACEMENT                            ROUTING
 the AI DECIDES                       the AI PLANS
 scripts legalize and measure         scripts EXECUTE
 refusals keep it honest    (113)     a CHECKER proves the plan    (17+9)
 output does NOT replay               output REPLAYS with no LLM
     └── the test: if it replays from a recorded command list without
         judgement, it is script work ──┘

 /plan-pcb-routing  + ## Step 0  + ## How to run this skill
                    + scripts/route_plan_check.py   ← a checker, not a driver

   All 8 citations resolve. Five became true by construction; three were
   re-pointed at the combined skill, where ca6bb455 actually moved that loop;
   and the eighth named the WRONG SKILL entirely.

 THE CATALOGUE                    72 tools, keyed by PATH, 0 undeclared
   purpose / doc pointer / flags   DERIVED  — no second copy, so no drift
   scope / kind                    DECLARED — measured not derivable
   a missing declaration is a GATE FAILURE, not an exemption
   the completeness floor holds PER DOOR, not just globally
```

**The one asymmetry that stays, deliberately.** 113 refusals on the footprints
and a checker on the copper is the principle working, not a defect. Refusals
keep an AI honest *while it decides*, so they belong where it decides; a
deterministic chain needs a checker instead. The skills now say so, so a future
reader does not "fix" it.

---

## What is here

**The registry** (`krt_registry.py`, `tests/test_937_tool_registry.py`). The
predicate is behavioural — `python3 <file> --help` exits 0 and prints a
`usage:` line — over the 240 tracked non-test `.py` files, ~11 s at 8 workers.
It is a strict superset of the 49 tools `test_431` discovers. `grep __main__`
is wrong both ways and would need an allowlist; this predicate **named its own
three false negatives** and they were fixed rather than exempted, which is why
the count went 67 → 70 before the registry itself and `route_plan_check.py`
made 72.

Derived so nothing can drift: `purpose` (the docstring's first line — all 72
have one), `doc` (a `docs/utilities.md` heading; 23 today, and the absence is
the backlog, not a failure), `flags` (unchanged, `script_flags`). Declared
because measurement says they cannot be derived: `scope` and `kind`, read **by
AST, never by import**, for the reason `krt_capabilities` gives for doing the
same with flags.

`kind` has five values, not the owner's two, because forcing the rest into that
pair would make the registry lie: `conditional` writes a board only under an
opt-in flag, `driver` emits instructions and touches no board, `utility` is not
board work at all. actor 22, instrument 35, utility 9, conditional 3, driver 2.
Per door: placement 31, routing 35, combined 32, and 11 declared into no door —
which is a declaration, not an omission.

**The routing door's entry gate.** `## Step 0` runs the same two instruments L2
does, so the loop's claim that "it will pass, you just did that work" is true by
construction. `## How to run this skill` says who is in the seat and why there
is no driver here.

**The plan checker** (`route_plan_check.py`). 17 rules enforced, 9 delegated and
named with the tool that owns each. It reads `parse_manifest`, **not**
`plan_steps_from_manifest` — see the corrections below.

**Both off-outline channels.** `grade_pad_legality` now computes the per-pad
census at margin 0 beside the clearance-inflated AABB, with the same #628
ring-ownership rule. **The verdict does not move**: 22 boards, 21 buildable, 1
NOT BUILDABLE, before and after.

**Thresholds that report.** `_guard_congestion` printed nothing in two of its
five return paths, including the one a *passing* board takes — so the crossings
delta that non-negotiable 4 says must always be reported was never printed at
all. P0 never opened either of the two JSONs its own flags name.

**Every stage body is measured.** The caps asserted against whatever the cheap
fixture returned, so a stage that refuses there was graded as its 3-line
refusal. P4's 98 lines passed that way; L2's 196 and L5's 161×3 were never
measured by anything.

---

## Corrections — figures I published to #937 that do not reproduce

| claim | truth, measured |
|---|---|
| "**17** rules are predicates over `(board, plan)`" | **36** — 20 plan-only, 13 board+plan, 3 board-only, 6 needing a run |
| "reuse `plan_steps_from_manifest`, THE single implementation" | **Wrong input.** It drops `cd`, `cp`, pipes and every `check_*`; loses tool identity (`route_planes` and `repair_planes` both become one action), argv and any index; and its pruner can nominate a **retry** as the chain end. Six of the seventeen rules have no representation in it at all |
| "the sweep costs 19 s, ~0 FP / **3 FN**" | **40.3 s serial / 13.4 s at 4 jobs**, and **7** files have `__main__` yet fail, with four different remedies |
| "`route.py` declares **93** flags, registry resolves **102**" | **94** in-file, **103** resolved, 97 raw `add_argument` sites, 108 `--help` option strings |
| "scope: writes rule empty for 30, disagrees on **21 of 37**" | Does not reproduce under any of 9 variants. Usage-undecided **24–26**, disagreements **8–13** |
| "`record_invocation` has **8** call sites" | **17** |
| "42 refusals over 39 / 68 over 64" | **44/41** and **69/64** = **113** |
| "**7** sites cite a routing Step 0 / V1–V5" | **8** |
| Step 5b at `:909`, asserts at `:943/:944` | heading **`:912`**, asserts **`:952`/`:954`** |

**Two rule statements were wrong, not just mis-cited**, and a checker built on
them would have enforced the opposite of the rule:

- **`:1958`** does not say the plan ends with the three checkers. Read with
  `:2557` and `:2562` it means they appear as trailing **comments** after the
  final `route.py` — ending on them would break the exit-code rule and the
  route.py rule at once.
- **`:2643` is not an `iff`.** "else leave the default 3" means *omit* the flag,
  the dense antecedent is a fact about the board, and `:1971` makes 5 a
  permitted retry on any board. Only the `> 5` ceiling is decidable.

## Defects found while building this

- **`--time-matching` has no entry in any `manifest_to_plan` table**, so the
  unknown-flag fallthrough eats the tokens after it:
  `route.py … --time-matching /DDR/CK_P /DDR/CK_N` converts to `nets: ["*"]`.
- **`rule1_check`'s docstring** opened "crossings and hpwl" while the code has
  checked hpwl alone since #789 — the retracted rule left as the operative
  sentence, in the docstring of the acceptance rule itself.
- **`tests/stress/perturb_batch.py`** claims to walk the *routing* skill's Step
  0 ladder while walking `place_optimize` through Step 0b/0c/0d/0e.
- **`--no-bga-zones` vs `--no-bga-zone`**: Step 10 rule 4 says the singular
  fails argparse; three other sites use the singular. Both spellings are real.
- **`_guard_damage` read `blocking`**, 1 of 5 not_buildable conjuncts since
  #918, so it told the reader there was "no damage to repair" about a board its
  own instrument graded NOT BUILDABLE. One tracked board is exactly that.
- **`test_431` could not see a tool going dark** — 7 of 50 discovered tools cite
  no flag at all and the 914-citation aggregate absorbed every one.
- **`capabilities()` mutated the caller's `sys.path`**, residue from an import
  #936 removed.

## What the measurement caught in my own work

Four times, and each is in a commit message:

1. **`ast.parse` does not enforce the `from __future__` placement rule but
   `compile()` does.** My first declaration pass broke 31 files and my
   verification sweep reported the tree clean.
2. **Three line citations went stale** from inserting 3 lines at the top of 70
   files, and **only one was covered by a gate**. My repair tool then corrupted
   a range (`1571-1573` → `1576-1573`), caught by reading the diff.
3. **Two refusal arms rendered zero times** while `--dump-refusals` reported
   full coverage, because the arms are composed outside the `err(...)` call.
4. **A battery row SURVIVED**: Step 5b is two asserts and every break I wrote
   exercised only one. The untested half is the GNDA failure itself.

## A clarity review, and what it found in this PR's own text

Four agents then read the three skills as an executor about to run a real
board. ~100 findings. The ones below were mine and are fixed here; the rest are
pre-existing and went to **#941** (the #936 family at larger scale) and
**#942** (subagent return contracts, a missing prompt-injection guard, and what
breaks on a non-Claude-Code harness).

- **A commit message in this PR was false.** It says it fixed the
  `--no-bga-zones` / `--no-bga-zone` contradiction; it did not. And the rule
  was wrong in a way nobody had measured: it claims the singular "fails
  argparse", and **all four tools accept it** -- three by explicit alias,
  `route_diff` by argparse prefix matching -- so the twelve singular spellings
  below it all work.
- **`route_plan_check.py` had the defect this PR wrote a memory about.** Its
  seventeen rules cited SKILL.md LINE NUMBERS taken from a research report on
  the file *before* this branch inserted 76 lines at its top: R14 pointed at
  pour prose instead of Step 5b's asserts. They cite SECTIONS now.
- **The off-outline refusal (from #939) ordered an executor to break a
  castellated board.** The per-pad census has no exemption for a castellated
  row, a card edge or a declared `edge_connectors` part -- which this skill
  says elsewhere are MEANT to cross the outline -- and there was no waiver in
  the argparse, so the gate was unpassable and the only compliant action
  destroys the mating edge. `--waive off-outline:<reason>` now exists and needs
  a reason: measured, bare refuses, reasonless refuses, reasoned clears.
- **L2 told the routing teammate that the routing skill fans out three
  verification subagents** -- a claim the combined SKILL.md retracts by name --
  and then asked it to return those verdict paths.

## Verification

```
tests/run_all.py                    601 passed, 0 failed, 0 timed out
tests/mutate_937.py                 13 rows, 13 killed, 0 survived, 0 broken
tests/mutation_anchors.py           49 batteries, 1089 anchors, 0 stale
krt_registry.py --check             72 tools, 0 undeclared
placement_driver --self-test        OK   (9 bodies, each under its ceiling)
loop_driver --self-test/--dump-all  OK   (12 arms, each under its ceiling)
route_plan_check --list             17 rules, 9 delegations
test_431_skill_commands             ALL PASS — 914 citations, 161 spans
```

22-board census, before and after, for the off-outline change: 21 buildable,
1 NOT BUILDABLE (`rp2350_fpga_eensy_prePlane`, via coincident origins — not
off-outline copper). The AABB channel fires on 3 boards, the per-pad channel on
1; the 2 disagreements are the two human reference boards `oob_pad_basis`
already predicted. The per-pad channel agrees with `render_placement`'s
authoritative measure exactly, on amounts: `U8 0.8mm`, `[]`, `[]`.

## What is left open, on purpose

- **The accept rule is still per HALF, not per lever.** The lever identity
  ships and is measured — 411 of 450 recorded ledger rows (91%) carry one — but
  consuming it moves DONE and STUCK verdicts, and CLAUDE.md is unambiguous that
  a verdict-moving change is graded by a corpus A/B, never by reasoning. That
  A/B is not something this PR can run.
- **P4 is pinned at 98 lines rather than split.** The finding stands — its body
  holds five verbs — but a split changes stage ids, which is the GUI's live
  progress contract, and that belongs in its own change.
- **No gate covers a `file.py:NNN` citation that still resolves but now points
  at the wrong line.** Three went stale here and two were invisible.
- **`loop_driver` L2 still gates on the coarse channel.** Deliberate: it is
  justified over 119 graded rows. What changed is that its refusal now prints
  both numbers and reads the disagreement out loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wa54dFaXWdK4aw3VsV8ay
