### PR TITLE
place_seed: the gate grades the seed's own work; an error on a part it was told not to move is set aside, named

### DIFF
--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -20,7 +20,14 @@ place_portfolio.py to diversify and rank what this emits.
 Exit codes: 0 seeded and graded clean; 2 bad arguments; 3 the board cannot be
 seeded (no Edge.Cuts outline -- the outline is spec-owned and will not be
 invented -- or the board is already placed / carries copper); 4 the seed was
-written but parts could not be seated or the intent grade has errors.
+written but parts could not be seated or the intent grade has errors ON
+PARTS THE SEED PLACED. A grade error on a part the seed was told not to move
+-- `(locked yes)` in the file, or matched by the intent's `must_lock` -- is
+printed and counted in `grade_errors_pinned`, and does not fail the gate:
+it is a contradiction between the board and the intent, which only their
+author can settle. Measured, run 27: a fixed USB socket declared
+`along_edge: center` within 0.6 mm sits 1.75 mm off centre, and every one of
+ten seeds failed on it, so nothing the seeder did could ever be ranked.
 """
 
 #: #937 registry: which door(s) show this tool, and whether it changes
@@ -32,6 +39,45 @@ import argparse
 import json
 import os
 import sys
+
+
+def _split_pinned(graded, output_file, intent):
+    """(own, pinned): the grade errors the seed is answerable for, and the
+    ones that sit on a part it was told not to move -- `(locked yes)` in the
+    written file (which is where `must_lock` lands after stamping) or matched
+    by a `must_lock` pattern. Block-level findings (no `ref`) are always own.
+    """
+    import fnmatch
+    from kicad_parser import parse_kicad_pcb
+    locked = {r for r, f in parse_kicad_pcb(output_file).footprints.items()
+              if getattr(f, 'locked', False)}
+    pats = tuple(getattr(intent, 'must_lock', ()) or ())
+
+    def pinned(v):
+        ref = getattr(v, 'ref', None)
+        return bool(ref) and (ref in locked
+                              or any(fnmatch.fnmatch(ref, p) for p in pats))
+    return ([v for v in graded.errors if not pinned(v)],
+            [v for v in graded.errors if pinned(v)])
+
+
+def _print_grade(own, pinned):
+    """The gate's errors, then the set-aside ones NAMED -- never silent."""
+    for v in own[:10]:
+        print(f"  GRADE ERROR [{v.rule}] {v.message}")
+    if pinned:
+        by = {}
+        for v in pinned:
+            by.setdefault(v.ref, set()).add(v.rule)
+        print(f"  {len(pinned)} grade error(s) sit on locked part(s) the seed "
+              f"did not place -- "
+              + '; '.join(f"{r}: {', '.join(sorted(rs))}"
+                          for r, rs in sorted(by.items()))
+              + ". Reported, not the seed's failure: a pinned pose that "
+              "breaks a declared clause is a contradiction between the board "
+              "and the intent, and only their author can say which is wrong.")
+        for v in pinned[:10]:
+            print(f"  GRADE ERROR (pinned) [{v.rule}] {v.message}")
 
 
 def main():
@@ -539,9 +585,10 @@ Examples:
                                      group_sources=sources,
                                      clearance=args.clearance,
                                      board_edge_clearance=args.board_edge_clearance)
-            for v in graded.errors[:10]:
-                print(f"  GRADE ERROR [{v.rule}] {v.message}")
-            summary['grade_errors'] = len(graded.errors)
+            own, pinned = _split_pinned(graded, args.output_file, intent)
+            _print_grade(own, pinned)
+            summary['grade_errors'] = len(own)
+            summary['grade_errors_pinned'] = len(pinned)
             summary['pad_conflicts_after'] = pads_after['pad_conflicts']
             # #697: the requirement each counted pair was graded at, when it
             # sits above args.clearance, so the count is explainable.
@@ -552,7 +599,7 @@ Examples:
                       f"{_req_cl(pads_after)}")
             summary['hole_conflicts_after'] = pads_after['hole_conflicts']
             summary['oob_pad_count_after'] = pads_after['oob_pad_count']
-            if graded.errors:
+            if own:
                 exit_rc = 4
         _stage.cleanup()
         summary.setdefault('complete', True)
@@ -811,8 +858,8 @@ Examples:
         print(f"place_seed: outline cannot be trusted for grading: {exc}",
               file=sys.stderr)
         return UNPLACED_EXIT
-    for v in graded.errors[:10]:
-        print(f"  GRADE ERROR [{v.rule}] {v.message}")
+    own, pinned = _split_pinned(graded, args.output_file, intent)
+    _print_grade(own, pinned)
     after = ratsnest.get('after', {})
     summary = {'placed': len(result['placements']),
                'unseated': len(result['unseated']),
@@ -838,18 +885,23 @@ Examples:
                    1 for e in (result.get('evictions') or [])
                    if not e.get('accepted')),
                'locked': n_locked,
-               'grade_errors': len(graded.errors),
+               'grade_errors': len(own),
+               'grade_errors_pinned': len(pinned),
                'grade_warnings': len(graded.warnings),
                'crossings': after.get('crossings'),
                'hpwl': (round(after['hpwl'], 3)
                         if after.get('hpwl') is not None else None),
                'output': args.output_file}
     print("JSON_SUMMARY: " + json.dumps(summary, sort_keys=True))
-    if result['unseated'] or graded.errors:
+    if result['unseated'] or own:
         print("place_seed: the seed does NOT satisfy its intent -- see the "
               "errors above. It was still written, for inspection.",
               file=sys.stderr)
         return 4
+    if pinned:
+        print(f"place_seed: {len(pinned)} grade error(s) on locked part(s) set "
+              f"aside (named above); the seed's own work grades clean.",
+              file=sys.stderr)
     return 0
 
 

--- a/tests/test_run27_seed_gate_pinned.py
+++ b/tests/test_run27_seed_gate_pinned.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""`place_seed`'s gate grades the seed's OWN work: a grade error on a part the
+seed was told not to move is reported and set aside, not exit 4.
+
+Run 27 replayed the run-26 placement half from a hand-authored zone plan and
+every one of ten seeds failed its gate on the same fixed USB socket -- declared
+`along_edge: center` within 0.6 mm, sitting 1.75 mm off centre by the
+mechanical declaration the run was given. A contradiction between the brief
+and the board, which no seed can resolve and which failed all of them, so
+`compare_seeds` had nothing to rank -- exactly run 26's shape (0 of 10
+passing) with a different clause behind it.
+
+Fixture: a 30 x 20 board; J1, a two-pad `edge_receptacle` declared on the west
+edge, `(locked yes)` in the file 3 mm inboard of it (its seat conjunct fires,
+courtyard basis, no drawn body); U1..U3 stacked at the board centre, the pile
+the seed places, with a zone that holds them.
+
+Run:
+    python3 tests/test_run27_seed_gate_pinned.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(TESTS_DIR)
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))
+
+RUN_ALL_FAST_OK = True
+
+SEED = os.path.join(ROOT, 'py_placer', 'place_seed.py')
+
+BOARD = '''(kicad_pcb
+ (version 20241229)
+ (net 0 "")
+ (net 1 "/A") (net 2 "/B") (net 3 "/C")
+ (gr_rect (start 0 0) (end 30 20) (layer "Edge.Cuts") (uuid "e1"))
+ (footprint "test:RCPT" (layer "F.Cu") (uuid "fp-j1") (at 3 10)%s
+   (property "Reference" "J1" (at 0 0 0))
+   (pad "1" smd rect (at 0 -1) (size 0.6 0.6) (layers "F.Cu") (net 1 "/A") (uuid "j1p1"))
+   (pad "2" smd rect (at 0 1) (size 0.6 0.6) (layers "F.Cu") (net 2 "/B") (uuid "j1p2"))
+ )
+ (footprint "test:C" (layer "F.Cu") (uuid "fp-u1") (at 15 10)
+   (property "Reference" "U1" (at 0 0 0))
+   (pad "1" smd rect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "/A") (uuid "u1p1"))
+   (pad "2" smd rect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 3 "/C") (uuid "u1p2"))
+ )
+ (footprint "test:C" (layer "F.Cu") (uuid "fp-u2") (at 15 10)
+   (property "Reference" "U2" (at 0 0 0))
+   (pad "1" smd rect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 2 "/B") (uuid "u2p1"))
+   (pad "2" smd rect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 3 "/C") (uuid "u2p2"))
+ )
+ (footprint "test:C" (layer "F.Cu") (uuid "fp-u3") (at 15 10)
+   (property "Reference" "U3" (at 0 0 0))
+   (pad "1" smd rect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 3 "/C") (uuid "u3p1"))
+   (pad "2" smd rect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "/A") (uuid "u3p2"))
+ )
+)
+'''
+
+
+def _intent(zone, must_lock=()):
+    return {'schema': 1, 'kind': 'floorplan-intent', 'units': 'mm',
+            'must_lock': list(must_lock),
+            'edge_connectors': [{'ref': 'J1', 'edge': 'west',
+                                 'class': 'edge_receptacle',
+                                 'overhang_mm': {'min': 0.0, 'max': 0.5}}],
+            'blocks': [{'name': 'ics', 'refs': ['U*'], 'zone': zone,
+                        'note': 'the pile'}]}
+
+
+def _run(tmp, name, locked, intent):
+    board = os.path.join(tmp, f'{name}.kicad_pcb')
+    with open(board, 'w', encoding='utf-8') as fh:
+        fh.write(BOARD % (' (locked yes)' if locked else ''))
+    ipath = os.path.join(tmp, f'{name}.json')
+    with open(ipath, 'w', encoding='utf-8') as fh:
+        json.dump(intent, fh)
+    out = os.path.join(tmp, f'{name}_out.kicad_pcb')
+    r = subprocess.run([sys.executable, '-X', 'utf8', SEED, board, out,
+                        '--intent', ipath, '--seed', '0'],
+                       capture_output=True, text=True, encoding='utf-8',
+                       errors='replace', cwd=ROOT)
+    text = (r.stdout or '') + (r.stderr or '')
+    summ = None
+    for ln in (r.stdout or '').splitlines():
+        if ln.startswith('JSON_SUMMARY: '):
+            summ = json.loads(ln[len('JSON_SUMMARY: '):])
+    return r.returncode, summ, text
+
+
+def main():
+    fails = []
+
+    def check(name, cond, detail=''):
+        print(f"  {'PASS' if cond else 'FAIL'}: {name}"
+              + (f"   [{detail}]" if detail and not cond else ''))
+        if not cond:
+            fails.append(name)
+
+    with tempfile.TemporaryDirectory(prefix='t_sgp_') as tmp:
+        # --- 1: the pinned arm: J1 locked in the file, must_lock too --------
+        rc, s, text = _run(tmp, 'pinned', True,
+                           _intent([8, 5, 22, 15], must_lock=['J1']))
+        check('a locked receptacle off its seat does not fail the gate',
+              rc == 0, f'rc {rc}\n{text[-900:]}')
+        check('...its errors are counted apart, as pinned',
+              s is not None and s.get('grade_errors') == 0
+              and (s.get('grade_errors_pinned') or 0) >= 1,
+              f'{s and {k: s.get(k) for k in ("grade_errors", "grade_errors_pinned")}}')
+        check('...and NAMED on the console, with the rule',
+              'J1: edge_connector' in text and 'GRADE ERROR (pinned)' in text
+              and 'set aside' in text, text[-600:])
+        # --- 2: the file lock alone pins (must_lock not declared) ----------
+        rc2, s2, _ = _run(tmp, 'filelock', True, _intent([8, 5, 22, 15]))
+        check('(locked yes) in the file pins on its own',
+              rc2 == 0 and s2 is not None and s2.get('grade_errors') == 0
+              and (s2.get('grade_errors_pinned') or 0) >= 1,
+              f'rc {rc2} {s2 and {k: s2.get(k) for k in ("grade_errors", "grade_errors_pinned")}}')
+        # --- 3: the gate still bites on the seed's OWN work ----------------
+        # A zone too small for three parts: the seed cannot satisfy it, and
+        # that IS the seeder's failure -- exit 4 as before, the pinned count
+        # still reported beside it.
+        rc3, s3, text3 = _run(tmp, 'own', True,
+                              _intent([14.5, 9.5, 15.5, 10.5], must_lock=['J1']))
+        check('an error on a part the seed placed still fails the gate',
+              rc3 == 4 and s3 is not None
+              and ((s3.get('grade_errors') or 0) >= 1
+                   or (s3.get('unseated') or 0) >= 1),
+              f'rc {rc3} {s3 and {k: s3.get(k) for k in ("grade_errors", "grade_errors_pinned", "unseated")}}')
+        check('...with the pinned errors still counted beside it',
+              s3 is not None and (s3.get('grade_errors_pinned') or 0) >= 1)
+        # --- 4: unlocked, the receptacle is the seed's to seat -------------
+        # Nothing pinned, nothing set aside: the seeder's edge stage seats J1
+        # on its band and the gate reads its own work.
+        rc4, s4, _ = _run(tmp, 'free', False, _intent([8, 5, 22, 15]))
+        check('an unlocked receptacle is seated by the seed and pins nothing',
+              s4 is not None and s4.get('grade_errors_pinned') == 0,
+              f'rc {rc4} {s4 and {k: s4.get(k) for k in ("grade_errors", "grade_errors_pinned")}}')
+
+    print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'ALL PASS'}")
+    return 1 if fails else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Replaying the run-26 placement half from a hand-authored zone plan, every one of ten seeds failed its gate on the same FIXED part: the USB socket, declared `along_edge: center` within 0.6 mm by the brief and sitting 1.75 mm off centre by the mechanical declaration the run was given. No seed can resolve a contradiction between the brief and the board, and one that fails all of them leaves `compare_seeds` nothing to rank -- run 26's shape again (0 of 10), with a different clause behind it.

**Change.** A grade error whose `ref` is a part the seed was told not to move -- `(locked yes)` in the written file (where `must_lock` lands after stamping) or matched by a `must_lock` pattern -- is printed as `GRADE ERROR (pinned)`, counted in `JSON_SUMMARY.grade_errors_pinned`, named on the console with its rule and why it is set aside, and does not turn the exit code. Errors on parts the seed placed, block-level findings and unseated parts fail the gate exactly as before; `grade_errors` now counts the gate's own errors. Both grade sites (seed path, `--repair`) share one `_split_pinned` / `_print_grade`; the module docstring states the rule. The finding itself is not lost: `check_floorplan` still reports it at every later grade, and P-close still has to waive it by name.

**Tests** (`tests/test_run27_seed_gate_pinned.py`): a locked receptacle 3 mm inboard of its declared edge exits 0 with `grade_errors 0`, `grade_errors_pinned >= 1` and `J1: edge_connector` named; the file lock alone pins; a zone too small for the pile still exits 4 with the pinned count beside it; an unlocked receptacle is seated by the seed and pins nothing.

**Measured on the replay** (run 27, esp_prog from scratch, five-block plan): with #949's nearest-edge follow-up, seed 0 is left with exactly this one error; with this change its gate passes on the seed's own work and the socket's clause is reported, not fatal.

**Gates green:** the new test, test_630_seeder_eviction, test_708, test_779, test_792 (both), test_compare_seeds, test_npth_seed_floor, test_place_seed, test_redo_seed_side_files, test_seeder_partner_centroid, the standing mutation-anchor preflight.

Seventh of the run-26 series (#947-#952). Independent of the others; touches `place_seed.py` in a region #951 does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5dqkz296U4Yzo2p21cwDi
