### PR TITLE
Placement writer: a rotation composes the texts' angles too, not only the pads'

### DIFF
--- a/py_placer/placement/writer.py
+++ b/py_placer/placement/writer.py
@@ -264,6 +264,62 @@ def _rotate_pad_angles(fp_text: str, delta_rot: float) -> str:
         fix_pad, fp_text)
 
 
+def _rotate_text_angles(fp_text: str, delta_rot: float, ref: str) -> str:
+    """Add delta_rot to the FIRST `(at x y [a])` of every top-level text node
+    (`property`, `fp_text`) in a footprint block.
+
+    KiCad stores a footprint text's angle as an ABSOLUTE board angle (probed
+    on pcbnew 10.0.0: `SetOrientationDegrees(old + d)` moves every text angle
+    by exactly d), so a rotation composes additively -- the same rule
+    `_rotate_pad_angles` applies to pads -- under the token rule
+    `_flip_at_angle` measured on the corpus: a present angle token is kept
+    (a text at 315 rotated by 45 keeps `(at x y 0)`), an absent one is added
+    only when the result is non-zero.
+
+    Until this existed the rotation path rotated pads only, so every rotated
+    part shipped its texts at the pre-rotation angle: 11 of run 26's 15 rotated
+    parts carried a Reference designator that no longer matched the pads it
+    labelled. The flip path has always composed its texts (#714) and is
+    untouched here -- one code path per mode, as `write_placed_output` says.
+    """
+    pieces = []
+    for head, s, e in _iter_sexpr_children(fp_text, 0):
+        if head not in _FLIP_TEXTS:
+            continue
+        node = fp_text[s:e]
+        m = re.search(r'\(at\s+([^\s()]+)\s+([^\s()]+)(?:\s+([^\s()]+))?\)',
+                      node)
+        if not m:
+            if re.search(r'\(at\b', node):
+                # Same doctrine as `_flip_at_angle`: an `(at ...)` that is
+                # there and does not parse must not be skipped silently, or
+                # the block ships with its pads turned and its texts not.
+                raise SideFlipUnsupported(
+                    f"{ref}: a text node has an `(at ...)` this rotation "
+                    f"cannot parse -- expected two or three plain numbers. "
+                    f"Refusing rather than rotating the pads and leaving the "
+                    f"text where it was: {node[:120]!r}")
+            continue
+        x, y, a = m.group(1), m.group(2), m.group(3)
+        na = round(((float(a) if a is not None else 0.0) + delta_rot) % 360, 6)
+        if a is not None or na != 0:
+            rep = f"(at {x} {y} {na:.6g})"
+        else:
+            rep = f"(at {x} {y})"
+        if rep != node[m.start():m.end()]:
+            pieces.append((s + m.start(), s + m.end(), rep))
+    if not pieces:
+        return fp_text
+    out = []
+    prev = 0
+    for s, e, rep in pieces:
+        out.append(fp_text[prev:s])
+        out.append(rep)
+        prev = e
+    out.append(fp_text[prev:])
+    return ''.join(out)
+
+
 class SideFlipUnsupported(Exception):
     """A flip was asked for on a footprint carrying a construct we will not guess at.
 
@@ -961,6 +1017,10 @@ def write_placed_output(input_file: str, output_file: str,
             delta_rot = (new_rot - old_rot) % 360
             if delta_rot != 0:
                 new_fp_text = _rotate_pad_angles(new_fp_text, delta_rot)
+                # The texts' angles are absolute too (pcbnew 10 probe), so
+                # they compose the same way; leaving them was how a rotated
+                # part shipped its Reference at the old angle.
+                new_fp_text = _rotate_text_angles(new_fp_text, delta_rot, key)
 
         content = content[:start] + new_fp_text + content[end:]
         modified_count += 1

--- a/tests/gui_parity/test_714_mirror_pcbnew_parity.py
+++ b/tests/gui_parity/test_714_mirror_pcbnew_parity.py
@@ -104,7 +104,28 @@ FIXTURES = [
 # parts shipped a reference designator rotated 180 degrees from where KiCad
 # puts it -- relative to their own pads, which had rotated correctly.
 COMPOSED_DELTAS = (None, 90.0, 180.0)
-PASSES = [(b, r, d) for (b, r) in FIXTURES for d in COMPOSED_DELTAS]
+# A third kind of pass: a ROTATION with no flip at all. It exists because its
+# absence hid the mirror-image bug of the one above -- the flip path composed
+# its text angles and the plain rotation path never did, so 11 of run 26's 15
+# rotated parts shipped their Reference at the pre-rotation angle while every
+# pad had turned correctly. pcbnew's `SetOrientationDegrees(old + d)` moves
+# each text by exactly d (absolute angles).
+#
+# ORTHOGONAL deltas only, and that is a measurement, not a shortcut: at
+# 137.25 deg pcbnew re-derives every footprint-local coordinate through the
+# rotation and loses a nanometre on 43 of them across 7 of the 16 fixtures
+# (pad `at`, `fp_line` ends, `fp_curve` points, `fp_circle` centres), and the
+# canonical child sort then re-pairs near-identical nodes so seven of those
+# read as large differences. This writer emits the board's own values, which
+# is the lossless side of that disagreement (the arc-mid waiver below is the
+# same story for the flip). A fractional delta's FORMATTING is pinned by
+# `tests/test_457_writer_precision.py` (137.25 there); what this gate proves
+# is the composition against pcbnew, and 90/270 prove it exactly.
+ROTATE_DELTAS = (90.0, 270.0)
+# Flip rows first: the Y-mirror direction check runs once, on the first row
+# with pads, and must see a flip.
+PASSES = ([(b, r, d) for (b, r) in FIXTURES for d in COMPOSED_DELTAS]
+          + [(b, r, ('rotate', d)) for (b, r) in FIXTURES for d in ROTATE_DELTAS])
 
 # A run that compared nothing must fail. Floors are below today's counts so a
 # board changing is not a failure, and far above zero so a vacuous run is.
@@ -307,16 +328,23 @@ def main(argv=None):
             if fp is None:
                 problems.append(f"{board}:{ref} not on the board -- fixture stale")
                 continue
+            rotate_only = isinstance(delta, tuple)
             before_y = [p.GetFPRelativePosition().y for p in fp.Pads()]
             before_x = [p.GetFPRelativePosition().x for p in fp.Pads()]
-            fp.Flip(fp.GetPosition(), tb)
-            if delta is not None:
-                # COMPOSED: a flip AND a rotation the caller chose, which
-                # is not pcbnew's bare flip and is the case every shipped
-                # consumer actually asks for.
+            if rotate_only:
+                # A plain rotation: no flip, the orientation moves by d and
+                # pcbnew turns pads AND texts with it.
                 fp.SetOrientationDegrees(
-                    round((fp.GetOrientationDegrees() + delta) % 360, 6))
-            if before_y and not direction_checked:
+                    round((fp.GetOrientationDegrees() + delta[1]) % 360, 6))
+            else:
+                fp.Flip(fp.GetPosition(), tb)
+                if delta is not None:
+                    # COMPOSED: a flip AND a rotation the caller chose, which
+                    # is not pcbnew's bare flip and is the case every shipped
+                    # consumer actually asks for.
+                    fp.SetOrientationDegrees(
+                        round((fp.GetOrientationDegrees() + delta) % 360, 6))
+            if before_y and not direction_checked and not rotate_only:
                 # The enum is KiCad 10; on 9 the second arg is a bool. Prove
                 # the direction TAKEN mirrors Y, so a KiCad that changes the
                 # meaning fails loudly instead of comparing a different flip.
@@ -337,12 +365,22 @@ def main(argv=None):
             fp0 = parse_kicad_pcb(src).footprints[ref]
             side = 'F' if (fp0.layer or 'F').startswith('B') else 'B'
             ours = os.path.join(tmp, f"{board}_{ref}_ours.kicad_pcb")
-            write_placed_output(src, ours, [{
-                'reference': ref, 'new_x': round(fp0.x, 6),
-                'new_y': round(fp0.y, 6),
-                'new_rotation': round(((-(fp0.rotation or 0.0))
-                                       + (delta or 0.0)) % 360, 6),
-                'new_side': side}])
+            if rotate_only:
+                # No `new_side`: this exercises the ordinary rotation path,
+                # the one every placement lap takes.
+                placement = {
+                    'reference': ref, 'new_x': round(fp0.x, 6),
+                    'new_y': round(fp0.y, 6),
+                    'new_rotation': round(((fp0.rotation or 0.0)
+                                           + delta[1]) % 360, 6)}
+            else:
+                placement = {
+                    'reference': ref, 'new_x': round(fp0.x, 6),
+                    'new_y': round(fp0.y, 6),
+                    'new_rotation': round(((-(fp0.rotation or 0.0))
+                                           + (delta or 0.0)) % 360, 6),
+                    'new_side': side}
+            write_placed_output(src, ours, [placement])
 
             ta, tk = _block(ours, ref), _block(kout, ref)
             if ta is None or tk is None:
@@ -362,7 +400,10 @@ def main(argv=None):
             d = _diff(canon(parse_sexpr(ta)), canon(parse_sexpr(tk)),
                       limit=args.show, waived=waived)
             if d:
-                tag = 'pure flip' if delta is None else f'flip + {delta} deg'
+                if rotate_only:
+                    tag = f'rotate + {delta[1]} deg'
+                else:
+                    tag = 'pure flip' if delta is None else f'flip + {delta} deg'
                 problems.append(
                     f"{board}:{ref} [{tag}] {len(d)} node difference(s):")
                 problems.extend("      " + x for x in d[:args.show])

--- a/tests/test_457_writer_precision.py
+++ b/tests/test_457_writer_precision.py
@@ -21,6 +21,7 @@ a format change (#369 A9), so the format itself is part of the contract.
 
 import math
 import os
+import re
 import sys
 import tempfile
 
@@ -197,7 +198,86 @@ def test_paren_in_property_does_not_bleed_a_rotation_into_the_next_footprint():
     os.unlink(out)
 
 
+# --- the texts rotate with the pads ----------------------------------------
+
+def _reference_at(block):
+    """The `(at ...)` token of the block's Reference property, or None."""
+    i = block.find('(property "Reference"')
+    if i < 0:
+        return None
+    m = re.search(r'\(at [^)]*\)', block[i:])
+    return m.group(0) if m else None
+
+
+def test_footprint_rotation_reaches_the_reference_text():
+    """A text's stored angle is absolute (pcbnew 10 probe), so rotating the
+    footprint must add the delta to it, exactly as it does to every pad. This
+    was the rotation path's gap: 11 of run 26's 15 rotated parts shipped their
+    Reference at the pre-rotation angle."""
+    src = _board(_fp('U1', 10.0, 10.0, rot=0, pad_angle=None))
+    out, text = _write(src, [{'reference': 'U1', 'new_x': 10.0, 'new_y': 10.0,
+                              'new_rotation': 90}])
+    assert _reference_at(text) == '(at 0 0 90)', f"{_reference_at(text)!r}"
+    assert '(at 0.5 0 90)' in text, "the pad rule regressed"
+    os.unlink(src)
+    os.unlink(out)
+
+
+def test_text_rotation_composes_with_a_stored_angle_and_keeps_the_token():
+    """A text already at 45 rotated by 90 reads 135; one at 315 rotated by 45
+    wraps to 0 and KEEPS its angle token (every text on the tracked corpus
+    carries the three-token form, and the flip path's token rule is the one
+    measured there)."""
+    for stored, delta, want in ((45, 90, '(at 1 1 135)'),
+                                (315, 45, '(at 1 1 0)'),
+                                (0, 137.25, '(at 1 1 137.25)')):
+        extra = (f'\t\t(fp_text user "hello"\n\t\t\t(at 1 1 {stored})\n'
+                 f'\t\t\t(layer "F.SilkS")\n\t\t)\n')
+        src = _board(_fp('U1', 10.0, 10.0, rot=0, pad_angle=None, extra=extra))
+        out, text = _write(src, [{'reference': 'U1', 'new_x': 10.0,
+                                  'new_y': 10.0, 'new_rotation': delta}])
+        i = text.index('(fp_text user')
+        got = re.search(r'\(at [^)]*\)', text[i:]).group(0)
+        assert got == want, f"stored {stored} + {delta}: {got!r} != {want!r}"
+        os.unlink(src)
+        os.unlink(out)
+
+
+def test_text_rotation_does_not_bleed_into_the_next_footprint():
+    """The #113 paren case, for texts: C1's rotation must not reach C2's
+    Reference through an unbalanced property value."""
+    mpn = '\t\t(property "MPN" "TCR2EF115,LM(CT"\n\t\t\t(at 0 0)\n\t\t)\n'
+    src = _board(_fp('C1', 10.0, 10.0, rot=0, pad_angle=None, extra=mpn)
+                 + _fp('C2', 20.0, 20.0, rot=0, pad_angle=None))
+    out, text = _write(src, [{'reference': 'C1', 'new_x': 10.0, 'new_y': 10.0,
+                              'new_rotation': 90}])
+    split = text.index('(footprint', text.index('"C1"'))
+    c1_block, c2_block = text[:split], text[split:]
+    assert _reference_at(c1_block) == '(at 0 0 90)', f"{_reference_at(c1_block)!r}"
+    assert _reference_at(c2_block) == '(at 0 0)', \
+        f"rotation bled into C2's Reference: {_reference_at(c2_block)!r}"
+    os.unlink(src)
+    os.unlink(out)
+
+
+def test_flip_path_owns_its_text_angles():
+    """A side change composes the text angle ONCE, on the flip path (#714):
+    `new_rot + 180 - (a - old_rot)` = 270 for rot 0 -> 90 flipped. If the
+    rotation path also ran, the angle would come out 0 (270 + 90)."""
+    src = _board(_fp('U1', 10.0, 10.0, rot=0, pad_angle=None))
+    out, text = _write(src, [{'reference': 'U1', 'new_x': 10.0, 'new_y': 10.0,
+                              'new_rotation': 90, 'new_side': 'B'}])
+    got = _reference_at(text)
+    assert got is not None and got.split()[-1].rstrip(')') == '270', f"{got!r}"
+    os.unlink(src)
+    os.unlink(out)
+
+
 TESTS = [
+    test_footprint_rotation_reaches_the_reference_text,
+    test_text_rotation_composes_with_a_stored_angle_and_keeps_the_token,
+    test_text_rotation_does_not_bleed_into_the_next_footprint,
+    test_flip_path_owns_its_text_angles,
     test_coordinate_keeps_six_decimals,
     test_large_coordinate_keeps_sub_micron_precision,
     test_written_position_round_trips_through_the_parser,


### PR DESCRIPTION
`write_placed_output`'s rotation path called `_rotate_pad_angles` and nothing else, so every rotated part shipped its `property`/`fp_text` nodes at the pre-rotation angle. KiCad stores those angles as absolute board angles (probed on pcbnew 10.0.0: `SetOrientationDegrees(old + d)` moves each text by exactly d), so a rotated part's Reference no longer matched the pads it labelled. Measured on run 26's delivered board: 11 of 15 rotated parts. The flip path has always composed its texts (#714); this is the same rule on the other path, as a separate helper so the modes stay one code path each.

**Change:** `_rotate_text_angles` walks the block's top-level children (the string-aware walk the flip uses), adds the delta to the first `(at x y [a])` of every text node under `_flip_at_angle`'s token rule, and refuses an `(at ...)` it cannot parse rather than rotating the pads and not the text. Called from the rotation branch only; the flip line `mutate_714` anchors is untouched.

**Tests:**
- `tests/test_457_writer_precision.py` +4: the Reference follows a 90° rotation (pad still does too); a stored angle composes and wraps keeping its token (45+90, 315+45 → `(at 1 1 0)`, 0+137.25); the #113 paren case for texts; a side change composes once on the flip path (270, not 0). Deleting the call site fails the first; dropping `% 360` fails the wrap (both measured).
- `tests/gui_parity/test_714_mirror_pcbnew_parity.py` gains rotation-only rows (90 and 270, no flip) against `SetOrientationDegrees` + `SaveBoard`: PASS, 75 fixtures, 3055 pads, node for node. Orthogonal deltas only, and that is measured: at 137.25° pcbnew re-derives 43 local coordinates by one nanometre across 7 of 16 fixtures (and the canonical child sort then re-pairs seven nodes), while this writer emits the board's own values, the lossless side of that disagreement, the same story as the existing arc-mid waiver.
- `tests/mutate_714.py --verify-anchors`: all 24 match exactly once. `test_714_{identity_write_unchanged,flip_roundtrip,mirror_discriminates,side_self_consistency,refusals}` green.

Second of a series from run 26's findings (first: #947).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5dqkz296U4Yzo2p21cwDi
