### PR TITLE
Floorplan: a declared edge connector inside its band is not off the board, and a receptacle's seat is its body, not its pad box

### DIFF
--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -1676,6 +1676,47 @@ class _Ctx:
         self._assembly_census = None
         self._bodies = None
         self._bodies_error = ''
+        self._oob_exempt = None
+
+    def oob_exempt(self) -> Dict[str, float]:
+        """`{ref: overhang_mm}` for every declared edge connector whose
+        courtyard leaves the outline by an amount INSIDE its own
+        `overhang_mm` band -- the parts `rule_edge_connector` has always said
+        are correct off the board, and that `rule_legality` used to count
+        against `legality_budget.oob_count` anyway.
+
+        Measured, run 26: an intent declaring `CON1 east overhang 0..0.5` and
+        `legality_budget {oob_count: 0}` (the emitter bakes the pile's own 0)
+        refused all ten of its seeds on CON1's 0.25 mm overhang, and the
+        placement was finished by hand.
+
+        The amount is `rect_outside_amount` with the part's OWN milled rings
+        skipped -- the exact call `QuenchState.legality_metrics` makes -- so
+        "counted" and "exempt" are decided on one number, never on two
+        readings of the outline. Only `edge_claims()` entries qualify (a
+        `connector_affinity` row claims no edge), only entries with a `max`
+        (an unbounded band would exempt any overhang whatever, which is the
+        run-10 160 mm case), and only when the part is actually off the board
+        (an interior connector is not "exempt" from anything). A part outside
+        its band is NOT exempt: it stays in the count AND `rule_edge_connector`
+        names it, two rules reporting one fact.
+        """
+        if self._oob_exempt is None:
+            out: Dict[str, float] = {}
+            for c in self.intent.edge_claims():
+                ref = c['ref']
+                part = self.parts.get(ref)
+                lim = c.get('overhang_mm') or {}
+                if part is None or lim.get('max') is None:
+                    continue
+                lo = float(lim.get('min', 0.0))
+                hi = float(lim['max'])
+                amt = self.gate.rect_outside_amount(
+                    part.rect, skip_rings=self.state._owned_rings(ref))  # noqa: SLF001
+                if amt > legality.EPS and lo - legality.EPS <= amt <= hi + legality.EPS:
+                    out[ref] = float(amt)
+            self._oob_exempt = out
+        return self._oob_exempt
 
     def assembly_census(self) -> Dict[str, object]:
         """#837's per-side census, memoised. The SAME function
@@ -2583,7 +2624,9 @@ def rule_edge_connector(ctx) -> Iterator[Violation]:
     """A connector that must reach the board edge: a card edge, a USB shell, a
     HAT header. This is the one class of part whose courtyard leaving the
     outline is CORRECT, so declaring it is also what stops `oob_count` from
-    reporting it as a defect forever."""
+    reporting it as a defect forever -- kept by `rule_legality` through
+    `_Ctx.oob_exempt()`, for a declared part inside its own overhang band
+    (it was a promise with no implementation until run 26 measured it)."""
     for c in ctx.intent.edge_connectors:
         ref = c['ref']
         part = ctx.parts.get(ref)
@@ -2644,19 +2687,45 @@ def rule_edge_connector(ctx) -> Iterator[Violation]:
             setback = INTERIOR_AFFINITY_MM
             _sev = WARN
         if setback is not None and amount <= legality.EPS:
-            clr = ctx.gate.edge_clearance(part.rect)
+            # The SEAT is a question about the part's BODY -- does its
+            # mating face reach the edge -- and a receptacle's pads sit
+            # well inboard of that face by construction: a micro-USB
+            # shell's SMD pads are 1.6-2.1 mm behind its opening. Measured
+            # on run 26's board: USB1's drawn fab body sits at 0.00 mm from
+            # the west edge where its pad box reads 2.1 mm, so the courtyard
+            # (here the pad-bbox fallback) reported "seated 1.30mm ... no
+            # overhang" on a socket that was flush, and the brief's four
+            # USB1 clauses had to be waived. For an `edge_receptacle` (or a
+            # brief row carrying `mount_mode: edge_mount`) the seat is
+            # therefore measured on the DRAWN body when the library drew one;
+            # everything else keeps the courtyard, and the OVERHANG conjunct
+            # above stays on the courtyard too (its edge-margin graze would
+            # read a flush body as a 0.55 mm overhang -- a different
+            # currency, not changed here).
+            basis = 'courtyard'
+            seat_rect = part.rect
+            ctxd = c.get('context') or {}
+            if (c.get('class') == 'edge_receptacle'
+                    or ctxd.get('mount_mode') == 'edge_mount'):
+                brect, src = ctx.body_rect(ref)
+                if brect is not None and src in ('fab', 'silk'):
+                    seat_rect, basis = brect, f'body:{src}'
+            clr = ctx.gate.edge_clearance(seat_rect)
             if clr > float(setback) + legality.EPS:
                 yield Violation(
                     rule='edge_connector', severity=_sev,
                     ref=ref,
                     message=(f"{ref} is an edge part seated {clr:.2f}mm from "
-                             f"the nearest edge with no overhang (seat "
-                             f"tolerance {float(setback):.2f}mm) -- "
+                             f"the nearest edge with no overhang ({basis}; "
+                             f"seat tolerance {float(setback):.2f}mm) -- "
                              + ("a plug may not reach it; disposition in the "
                                 "boundary review or declare max_setback_mm"
                                 if _sev == WARN else
                                 "the mating face cannot reach the edge")),
-                    measured={'edge_clearance_mm': round(clr, 4)},
+                    measured={'edge_clearance_mm': round(clr, 4),
+                              'basis': basis,
+                              'courtyard_clearance_mm': round(
+                                  ctx.gate.edge_clearance(part.rect), 4)},
                     expected={'max_setback_mm': float(setback)})
 
         # #712: WHERE ALONG the edge. The three conjuncts above are all
@@ -3340,6 +3409,17 @@ def rule_legality(ctx) -> Iterator[Violation]:
     slot as clean. Count and amount both see the real rings.
     """
     budget = ctx.intent.legality_budget or {}
+    # Declared edge connectors inside their own overhang band are off the
+    # board CORRECTLY (the promise in `rule_edge_connector`'s docstring, now
+    # kept here): they leave `oob_count` before it meets the budget. The raw
+    # count stays in `ctx.legality['oob_count']` -- it is the optimizer's own
+    # number and `test_legality_numbers_are_the_optimizers_own` pins it --
+    # and the exemption is published beside it as `oob_count_exempt`.
+    # `oob_amount` is NOT reduced: an author who budgets millimetres of
+    # overhang is budgeting the connectors too, and no run has asked for
+    # the split; say so here rather than guess.
+    exempt = ctx.oob_exempt()
+    ctx.legality['oob_count_exempt'] = len(exempt)
     for key, label in (('overlap_area', 'courtyard overlap area (mm2)'),
                        ('oob_count', 'parts leaving the board outline'),
                        ('oob_amount', 'total off-board overhang (mm)')):
@@ -3354,12 +3434,21 @@ def rule_legality(ctx) -> Iterator[Violation]:
         if got is None:
             continue
         lim = float(budget[key])
+        measured = {key: round(float(got), 4)}
+        note = ''
+        if key == 'oob_count' and exempt:
+            raw = got
+            got = raw - len(exempt)
+            measured = {key: int(got), 'oob_count_raw': int(raw),
+                        'exempt': sorted(exempt)}
+            note = (f" ({len(exempt)} declared edge connector(s) within "
+                    f"their overhang band exempt: {', '.join(sorted(exempt))})")
         if got > lim + legality.EPS:
             yield Violation(
                 rule='legality', severity=ctx.sev('legality'),
                 message=(f"{label}: {got:.3f} exceeds the declared budget "
-                         f"{lim:.3f}"),
-                measured={key: round(float(got), 4)}, expected={key: lim})
+                         f"{lim:.3f}{note}"),
+                measured=measured, expected={key: lim})
 
 
 def rule_proximity(ctx) -> Iterator[Violation]:

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -2656,15 +2656,39 @@ def rule_edge_connector(ctx) -> Iterator[Violation]:
                                   f"{float(hi):.2f}mm"),
                 measured={'overhang_mm': round(amount, 4)},
                 expected={'min': lo, 'max': float(hi)})
+        # The SEAT BASIS, decided once for the two conjuncts that ask where
+        # the part's MATING FACE is (nearest edge, seat). A receptacle's
+        # pads sit well inboard of its opening by construction: a micro-USB
+        # shell's SMD pads are 1.6-2.1 mm behind it. For an
+        # `edge_receptacle` (or a brief row carrying `mount_mode:
+        # edge_mount`) both conjuncts are therefore measured on the DRAWN
+        # body when the library drew one; everything else keeps the
+        # courtyard, and the OVERHANG conjunct above stays on the courtyard
+        # too (its edge-margin graze would read a flush body as a 0.55 mm
+        # overhang -- a different currency, not changed here).
+        basis = 'courtyard'
+        seat_rect = part.rect
+        ctxd = c.get('context') or {}
+        if (c.get('class') == 'edge_receptacle'
+                or ctxd.get('mount_mode') == 'edge_mount'):
+            brect, src = ctx.body_rect(ref)
+            if brect is not None and src in ('fab', 'silk'):
+                seat_rect, basis = brect, f'body:{src}'
         edge = c.get('edge')
         if edge and ctx.outline_bounds:
-            actual = _nearest_edge(part.rect, ctx.outline_bounds)
+            # Run 27's replay measured the courtyard reading on the same
+            # USB1: its pad box is 1.6 mm from the west edge and 1.3 mm from
+            # the south, so a socket flush with the west edge read "nearest
+            # the south edge but declared on the west" -- on every one of
+            # ten seeds, since the socket is a fixed part.
+            actual = _nearest_edge(seat_rect, ctx.outline_bounds)
             if actual != edge:
                 yield Violation(
                     rule='edge_connector', severity=ctx.sev('edge_connector'),
                     ref=ref, message=(f"{ref} sits nearest the {actual} edge "
                                       f"but is declared on the {edge} edge"),
-                    measured={'edge': actual}, expected={'edge': edge})
+                    measured={'edge': actual, 'basis': basis},
+                    expected={'edge': edge})
         # Run-4 A: the missing PROXIMITY conjunct. The rule used to grade only
         # the overhang band and the nearest-edge identity, so a receptacle
         # 15.8 mm INTERIOR passed ("nearest west, declared west" is satisfied
@@ -2688,28 +2712,12 @@ def rule_edge_connector(ctx) -> Iterator[Violation]:
             _sev = WARN
         if setback is not None and amount <= legality.EPS:
             # The SEAT is a question about the part's BODY -- does its
-            # mating face reach the edge -- and a receptacle's pads sit
-            # well inboard of that face by construction: a micro-USB
-            # shell's SMD pads are 1.6-2.1 mm behind its opening. Measured
-            # on run 26's board: USB1's drawn fab body sits at 0.00 mm from
-            # the west edge where its pad box reads 2.1 mm, so the courtyard
-            # (here the pad-bbox fallback) reported "seated 1.30mm ... no
-            # overhang" on a socket that was flush, and the brief's four
-            # USB1 clauses had to be waived. For an `edge_receptacle` (or a
-            # brief row carrying `mount_mode: edge_mount`) the seat is
-            # therefore measured on the DRAWN body when the library drew one;
-            # everything else keeps the courtyard, and the OVERHANG conjunct
-            # above stays on the courtyard too (its edge-margin graze would
-            # read a flush body as a 0.55 mm overhang -- a different
-            # currency, not changed here).
-            basis = 'courtyard'
-            seat_rect = part.rect
-            ctxd = c.get('context') or {}
-            if (c.get('class') == 'edge_receptacle'
-                    or ctxd.get('mount_mode') == 'edge_mount'):
-                brect, src = ctx.body_rect(ref)
-                if brect is not None and src in ('fab', 'silk'):
-                    seat_rect, basis = brect, f'body:{src}'
+            # mating face reach the edge -- on `seat_rect`, the basis
+            # decided above. Measured on run 26's board: USB1's drawn fab
+            # body sits at 0.00 mm from the west edge where its pad box
+            # reads 2.1 mm, so the courtyard (here the pad-bbox fallback)
+            # reported "seated 1.30mm ... no overhang" on a socket that was
+            # flush, and the brief's four USB1 clauses had to be waived.
             clr = ctx.gate.edge_clearance(seat_rect)
             if clr > float(setback) + legality.EPS:
                 yield Violation(

--- a/tests/test_549_floorplan_grade.py
+++ b/tests/test_549_floorplan_grade.py
@@ -491,14 +491,67 @@ def test_oob_area_is_refused_as_a_budget_because_it_is_cutout_blind():
 
 
 def test_a_legality_budget_bites_when_exceeded():
+    """Two arms, because one used to hide the other: ulx3s's emitted intent
+    DECLARES its overhanging parts as edge connectors, so with the exemption
+    the `oob_count` arm no longer fires and the old single assertion would
+    have passed on `overlap_area` alone."""
     raw = _emit()
     raw['legality_budget'] = {'overlap_area': 0.0, 'oob_count': 0}
+    n_conn = len(raw['edge_connectors'])
+    assert n_conn, "ulx3s has overhanging parts and none were recorded"
+    # (a) declared: the overlap arm bites, the outline arm is exempt by name,
+    #     and the raw count stays the optimizer's own beside the exemption.
     r = _graded(raw)
-    hits = [v for v in r.violations if v.rule == 'legality']
-    # ulx3s has real overhanging connectors, so a zero budget must catch them.
-    assert hits, "a zero legality budget caught nothing on ulx3s"
-    print(f"  PASS: {len(hits)} budget violation(s): "
-          f"{[v.message[:52] for v in hits]}")
+    hits = {v.expected and next(iter(v.expected)): v
+            for v in r.violations if v.rule == 'legality'}
+    assert 'overlap_area' in hits, "a zero overlap budget caught nothing on ulx3s"
+    assert 'oob_count' not in hits, \
+        f"declared edge connectors still counted: {hits['oob_count'].message}"
+    assert r.legality['oob_count_exempt'] == n_conn, r.legality
+    assert r.legality['oob_count'] == n_conn, \
+        "the raw oob_count must stay the optimizer's own number"
+    # (b) undeclared: the same parts are off the board and nothing vouches for
+    #     them, so a zero budget must catch every one.
+    raw['edge_connectors'] = []
+    r2 = _graded(raw)
+    oob = [v for v in r2.violations if v.rule == 'legality'
+           and 'oob_count' in v.expected]
+    assert len(oob) == 1 and oob[0].measured['oob_count'] == n_conn, \
+        [v.message for v in oob]
+    assert r2.legality['oob_count_exempt'] == 0
+    print(f"  PASS: overlap bites either way; oob_count {n_conn} exempt when "
+          f"declared, {n_conn} counted when not")
+
+
+def test_declared_edge_connectors_within_band_are_not_oob():
+    """The promise in rule_edge_connector's docstring, kept: a declared edge
+    connector inside its own overhang band leaves `oob_count` before the
+    budget sees it. Outside the band it stays counted AND the edge rule names
+    it (two rules, one fact); an entry with no `max` exempts nothing."""
+    raw = _emit()
+    raw['legality_budget'] = {'oob_count': 0}
+    conns = raw['edge_connectors']
+    assert not [v for v in _graded(raw).violations if v.rule == 'legality'], \
+        "a zero oob budget fired on parts the intent declares off the board"
+    # Tighten one band to nothing: that part is outside it now.
+    ref = conns[0]['ref']
+    conns[0]['overhang_mm'] = {'min': 0.0, 'max': 0.0}
+    r = _graded(raw)
+    leg = [v for v in r.violations if v.rule == 'legality']
+    edge = [v for v in r.violations if v.rule == 'edge_connector' and v.ref == ref]
+    assert len(leg) == 1 and leg[0].measured['oob_count'] == 1, \
+        [v.message for v in leg]
+    assert ref not in leg[0].measured['exempt'], leg[0].measured
+    assert edge, f"{ref} outside its band was not named by edge_connector"
+    assert r.legality['oob_count_exempt'] == len(conns) - 1
+    # No max at all: an unbounded band vouches for nothing.
+    conns[0]['overhang_mm'] = {'min': 0.0}
+    r = _graded(raw)
+    leg = [v for v in r.violations if v.rule == 'legality']
+    assert len(leg) == 1 and leg[0].measured['oob_count'] == 1, \
+        [v.message for v in leg]
+    print(f"  PASS: {len(conns)} declared parts exempt; one pushed outside its "
+          f"band (and one with no max) is counted and named")
 
 
 def test_the_envelope_rule_refuses_to_licence_a_resize():
@@ -679,6 +732,7 @@ TESTS = [
     test_legality_numbers_are_the_optimizers_own,
     test_oob_area_is_refused_as_a_budget_because_it_is_cutout_blind,
     test_a_legality_budget_bites_when_exceeded,
+    test_declared_edge_connectors_within_band_are_not_oob,
     test_the_envelope_rule_refuses_to_licence_a_resize,
     test_emit_never_claims_a_zone_it_cannot_defend,
     test_emit_records_the_overhanging_parts_as_edge_connectors,

--- a/tests/test_run26_edge_seat_body_basis.py
+++ b/tests/test_run26_edge_seat_body_basis.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""The edge-connector SEAT is measured on the drawn body, not the pad box.
+
+`rule_edge_connector`'s seat conjunct asked "is this part's mating face at the
+edge?" and answered it with the courtyard rect -- on a courtyard-less library
+the pad bounding box. A receptacle's pads sit well inboard of its opening by
+construction, so run 26 graded a micro-USB socket whose fab body is flush
+with the west edge as "seated 1.30mm from the nearest edge with no overhang"
+and had to waive the brief's four USB1 clauses by name. Measured on the
+tracked esp_prog fixture (same pose): drawn fab body x = 114.0 = the outline,
+pad copper from x = 115.6.
+
+For an `edge_receptacle` (or a brief row carrying `mount_mode: edge_mount`)
+the seat is now measured on the drawn body when the library drew one (fab,
+else silk); every other entry, and the OVERHANG conjunct, keep the courtyard.
+
+Run:
+    python3 tests/test_run26_edge_seat_body_basis.py
+"""
+
+import os
+import sys
+import tempfile
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(TESTS_DIR)
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))
+
+from kicad_parser import parse_kicad_pcb  # noqa: E402
+from placement import floorplan as fp  # noqa: E402
+
+RUN_ALL_FAST_OK = True
+
+ESP = os.path.join(ROOT, 'kicad_files', 'esp_prog.kicad_pcb')
+
+#: A 20 x 10 board; U1 at (2, 5) with two pads 1.6 mm inboard of the west edge
+#: and a drawn body (on the layer the test picks) reaching the edge exactly.
+SYNTH = '''(kicad_pcb
+ (version 20241229)
+ (net 0 "")
+ (net 1 "/A")
+ (gr_rect (start 0 0) (end 20 10) (layer "Edge.Cuts") (uuid "e1"))
+ (footprint "test:RCPT" (layer "F.Cu") (uuid "fp-u1") (at 2 5)
+   (property "Reference" "U1" (at 0 0 0))
+%s   (pad "1" smd rect (at -0.1 -1) (size 0.6 0.6) (layers "F.Cu") (net 1 "/A") (uuid "p1"))
+   (pad "2" smd rect (at -0.1 1) (size 0.6 0.6) (layers "F.Cu") (net 0 "") (uuid "p2"))
+ )
+)
+'''
+BODY = '   (fp_rect (start -2 -3) (end 1.5 3) (stroke (width 0.1) (type solid)) (fill no) (layer "%s") (uuid "b1"))\n'
+
+
+def _grade(board, entry):
+    intent = fp.intent_from_dict({'schema': fp.SCHEMA_VERSION, 'kind': fp.KIND,
+                                  'units': 'mm', 'edge_connectors': [entry]})
+    return fp.grade(intent, parse_kicad_pcb(board), board)
+
+
+def _seat(result, ref):
+    return [v for v in result.violations
+            if v.rule == 'edge_connector' and v.ref == ref
+            and 'edge_clearance_mm' in v.measured]
+
+
+def _synth(body_layer):
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    with os.fdopen(fd, 'w', encoding='utf-8') as fh:
+        fh.write(SYNTH % (BODY % body_layer if body_layer else ''))
+    return path
+
+
+def main():
+    fails = []
+
+    def check(name, cond, detail=''):
+        print(f"  {'PASS' if cond else 'FAIL'}: {name}"
+              + (f"   [{detail}]" if detail and not cond else ''))
+        if not cond:
+            fails.append(name)
+
+    # --- 0: the fixture is what the docstring says (anti-vacuity) ----------
+    pcb = parse_kicad_pcb(ESP)
+    from placement.body import board_bodies
+    rect, src = fp.drawn_body_rect(board_bodies(pcb, ESP).get('USB1'),
+                                   pcb.footprints['USB1'])
+    x0 = pcb.board_info.board_bounds[0]
+    check('esp_prog USB1 draws a fab body flush with the west edge',
+          src == 'fab' and rect is not None and abs(rect[0] - x0) < 1e-6,
+          f'{src} {rect} edge {x0}')
+    pad_x = min(p.global_x - p.size_x / 2 for p in pcb.footprints['USB1'].pads
+                if p.pad_type != 'np_thru_hole')
+    check('and its pad copper is well inboard of that body',
+          pad_x - x0 > 1.0, f'{pad_x - x0:.2f} mm')
+
+    # --- 1: the real board, declared as the brief declares it --------------
+    base = {'ref': 'USB1', 'class': 'edge_receptacle', 'edge': 'west',
+            'overhang_mm': {'min': 0.0, 'max': 0.65}}
+    r = _grade(ESP, dict(base))
+    check('an edge_receptacle flush by its body raises no seat finding',
+          _seat(r, 'USB1') == [], f'{[v.message for v in _seat(r, "USB1")]}')
+    # The same pose, judged on the courtyard as before: a plain entry armed
+    # by max_setback_mm keeps the old currency and DOES fire -- the change is
+    # scoped to the receptacle class, not a loosening of the seat rule.
+    plain = {'ref': 'USB1', 'edge': 'west', 'max_setback_mm': 0.5,
+             'overhang_mm': {'min': 0.0, 'max': 0.65}}
+    r2 = _grade(ESP, plain)
+    s2 = _seat(r2, 'USB1')
+    check('a plain entry is still measured on the courtyard and fires',
+          len(s2) == 1 and s2[0].measured.get('basis') == 'courtyard'
+          and s2[0].measured['edge_clearance_mm'] > 1.0,
+          f'{[(v.measured, v.message[:60]) for v in s2]}')
+    # A brief row: no class, but mount_mode carried in context -> body basis.
+    brief_row = {'ref': 'USB1', 'edge': 'west', 'max_setback_mm': 0.5,
+                 'overhang_mm': {'min': 0.0, 'max': 0.65},
+                 'context': {'mount_mode': 'edge_mount'}}
+    r3 = _grade(ESP, brief_row)
+    check('mount_mode: edge_mount selects the body basis too',
+          _seat(r3, 'USB1') == [], f'{[v.message for v in _seat(r3, "USB1")]}')
+    # Anti-vacuity for the class arm: push the tolerance below the body's
+    # own 0.00 mm is impossible, so instead demand a seat the body cannot
+    # meet from the OTHER side -- an east claim on a west-flush part.
+    east = dict(base, edge='east')
+    r4 = _grade(ESP, east)
+    check('the body basis is a measurement, not a bypass: an east claim on a '
+          'west-flush part still fails the edge rule',
+          any(v.rule == 'edge_connector' and v.ref == 'USB1'
+              for v in r4.violations))
+
+    # --- 2: synthetic: no drawn body -> courtyard; silk body -> body:silk --
+    for layer, want_basis, want_hit in (
+            (None, 'courtyard', True),      # pads only: 1.6 mm inboard, fires
+            ('F.SilkS', 'body:silk', False),  # silk box reaches the edge
+            ('F.Fab', 'body:fab', False)):
+        path = _synth(layer)
+        try:
+            entry = {'ref': 'U1', 'class': 'edge_receptacle', 'edge': 'west',
+                     'overhang_mm': {'min': 0.0, 'max': 0.65}}
+            rs = _grade(path, entry)
+            hits = _seat(rs, 'U1')
+            if want_hit:
+                check(f'synthetic [{layer}]: seat fires on the {want_basis}',
+                      len(hits) == 1 and hits[0].measured['basis'] == want_basis
+                      and abs(hits[0].measured['edge_clearance_mm'] - 1.6) < 0.05,
+                      f'{[(v.measured, v.message[:70]) for v in hits]}')
+            else:
+                check(f'synthetic [{layer}]: a body at the edge seats it ({want_basis})',
+                      hits == [], f'{[(v.measured, v.message[:70]) for v in hits]}')
+                # and the courtyard reading is still reported beside it when
+                # the rule DOES fire elsewhere -- assert the basis by grading
+                # the same board with the tolerance made impossible to meet.
+                tight = dict(entry, max_setback_mm=-1.0)
+                tight.pop('class')
+                tight['context'] = {'mount_mode': 'edge_mount'}
+                rt = _grade(path, tight)
+                ht = _seat(rt, 'U1')
+                check(f'synthetic [{layer}]: the finding names its basis',
+                      len(ht) == 1 and ht[0].measured['basis'] == want_basis
+                      and abs(ht[0].measured['courtyard_clearance_mm'] - 1.6) < 0.05,
+                      f'{[v.measured for v in ht]}')
+        finally:
+            os.unlink(path)
+
+    print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'ALL PASS'}")
+    return 1 if fails else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_run26_edge_seat_body_basis.py
+++ b/tests/test_run26_edge_seat_body_basis.py
@@ -13,6 +13,10 @@ pad copper from x = 115.6.
 For an `edge_receptacle` (or a brief row carrying `mount_mode: edge_mount`)
 the seat is now measured on the drawn body when the library drew one (fab,
 else silk); every other entry, and the OVERHANG conjunct, keep the courtyard.
+The NEAREST-EDGE conjunct reads the same basis: run 27's replay measured the
+same socket's pad box 1.6 mm from the west edge and 1.3 mm from the south, so
+on the courtyard it read "nearest the south edge but declared on the west" on
+every one of ten seeds -- a fixed part, so no seed could pass.
 
 Run:
     python3 tests/test_run26_edge_seat_body_basis.py
@@ -128,6 +132,33 @@ def main():
           'west-flush part still fails the edge rule',
           any(v.rule == 'edge_connector' and v.ref == 'USB1'
               for v in r4.violations))
+
+    # --- 1b: the NEAREST-EDGE conjunct reads the same basis (run 27) -----
+    def _near(result, ref):
+        return [v for v in result.violations
+                if v.rule == 'edge_connector' and v.ref == ref
+                and 'edge' in v.measured
+                and 'edge_clearance_mm' not in v.measured]
+
+    b = pcb.board_info.board_bounds
+    pads = [p for p in pcb.footprints['USB1'].pads
+            if p.pad_type != 'np_thru_hole']
+    south_gap = b[3] - max(p.global_y + p.size_y / 2 for p in pads)
+    west_gap = min(p.global_x - p.size_x / 2 for p in pads) - b[0]
+    check('anti-vacuity: USB1 pad box lies nearer the south edge than the west',
+          south_gap < west_gap, f'south {south_gap:.2f} west {west_gap:.2f}')
+    check('an edge_receptacle flush by its body is nearest its declared edge',
+          _near(r, 'USB1') == [], f'{[v.message for v in _near(r, "USB1")]}')
+    n2 = _near(r2, 'USB1')
+    check('a plain entry still reads the courtyard, and misreads south',
+          len(n2) == 1 and n2[0].measured.get('edge') == 'south'
+          and n2[0].measured.get('basis') == 'courtyard',
+          f'{[(v.measured, v.message[:60]) for v in n2]}')
+    check('mount_mode: edge_mount selects the body basis for nearest-edge too',
+          _near(r3, 'USB1') == [], f'{[v.message for v in _near(r3, "USB1")]}')
+    check('and the east claim is refused by nearest-edge on the body, not only by the seat',
+          any(v.measured.get('edge') == 'west' for v in _near(r4, 'USB1')),
+          f'{[v.measured for v in _near(r4, "USB1")]}')
 
     # --- 2: synthetic: no drawn body -> courtyard; silk body -> body:silk --
     for layer, want_basis, want_hit in (


### PR DESCRIPTION
Two grader defects that together refused every automated seed of run 26 (esp_prog, placed from scratch) and forced the placement to be finished by hand through `place_pose`.

**1. The `oob_count` exemption that was promised and never implemented.** `rule_edge_connector`'s docstring says declaring an edge connector "stops `oob_count` from reporting it as a defect forever". `rule_legality` compared the raw courtyard count to `legality_budget.oob_count`, which `emit_intent` bakes from the board it is emitted from (0 on a pile). An intent declaring `CON1 east overhang 0..0.5` therefore refused all ten seeds on CON1's 0.25 mm overhang; `compare_seeds` had nothing to rank. Now `_Ctx.oob_exempt()` collects every `edge_claims()` entry with a `max` whose courtyard leaves the outline by an amount inside its band, measured with the same `rect_outside_amount(..., skip_rings=...)` call `legality_metrics` makes, and `rule_legality` subtracts them for `oob_count`, publishes `legality['oob_count_exempt']`, keeps the raw number as the optimizer's own, and names the exempt refs. Outside the band a part stays counted and the edge rule names it too; no `max` exempts nothing; `oob_amount` is left alone (the comment says why).

**2. The seat measured on the pad box.** The seat conjunct answered "does the mating face reach the edge" with the courtyard rect, i.e. the pad box on a courtyard-less library. A receptacle's pads sit inboard of its opening by construction: on the tracked esp_prog fixture USB1's drawn fab body is at x = 114.0 = the outline while its pad copper starts at 115.6, so the rule read a flush socket as "seated 1.30mm from the nearest edge with no overhang" and run 26 had to waive the brief's four USB1 clauses by name. For an `edge_receptacle` (or a brief row with `mount_mode: edge_mount`) the seat is now measured on the drawn body (`_Ctx.body_rect`, fab else silk); the finding reports `basis` and the courtyard reading beside it. The overhang conjunct and every other entry keep the courtyard (a flush body's edge-margin graze would read as a 0.55 mm overhang; a different currency, named rather than changed).

**Tests** (+64 lines in `test_549_floorplan_grade.py`, new `tests/test_run26_edge_seat_body_basis.py`): the budget test gains a second arm because ulx3s declares its 10 overhanging parts, so the old single assertion would have kept passing on `overlap_area` alone; a declared-band test (zero budget passes; band tightened to 0 -> counted AND named; no max -> counted); the seat test on the real fixture with anti-vacuity first (the body IS flush, the pads ARE inboard), a plain entry that still fires on the courtyard at 1.6 mm, `mount_mode`, an east claim on a west-flush part still failing, and synthetic no-body/silk/fab arms. Measured mutations: dropping the subtraction fails the declared arm; seating on the courtyard again fails four seat arms.

**Gates green:** test_549 (grade, cli, schema), test_712, test_713, test_702, test_902, test_711, test_923, test_run5_emit_guard, test_456, test_628, test_431_render_placement, test_504, test_794, test_548, test_895; every floorplan mutation battery's anchors match exactly once (702, 797, 799, 837, 893_916, 902, 705_792_794, 711, 936).

Named, out of scope: `emit_intent`'s plausibility note and `part_class.pose_plausible` still measure the courtyard, so an emitted intent still carries the "1.30 mm, no overhang" note for such a part.

Third of the run-26 series (#947, #948).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5dqkz296U4Yzo2p21cwDi
