### PR TITLE
#908 follow-up: a footprint's graphic copper is not a track, so its stroke is not a track width

### DIFF
--- a/py_router/check_drc.py
+++ b/py_router/check_drc.py
@@ -3463,6 +3463,14 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
         for seg in pcb_data.segments:
             if matching_net_ids is not None and seg.net_id not in matching_net_ids:
                 continue
+            if getattr(seg, 'graphic', False):
+                # Footprint / board graphic copper (#908, #337): a filled
+                # fp_poly's STROKE is an outline width, not a track width --
+                # the copper is the fill. KiCad's track_width constraint
+                # applies to PCB_TRACK only, never to a shape, so grading
+                # the perimeter segments here manufactured 8 permanent
+                # 'track-width' rows on a SOT-89 tab (run 26, esp_prog).
+                continue
             _tf = _track_floor(seg)
             too_thin, shortfall = check_track_width(seg, _tf, size_margin)
             if too_thin:

--- a/py_router/fix_kicad_drc_settings.py
+++ b/py_router/fix_kicad_drc_settings.py
@@ -607,7 +607,14 @@ def scan_board_minima(pcb_path: str):
         return {}
 
     out = {}
-    widths = [s.width for s in pcb.segments if s.width and s.width > 0]
+    # Footprint / board GRAPHIC copper (#908, #337) is a shape, not a track:
+    # a filled fp_poly's stroke width is an outline width and KiCad's
+    # min_track_width rule never grades it. Counting it here wrote
+    # `rules.min_track_width 0.15 -> 0.1` on every step of a chain whose
+    # only 0.1 mm "track" was a SOT-89 tab outline, and made check_complete
+    # read that board as UNSOUND (run 26, esp_prog).
+    widths = [s.width for s in pcb.segments
+              if s.width and s.width > 0 and not getattr(s, 'graphic', False)]
     if widths:
         out["min_track_width"] = min(widths)
     via_drills = [v.drill for v in pcb.vias if v.drill]

--- a/py_router/fix_kicad_drc_settings.py
+++ b/py_router/fix_kicad_drc_settings.py
@@ -555,7 +555,12 @@ def _fab_floor_disclosure(output_pcb: str, rules_before: dict, proj: dict,
         pcb = parse_kicad_pcb(output_pcb)
         for key, _label, was, _now, _mv in relaxed:
             if key == "min_track_width":
-                objs = [s.width for s in pcb.segments if s.width]
+                # Graphic copper is a shape, not a track (#908, #337) -- the
+                # same exclusion `scan_board_minima` makes below. Counting a
+                # filled fp_poly's stroke here told the reader that N tracks
+                # sit under the original floor when none of them is a track.
+                objs = [s.width for s in pcb.segments
+                        if s.width and not getattr(s, 'graphic', False)]
             elif key == "min_via_diameter":
                 objs = [v.size for v in pcb.vias if v.size]
             elif key == "min_via_drill":

--- a/tests/test_908_graphic_width_rows.py
+++ b/tests/test_908_graphic_width_rows.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""#908 follow-up: a footprint's GRAPHIC copper is not a track, so its stroke
+width is not a track width.
+
+A filled `fp_poly` on a copper layer parses as net-0 `graphic=True` segments
+(#908), one per perimeter edge, carrying the poly's STROKE width. The copper
+is the fill; the stroke is an outline. KiCad's `track_width` constraint grades
+`PCB_TRACK` only and never a shape, so two consumers that walked
+`pcb.segments` without excluding graphics manufactured findings out of a
+SOT-89 tab outline:
+
+  * `check_drc` graded the eight 0.1 mm perimeter segments of esp_prog's U2
+    against the 0.15 mm fab floor -> 8 permanent `track-width` rows on a
+    board with NO tracks (run 26: `board_score` counted them as `undersized 8`
+    on every placement lap, and `blocking 0` was unreachable);
+  * `fix_kicad_drc_settings.scan_board_minima` took `min(width)` over the same
+    segments -> every chain step's writeback wrote `rules.min_track_width
+    0.15 -> 0.1`, and `check_complete --authored-from` then read the board as
+    UNSOUND ("track width 0.15 -> 0.1").
+
+Both now skip `seg.graphic`. This file pins each on the tracked fixture that
+produced them, with a control board carrying ONE real 0.1 mm track so that a
+checker which reports nothing at all cannot pass.
+
+Run:
+    python3 tests/test_908_graphic_width_rows.py
+"""
+
+import contextlib
+import io
+import os
+import sys
+import tempfile
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(TESTS_DIR)
+sys.path.insert(0, ROOT_DIR)
+sys.path.insert(0, os.path.join(ROOT_DIR, 'py_router'))  # #522
+sys.path.insert(0, os.path.join(ROOT_DIR, 'py_tools'))  # #522
+
+from check_drc import run_drc
+from fix_kicad_drc_settings import scan_board_minima
+from kicad_parser import parse_kicad_pcb
+
+RUN_ALL_FAST_OK = True
+
+FIXTURE = os.path.join(ROOT_DIR, 'kicad_files', 'esp_prog.kicad_pcb')
+FLOOR = 0.15
+STROKE = 0.1
+
+#: The control: the same SOT-89-style tab (a filled poly with a 0.1 stroke)
+#: beside ONE real 0.1 mm track on a net. Only the track is a track.
+CONTROL = '''(kicad_pcb
+ (version 20221018)
+ (net 0 "")
+ (net 1 "/A")
+ (footprint "L:P" (layer "F.Cu") (at 10 10)
+   (property "Reference" "U1")
+   (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "/A"))
+   (fp_poly (pts (xy 0.4 -0.5) (xy 3.4 -0.5) (xy 3.4 0.5) (xy 0.4 0.5))
+     (stroke (width 0.1) (type solid)) (fill yes)
+     (layer "F.Cu") (uuid "poly1")))
+ (segment (start 20 20) (end 24 20) (width 0.1) (layer "F.Cu") (net 1) (uuid "t1"))
+)
+'''
+
+
+def _quiet_drc(path):
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        return run_drc(path, clearance=0.25, min_track_width=FLOOR, quiet=True)
+
+
+def _width_rows(violations):
+    return [v for v in violations if v.get('type') == 'track-width']
+
+
+def main():
+    fails = []
+
+    def check(name, cond, detail=''):
+        print(f"  {'PASS' if cond else 'FAIL'}: {name}"
+              + (f"   [{detail}]" if detail and not cond else ''))
+        if not cond:
+            fails.append(name)
+
+    # --- 0: the fixture is what this file says it is (anti-vacuity) --------
+    pcb = parse_kicad_pcb(FIXTURE)
+    graphics = [s for s in pcb.segments if getattr(s, 'graphic', False)]
+    check('esp_prog carries exactly 8 segments, all graphic (U2 tab outline)',
+          len(pcb.segments) == 8 and len(graphics) == 8,
+          f'{len(pcb.segments)} segments, {len(graphics)} graphic')
+    check('every one is the 0.1 mm stroke of U2',
+          all(abs(s.width - STROKE) < 1e-9 for s in graphics)
+          and {getattr(s, 'owner_ref', None) for s in graphics} == {'U2'},
+          f'widths {sorted({s.width for s in graphics})}, '
+          f'owners {sorted({getattr(s, "owner_ref", None) for s in graphics})}')
+    check('the fixture has no real track at all (so a width row can only be a graphic)',
+          not [s for s in pcb.segments if not getattr(s, 'graphic', False)])
+
+    # --- 1: check_drc grades no graphic against the track-width floor -------
+    rows = _width_rows(_quiet_drc(FIXTURE))
+    check('check_drc reports 0 track-width rows on esp_prog at the 0.15 floor',
+          rows == [], f'{len(rows)} rows: {rows[:2]}')
+
+    # --- 2: scan_board_minima does not take a stroke as the board's track ---
+    minima = scan_board_minima(FIXTURE)
+    check('scan_board_minima reports no min_track_width on a track-less board',
+          'min_track_width' not in minima, f'{minima}')
+
+    # --- 3: the control -- a REAL 0.1 mm track beside the same kind of poly --
+    with tempfile.NamedTemporaryFile('w', suffix='.kicad_pcb', delete=False,
+                                     encoding='utf-8') as fh:
+        fh.write(CONTROL)
+        control = fh.name
+    try:
+        cpcb = parse_kicad_pcb(control)
+        cg = [s for s in cpcb.segments if getattr(s, 'graphic', False)]
+        real = [s for s in cpcb.segments if not getattr(s, 'graphic', False)]
+        check('the control parses as 4 graphic segments plus 1 real track',
+              len(cg) == 4 and len(real) == 1 and abs(real[0].width - STROKE) < 1e-9,
+              f'{len(cg)} graphic, {len(real)} real')
+        crow = _width_rows(_quiet_drc(control))
+        check('check_drc reports exactly 1 track-width row on the control (the track)',
+              len(crow) == 1, f'{len(crow)} rows: {crow[:3]}')
+        check('and that row is the track, not a poly edge',
+              bool(crow) and tuple(round(c, 3) for c in crow[0].get('seg_loc', ())) ==
+              (20.0, 20.0, 24.0, 20.0),
+              f'{crow[0].get("seg_loc") if crow else None}')
+        cmin = scan_board_minima(control)
+        check('scan_board_minima reads the control\'s track width 0.1',
+              abs(cmin.get('min_track_width', 0.0) - STROKE) < 1e-9, f'{cmin}')
+    finally:
+        os.unlink(control)
+
+    print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'ALL PASS'}")
+    return 1 if fails else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_908_graphic_width_rows.py
+++ b/tests/test_908_graphic_width_rows.py
@@ -16,9 +16,14 @@ SOT-89 tab outline:
   * `fix_kicad_drc_settings.scan_board_minima` took `min(width)` over the same
     segments -> every chain step's writeback wrote `rules.min_track_width
     0.15 -> 0.1`, and `check_complete --authored-from` then read the board as
-    UNSOUND ("track width 0.15 -> 0.1").
+    UNSOUND ("track width 0.15 -> 0.1");
+  * `fix_kicad_drc_settings._fab_floor_disclosure`'s census counted them too,
+    so the FAB FLOOR RELAXED banner told its reader that N tracks sit under
+    the original floor on a board whose only sub-floor copper is an outline.
+    That one writes nothing, but it is the line a human reads to decide
+    whether to re-route, and a wrong denominator there is a wrong decision.
 
-Both now skip `seg.graphic`. This file pins each on the tracked fixture that
+All three now skip `seg.graphic`. This file pins each on the tracked fixture that
 produced them, with a control board carrying ONE real 0.1 mm track so that a
 checker which reports nothing at all cannot pass.
 
@@ -39,7 +44,7 @@ sys.path.insert(0, os.path.join(ROOT_DIR, 'py_router'))  # #522
 sys.path.insert(0, os.path.join(ROOT_DIR, 'py_tools'))  # #522
 
 from check_drc import run_drc
-from fix_kicad_drc_settings import scan_board_minima
+from fix_kicad_drc_settings import _fab_floor_disclosure, scan_board_minima
 from kicad_parser import parse_kicad_pcb
 
 RUN_ALL_FAST_OK = True
@@ -130,6 +135,31 @@ def main():
         cmin = scan_board_minima(control)
         check('scan_board_minima reads the control\'s track width 0.1',
               abs(cmin.get('min_track_width', 0.0) - STROKE) < 1e-9, f'{cmin}')
+
+        # --- 4: the FAB FLOOR RELAXED census counts tracks, not outlines ---
+        # The control carries 1 real track and 4 poly edges, every one of them
+        # 0.1 mm and so every one of them under a declared 0.15. The banner
+        # must say `1 of 1`, never `5 of 5`: the denominator is the population
+        # a reader would have to re-route.
+        lines = _fab_floor_disclosure(
+            control, {'min_track_width': FLOOR},
+            {'board': {'design_settings': {'rules': {'min_track_width': STROKE}}}})
+        tw = [ln for ln in lines if 'track width' in ln]
+        check('the relaxation banner fires on the control at all',
+              len(tw) == 1, f'{lines}')
+        check('...and its census counts the 1 real track, not the 4 poly edges',
+              bool(tw) and '1 of 1 object(s)' in tw[0], f'{tw[0] if tw else None}')
+
+        # And on the fixture, whose only sub-floor copper IS an outline: there
+        # is no track to count, so the census abstains rather than reporting
+        # eight.
+        flines = _fab_floor_disclosure(
+            FIXTURE, {'min_track_width': FLOOR},
+            {'board': {'design_settings': {'rules': {'min_track_width': STROKE}}}})
+        ftw = [ln for ln in flines if 'track width' in ln]
+        check('on esp_prog the census reports no object at all (nothing is a track)',
+              len(ftw) == 1 and 'object(s)' not in ftw[0],
+              f'{ftw[0] if ftw else flines}')
     finally:
         os.unlink(control)
 


### PR DESCRIPTION
Two consumers walked `pcb.segments` without excluding the #908 `graphic=True` segments. On esp_prog, U2's SOT-89 tab (eight 0.1 mm perimeter segments, net 0, no real track on the board) produced findings out of thin air:

- `check_drc`'s fab-floor width loop graded the stroke against `--min-track-width 0.15`: 8 permanent `track-width` rows. Run 26's `board_score` counted them as `undersized 8` on every copper-free placement lap.
- `fix_kicad_drc_settings.scan_board_minima` took `min(width)` over the same segments: every chain step's writeback wrote `rules.min_track_width 0.15 -> 0.1`, and `check_complete --authored-from` read the board as UNSOUND.

KiCad's `track_width` constraint applies to `PCB_TRACK` only; a filled `fp_poly`'s copper is the fill and its stroke is an outline. Both loops now skip `seg.graphic` (16 lines).

**Test:** `tests/test_908_graphic_width_rows.py` (fast lane) pins both on the tracked fixture, asserting first that the fixture is exactly 8 graphic segments of U2 at 0.1 mm and nothing else, and on a control board with ONE real 0.1 mm track beside the same kind of poly. Measured: reverting the `check_drc` hunk fails it with 8 rows on the fixture and 5 on the control; reverting the scanner hunk fails it with `min_track_width 0.1`.

**Gates run green:** the new test, `test_908_{drc_report,footprint_copper,own_pad_lift,writer_owner_gate}`, `test_fix_drc_settings`, `test_fix_drc_autoinvoke`, `test_copper_graphics_layers_plural`.

**Provenance:** both edits were made mid-run in run 26 (disclosed there as ledger rows 7 and 24); this PR is where they get a commit and a test. First of a series from that run's findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5dqkz296U4Yzo2p21cwDi
